### PR TITLE
Deepen blog delivery pipeline (#16)

### DIFF
--- a/docs/CODEBASE-CONVENTIONS.md
+++ b/docs/CODEBASE-CONVENTIONS.md
@@ -64,6 +64,20 @@ This document defines how to work in this codebase so that new and changed code 
 
 - **Source of truth:** Markdown in `public/blog/*.md` (synced via `scripts/sync-blogs.js`). Directory reads and frontmatter assembly are in `src/lib/blog.ts`; **markdown string → HTML** for tests and reuse is in `src/lib/blog-markdown.ts` (`processMarkdown`).
 - **Types:** Use `BlogPost` and `BlogPostFrontmatter` from `@/data/types`. Frontmatter keys: prefer a single canonical key per field; document if both kebab-case and camelCase are supported for legacy reasons.
+- **Sitemap:** `src/lib/sitemap.ts` (`buildSitemap`) derives blog URLs and `lastModified` dates from `getAllBlogPosts` so sitemap entries stay consistent with the reader module. `getAllBlogSlugs` remains available for static generation (`generateStaticParams`).
+
+#### `sync-blogs` contract
+
+Obsidian → private Git repo → Amplify build → `node scripts/sync-blogs.js` → `public/blog` and `public/img`. The script behaviour is defined in `scripts/sync-blogs.js`; this section documents the contract only.
+
+| Aspect | Detail |
+|--------|--------|
+| **Inputs** | Private blog repo path (`BLOG_REPO_PATH`, default `temp-blog-repo` locally). Markdown under `{BLOG_REPO_PATH}/{BLOGS_FOLDER_NAME}/` (default folder name `Blog`), searched recursively. Images from `{BLOG_REPO_PATH}/Images/`. |
+| **Outputs** | One `.md` file per post in `public/blog/{slug}.md`. Image files copied flat into `public/img/` (portfolio images may also live there; orphaned blog images are not deleted). |
+| **Slug rules** | URL-safe lowercase slug from the filename. Posts directly under `Blog/` use the filename (without `.md`). Posts in subfolders use `{folder-path}-{filename}` with path segments joined by hyphens. Duplicate slugs get a numeric suffix (`-1`, `-2`, …). |
+| **Validation** | Each source file must start with YAML frontmatter (`---`). Invalid or unreadable files are reported; the script exits non-zero on errors after sync. |
+| **Cleanup** | Orphaned `.md` files in `public/blog` (no longer present in the source repo) are removed. Image cleanup is skipped so committed portfolio assets in `public/img` are preserved. |
+| **When it runs** | Amplify `preBuild` (see `amplify.yml` and `docs/CI-AND-DEPLOYMENT.md`). Locally, run `node scripts/sync-blogs.js` when you need real posts; CI does not clone the private repo. |
 
 ---
 
@@ -126,7 +140,7 @@ This document defines how to work in this codebase so that new and changed code 
 ## 9. SEO and metadata
 
 - **Structured data:** Prefer data from `src/data` and shared types. Avoid hardcoding person, organisation, or profile details in `structured-data.tsx`; move them to `site` or a dedicated JSON and type so they stay in sync with the rest of the site.
-- **Sitemap:** When adding new public routes (including listing and detail pages like blog), add them to `src/app/sitemap.ts` with an appropriate `changeFrequency` and `priority`.
+- **Sitemap:** When adding new public routes (including listing and detail pages like blog), add them to `src/lib/sitemap.ts` (via `buildSitemap`) with an appropriate `changeFrequency` and `priority`. Blog post entries use dates from the reader module.
 - **Robots:** Keep `src/app/robots.ts` in sync with the intended indexing policy.
 
 ---

--- a/src/app/blog/[slug]/page.test.ts
+++ b/src/app/blog/[slug]/page.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/blog', () => ({
+  getBlogPostBySlug: vi.fn(),
+  getAllBlogSlugs: vi.fn(() => []),
+}));
+
+import { getBlogPostBySlug } from '@/lib/blog';
+import { generateMetadata } from '@/app/blog/[slug]/page';
+import { site } from '@/data';
+import type { BlogPost } from '@/data/types';
+
+const basePost: BlogPost = {
+  slug: 'test-post',
+  frontmatter: {
+    title: 'Test Post',
+    date: '2025-03-15',
+    excerpt: 'An excerpt.',
+    category: 'Engineering',
+    tags: ['testing'],
+    image: '',
+    author: 'Test Author',
+    aiGeneratedContent: false,
+  },
+  content: '<p>Body</p>',
+};
+
+describe('blog post page metadata', () => {
+  it('uses the shared fallback image in openGraph when the post has no hero image', async () => {
+    vi.mocked(getBlogPostBySlug).mockReturnValue(basePost);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'test-post' }),
+    });
+
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: '/img/mangrove_beach.webp',
+        alt: 'Test Post',
+      },
+    ]);
+  });
+
+  it('uses the resolved post image in openGraph when a hero image is set', async () => {
+    vi.mocked(getBlogPostBySlug).mockReturnValue({
+      ...basePost,
+      frontmatter: {
+        ...basePost.frontmatter,
+        image: '/blog/test-post/hero.webp',
+      },
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'test-post' }),
+    });
+
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: '/blog/test-post/hero.webp',
+        alt: 'Test Post',
+      },
+    ]);
+  });
+
+  it('keeps title and article fields derived from the loaded post', async () => {
+    vi.mocked(getBlogPostBySlug).mockReturnValue(basePost);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'test-post' }),
+    });
+
+    expect(metadata).toMatchObject({
+      title: `Test Post - ${site.metadata.author}`,
+      description: 'An excerpt.',
+      openGraph: {
+        title: 'Test Post',
+        description: 'An excerpt.',
+        url: `${site.metadata.siteUrl}/blog/test-post`,
+        type: 'article',
+        publishedTime: '2025-03-15',
+        authors: ['Test Author'],
+        tags: ['testing'],
+      },
+    });
+  });
+});

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,12 +1,15 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
-import { format } from "date-fns";
 import "katex/dist/katex.min.css";
-import { Header, SkipToContent, Container, Section, Breadcrumb } from "@/components/ui";
+import { Header, SkipToContent, Container, Section, Breadcrumb, Heading, Text } from "@/components/ui";
 import { FooterSection } from "@/components/sections/footer-section";
 import { getBlogPostBySlug, getAllBlogSlugs } from "@/lib/blog";
-import { BLOG_FALLBACK_IMAGE } from "@/lib/blog-constants";
+import {
+  formatBlogArticleDate,
+  hasBlogPostHeroImage,
+  resolveBlogPostImage,
+} from "@/lib/blog-presentation";
 import { site, footer } from "@/data";
 
 interface BlogPostPageProps {
@@ -40,14 +43,12 @@ export async function generateMetadata({
       description: post.frontmatter.excerpt,
       url: `${site.metadata.siteUrl}/blog/${slug}`,
       type: "article",
-      images: post.frontmatter.image
-        ? [
-            {
-              url: post.frontmatter.image,
-              alt: post.frontmatter.title,
-            },
-          ]
-        : [],
+      images: [
+        {
+          url: resolveBlogPostImage(post.frontmatter.image),
+          alt: post.frontmatter.title,
+        },
+      ],
       publishedTime: post.frontmatter.date,
       authors: [post.frontmatter.author],
       tags: post.frontmatter.tags,
@@ -63,7 +64,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     notFound();
   }
 
-  const formattedDate = format(new Date(post.frontmatter.date), "MMMM d, yyyy");
+  const formattedDate = formatBlogArticleDate(post.frontmatter.date);
 
   return (
     <>
@@ -95,16 +96,22 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 </div>
 
                 {/* Title */}
-                <h1 className="text-[var(--foreground)] font-body font-bold text-4xl md:text-5xl mb-6">
+                <Heading as="h1" size="lg" className="mb-6">
                   {post.frontmatter.title}
-                </h1>
+                </Heading>
 
                 {/* Meta info */}
                 <div className="mb-8">
-                  <div className="flex flex-wrap items-center gap-4 text-sm text-[var(--foreground)]/60 mb-3">
-                    <span>{post.frontmatter.author}</span>
-                    <span>•</span>
-                    <time dateTime={post.frontmatter.date}>{formattedDate}</time>
+                  <div className="flex flex-wrap items-center gap-4 mb-3">
+                    <Text as="span" size="xs" variant="muted">
+                      {post.frontmatter.author}
+                    </Text>
+                    <Text as="span" size="xs" variant="muted">
+                      •
+                    </Text>
+                    <Text as="span" size="xs" variant="muted">
+                      <time dateTime={post.frontmatter.date}>{formattedDate}</time>
+                    </Text>
                     {post.frontmatter.aiGeneratedContent && (
                       <>
                         <span>•</span>
@@ -141,10 +148,8 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                   )}
                 </div>
 
-                {/* Featured Image - don't show if empty or fallback */}
-                {post.frontmatter.image && 
-                 post.frontmatter.image.trim() !== '' && 
-                 post.frontmatter.image !== BLOG_FALLBACK_IMAGE && (
+                {/* Featured Image */}
+                {hasBlogPostHeroImage(post.frontmatter.image) && (
                   <div className="relative aspect-[16/9] overflow-hidden rounded-lg mb-8 bg-[var(--muted)]">
                     <Image
                       src={post.frontmatter.image}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import dynamic from "next/dynamic";
 import { Header, SkipToContent } from "@/components/ui";
 import { HeroSection } from "@/components/sections/homepage/hero-section";
 import { home, footer, careerProfile, getHomeExperienceView } from "@/data";
-import { getAllBlogPosts } from "@/lib/blog";
+import { getRecentBlogPosts } from "@/lib/blog";
 
 // Lazy load below-the-fold sections for better performance
 const AboutSection = dynamic(() => import("@/components/sections/homepage/about-section").then(mod => ({ default: mod.AboutSection })), {
@@ -26,7 +26,7 @@ const FooterSection = dynamic(() => import("@/components/sections/footer-section
 });
 
 export default function Home() {
-  const blogPosts = getAllBlogPosts();
+  const blogPosts = getRecentBlogPosts(3);
 
   return (
     <>

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,6 +1,15 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import sitemap from '@/app/sitemap';
+import { getAllBlogPosts } from '@/lib/blog';
+import { buildSitemap } from '@/lib/sitemap';
 import { site } from '@/data';
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../test/fixtures/blog',
+);
 
 describe('sitemap', () => {
   it('includes the About page entry unchanged', () => {
@@ -13,5 +22,33 @@ describe('sitemap', () => {
       changeFrequency: 'monthly',
       priority: 0.9,
     });
+  });
+
+  it('includes the /blog listing entry', () => {
+    const entries = buildSitemap(fixturesDir);
+    const blogListing = entries.find((entry) => entry.url === `${site.metadata.siteUrl}/blog`);
+
+    expect(blogListing).toEqual({
+      url: `${site.metadata.siteUrl}/blog`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    });
+  });
+
+  it('includes blog post URLs with lastModified dates from the reader module', () => {
+    const posts = getAllBlogPosts(fixturesDir);
+    const entries = buildSitemap(fixturesDir);
+
+    for (const post of posts) {
+      const entry = entries.find((item) => item.url === `${site.metadata.siteUrl}/blog/${post.slug}`);
+
+      expect(entry).toEqual({
+        url: `${site.metadata.siteUrl}/blog/${post.slug}`,
+        lastModified: new Date(post.frontmatter.date),
+        changeFrequency: 'yearly',
+        priority: 0.6,
+      });
+    }
   });
 });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,43 +1,7 @@
-import { MetadataRoute } from 'next'
-import { site } from '@/data'
-import { getAllBlogSlugs } from '@/lib/blog'
+import type { MetadataRoute } from 'next'
+import { buildSitemap } from '@/lib/sitemap'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = site.metadata.siteUrl
-  const blogSlugs = getAllBlogSlugs()
-  const lastModified = new Date()
-
-  return [
-    {
-      url: baseUrl,
-      lastModified,
-      changeFrequency: 'monthly' as const,
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified,
-      changeFrequency: 'monthly' as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/portfolio`,
-      lastModified,
-      changeFrequency: 'weekly' as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/blog`,
-      lastModified,
-      changeFrequency: 'weekly' as const,
-      priority: 0.8,
-    },
-    ...blogSlugs.map((slug) => ({
-      url: `${baseUrl}/blog/${slug}`,
-      lastModified,
-      changeFrequency: 'yearly' as const,
-      priority: 0.6,
-    })),
-  ]
+  return buildSitemap()
 }
 

--- a/src/components/ui/blog-card.tsx
+++ b/src/components/ui/blog-card.tsx
@@ -2,9 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { format } from "date-fns";
 import { useState } from "react";
-import { BLOG_FALLBACK_IMAGE } from "@/lib/blog-constants";
+import {
+  formatBlogCardDate,
+  resolveBlogPostImage,
+} from "@/lib/blog-presentation";
 
 interface BlogCardProps {
   slug: string;
@@ -32,11 +34,8 @@ export function BlogCard({
   const [isHovered, setIsHovered] = useState(false);
   const [imageError, setImageError] = useState(false);
 
-  const formattedDate = format(new Date(date), "MMM d, yyyy");
-  
-  // Determine which image to use - check for empty string, null, undefined, or whitespace
-  const hasImage = image && image.trim() !== '';
-  const imageSrc = (!hasImage || imageError) ? BLOG_FALLBACK_IMAGE : image;
+  const formattedDate = formatBlogCardDate(date);
+  const imageSrc = resolveBlogPostImage(image, { imageLoadFailed: imageError });
 
   return (
     <Link

--- a/src/lib/blog-constants.ts
+++ b/src/lib/blog-constants.ts
@@ -1,2 +1,0 @@
-export const BLOG_FALLBACK_IMAGE = "/img/mangrove_beach.webp";
-

--- a/src/lib/blog-presentation.test.ts
+++ b/src/lib/blog-presentation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatBlogArticleDate,
+  formatBlogCardDate,
+  hasBlogPostHeroImage,
+  resolveBlogPostImage,
+} from './blog-presentation';
+
+describe('resolveBlogPostImage', () => {
+  it('returns the fallback image when the post has no hero image', () => {
+    expect(resolveBlogPostImage('')).toBe('/img/mangrove_beach.webp');
+  });
+
+  it('returns the post image when a hero image is set', () => {
+    expect(resolveBlogPostImage('/blog/my-post/hero.webp')).toBe(
+      '/blog/my-post/hero.webp',
+    );
+  });
+
+  it('returns the fallback image when the hero image is only whitespace', () => {
+    expect(resolveBlogPostImage('   ')).toBe('/img/mangrove_beach.webp');
+  });
+
+  it('returns the fallback image when the image failed to load', () => {
+    expect(
+      resolveBlogPostImage('/blog/my-post/hero.webp', { imageLoadFailed: true }),
+    ).toBe('/img/mangrove_beach.webp');
+  });
+});
+
+describe('hasBlogPostHeroImage', () => {
+  it('returns false when the post has no hero image', () => {
+    expect(hasBlogPostHeroImage('')).toBe(false);
+  });
+
+  it('returns true when the post has a hero image', () => {
+    expect(hasBlogPostHeroImage('/blog/my-post/hero.webp')).toBe(true);
+  });
+
+  it('returns false when the hero image is the fallback path', () => {
+    expect(hasBlogPostHeroImage('/img/mangrove_beach.webp')).toBe(false);
+  });
+});
+
+describe('formatBlogCardDate', () => {
+  it('formats dates for blog listing cards', () => {
+    expect(formatBlogCardDate('2025-03-15')).toBe('Mar 15, 2025');
+  });
+});
+
+describe('formatBlogArticleDate', () => {
+  it('formats dates for article headers', () => {
+    expect(formatBlogArticleDate('2025-03-15')).toBe('March 15, 2025');
+  });
+});

--- a/src/lib/blog-presentation.ts
+++ b/src/lib/blog-presentation.ts
@@ -1,0 +1,29 @@
+import { format } from 'date-fns';
+
+export const BLOG_FALLBACK_IMAGE = '/img/mangrove_beach.webp';
+
+export function resolveBlogPostImage(
+  image: string,
+  options?: { imageLoadFailed?: boolean },
+): string {
+  const hasImage = image && image.trim() !== '';
+
+  if (!hasImage || options?.imageLoadFailed) {
+    return BLOG_FALLBACK_IMAGE;
+  }
+
+  return image;
+}
+
+export function hasBlogPostHeroImage(image: string): boolean {
+  const resolvedImage = resolveBlogPostImage(image);
+  return resolvedImage !== BLOG_FALLBACK_IMAGE;
+}
+
+export function formatBlogCardDate(date: string): string {
+  return format(new Date(date), 'MMM d, yyyy');
+}
+
+export function formatBlogArticleDate(date: string): string {
+  return format(new Date(date), 'MMMM d, yyyy');
+}

--- a/src/lib/blog.test.ts
+++ b/src/lib/blog.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+const requestCache = new Map<string, unknown>();
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+
+  return {
+    ...actual,
+    cache: <T extends (...args: unknown[]) => unknown>(fn: T) =>
+      ((...args: Parameters<T>) => {
+        const key = JSON.stringify(args);
+        if (!requestCache.has(key)) {
+          requestCache.set(key, fn(...args));
+        }
+        return requestCache.get(key) as ReturnType<T>;
+      }) as T,
+  };
+});
+
+import {
+  getAllBlogPosts,
+  getAllBlogSlugs,
+  getBlogPostBySlug,
+  getRecentBlogPosts,
+} from './blog';
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../test/fixtures/blog',
+);
+
+describe('getBlogPostBySlug', () => {
+  it('returns a typed BlogPost with normalised frontmatter and HTML content', () => {
+    const post = getBlogPostBySlug('complete-post', fixturesDir);
+
+    expect(post).not.toBeNull();
+    expect(post!.slug).toBe('complete-post');
+    expect(post!.frontmatter).toEqual({
+      title: 'Complete Post',
+      date: '2025-03-15',
+      excerpt: 'A complete blog post for testing.',
+      category: 'Engineering',
+      tags: ['testing', 'blog'],
+      image: '/blog/complete-post/hero.webp',
+      author: 'Test Author',
+      aiGeneratedContent: true,
+    });
+    expect(post!.content).toContain('Hello');
+    expect(post!.content).toMatch(/<p\b/);
+  });
+
+  it('returns null for a missing slug', () => {
+    expect(getBlogPostBySlug('does-not-exist', fixturesDir)).toBeNull();
+  });
+
+  it('normalises kebab-case ai-generated-content to aiGeneratedContent', () => {
+    const post = getBlogPostBySlug('kebab-ai-flag', fixturesDir);
+
+    expect(post!.frontmatter.aiGeneratedContent).toBe(true);
+  });
+
+  it('normalises camelCase aiGeneratedContent', () => {
+    const post = getBlogPostBySlug('camel-ai-flag', fixturesDir);
+
+    expect(post!.frontmatter.aiGeneratedContent).toBe(true);
+  });
+
+  it('parses GFM tables and maths through the full reader path', () => {
+    const post = getBlogPostBySlug('gfm-maths-post', fixturesDir);
+
+    expect(post).not.toBeNull();
+    expect(post!.content).toMatch(/<table\b/);
+    expect(post!.content).toContain('Alpha');
+    expect(post!.content).toMatch(/class="katex"/);
+    expect(post!.content).toContain('E = mc^2');
+    expect(post!.content).toContain('\\int_0^1');
+  });
+
+  it('fills defaults for missing optional frontmatter fields', () => {
+    const post = getBlogPostBySlug('minimal-post', fixturesDir);
+
+    expect(post!.frontmatter).toEqual({
+      title: 'Minimal Post',
+      date: '2025-01-10',
+      excerpt: '',
+      category: '',
+      tags: [],
+      image: '',
+      author: '',
+      aiGeneratedContent: false,
+    });
+  });
+
+  it('reads each slug once when loaded twice without a custom directory', () => {
+    const blogDir = path.join(process.cwd(), 'public', 'blog');
+    const slug = `cache-dedupe-${Date.now()}`;
+    const filePath = path.join(blogDir, `${slug}.md`);
+
+    fs.mkdirSync(blogDir, { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      `---
+title: Cache Test
+date: 2025-01-01
+---
+
+Cached body.`,
+    );
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+
+    try {
+      requestCache.clear();
+      getBlogPostBySlug(slug);
+      getBlogPostBySlug(slug);
+
+      const slugReads = readSpy.mock.calls.filter(([file]) => file === filePath);
+      expect(slugReads).toHaveLength(1);
+    } finally {
+      fs.unlinkSync(filePath);
+      readSpy.mockRestore();
+    }
+  });
+});
+
+describe('getAllBlogPosts', () => {
+  it('returns posts sorted newest-first', () => {
+    const posts = getAllBlogPosts(fixturesDir);
+    const titles = posts.map((post) => post.frontmatter.title);
+
+    expect(titles.indexOf('Newer Post')).toBeLessThan(titles.indexOf('Older Post'));
+  });
+});
+
+describe('getRecentBlogPosts', () => {
+  it('returns only the N most recent posts in newest-first order', () => {
+    const posts = getRecentBlogPosts(2, fixturesDir);
+
+    expect(posts).toHaveLength(2);
+    expect(posts[0].frontmatter.title).toBe('Newer Post');
+    expect(posts[1].frontmatter.title).toBe('Complete Post');
+  });
+
+  it('includes teaser frontmatter without processing post body to HTML', () => {
+    const posts = getRecentBlogPosts(6, fixturesDir);
+    const complete = posts.find((post) => post.slug === 'complete-post');
+
+    expect(complete).toBeDefined();
+    expect(complete!.frontmatter).toEqual({
+      title: 'Complete Post',
+      date: '2025-03-15',
+      excerpt: 'A complete blog post for testing.',
+      category: 'Engineering',
+      tags: ['testing', 'blog'],
+      image: '/blog/complete-post/hero.webp',
+      author: 'Test Author',
+      aiGeneratedContent: true,
+    });
+    expect(complete!.content).toBe('');
+    expect(getBlogPostBySlug('complete-post', fixturesDir)!.content).toMatch(/<p\b/);
+  });
+});
+
+describe('getAllBlogSlugs', () => {
+  it('returns slugs for all markdown files in the directory', () => {
+    const slugs = getAllBlogSlugs(fixturesDir);
+
+    expect(slugs).toContain('complete-post');
+    expect(slugs).toContain('minimal-post');
+    expect(slugs.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe('missing or empty blog directory', () => {
+  it('returns an empty array from getAllBlogPosts when the directory is missing', () => {
+    const missingDir = path.join(os.tmpdir(), 'missing-blog-dir-test');
+
+    expect(getAllBlogPosts(missingDir)).toEqual([]);
+  });
+
+  it('returns null from getBlogPostBySlug when the directory is missing', () => {
+    const missingDir = path.join(os.tmpdir(), 'missing-blog-dir-test');
+
+    expect(getBlogPostBySlug('any-slug', missingDir)).toBeNull();
+  });
+
+  it('returns an empty array from getAllBlogSlugs when the directory is missing', () => {
+    const missingDir = path.join(os.tmpdir(), 'missing-blog-dir-test');
+
+    expect(getAllBlogSlugs(missingDir)).toEqual([]);
+  });
+
+  it('returns empty results for an existing but empty directory', () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-blog-dir-'));
+
+    try {
+      expect(getAllBlogPosts(emptyDir)).toEqual([]);
+      expect(getRecentBlogPosts(3, emptyDir)).toEqual([]);
+      expect(getAllBlogSlugs(emptyDir)).toEqual([]);
+      expect(getBlogPostBySlug('any-slug', emptyDir)).toBeNull();
+    } finally {
+      fs.rmdirSync(emptyDir);
+    }
+  });
+
+  it('returns an empty array from getRecentBlogPosts when the directory is missing', () => {
+    const missingDir = path.join(os.tmpdir(), 'missing-blog-dir-test');
+
+    expect(getRecentBlogPosts(3, missingDir)).toEqual([]);
+  });
+});

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,62 +1,43 @@
 import fs from 'fs';
 import path from 'path';
+import { cache } from 'react';
 import matter from 'gray-matter';
-import type { BlogPost } from '@/data/types';
+import type { BlogPost, BlogPostFrontmatter } from '@/data/types';
 import { processMarkdown } from '@/lib/blog-markdown';
 
-const blogDirectory = path.join(process.cwd(), 'public', 'blog');
+const defaultBlogDirectory = path.join(process.cwd(), 'public', 'blog');
 
-export function getAllBlogPosts(): BlogPost[] {
-  // Check if blog directory exists
-  if (!fs.existsSync(blogDirectory)) {
-    return [];
-  }
-
-  // Get all markdown files from the blog directory
-  const fileNames = fs.readdirSync(blogDirectory).filter(
-    (fileName) => fileName.endsWith('.md')
-  );
-
-  const allPostsData = fileNames.map((fileName) => {
-    // Remove .md extension to get slug
-    const slug = fileName.replace(/\.md$/, '');
-
-    // Read markdown file as string
-    const fullPath = path.join(blogDirectory, fileName);
-    const fileContents = fs.readFileSync(fullPath, 'utf8');
-
-    // Parse frontmatter and content
-    const { data, content } = matter(fileContents);
-
-    // Process markdown content to HTML
-    const contentHtml = processMarkdown(content);
-
-    // Combine the data with the slug and content
-    return {
-      slug,
-      frontmatter: {
-        title: data.title || '',
-        date: data.date || '',
-        excerpt: data.excerpt || '',
-        category: data.category || '',
-        tags: Array.isArray(data.tags) ? data.tags : [],
-        image: data.image || '',
-        author: data.author || '',
-        aiGeneratedContent: data['ai-generated-content'] === true || data.aiGeneratedContent === true,
-      },
-      content: contentHtml,
-    } as BlogPost;
-  });
-
-  // Sort posts by date (newest first)
-  return allPostsData.sort((a, b) => {
-    const dateA = new Date(a.frontmatter.date).getTime();
-    const dateB = new Date(b.frontmatter.date).getTime();
-    return dateB - dateA;
-  });
+function resolveBlogDirectory(blogDirectory?: string): string {
+  return blogDirectory ?? defaultBlogDirectory;
 }
 
-export function getBlogPostBySlug(slug: string): BlogPost | null {
+function formatDate(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  return '';
+}
+
+function normalizeFrontmatter(data: Record<string, unknown>): BlogPostFrontmatter {
+  return {
+    title: typeof data.title === 'string' ? data.title : '',
+    date: formatDate(data.date),
+    excerpt: typeof data.excerpt === 'string' ? data.excerpt : '',
+    category: typeof data.category === 'string' ? data.category : '',
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    image: typeof data.image === 'string' ? data.image : '',
+    author: typeof data.author === 'string' ? data.author : '',
+    aiGeneratedContent:
+      data['ai-generated-content'] === true || data.aiGeneratedContent === true,
+  };
+}
+
+function readBlogPost(slug: string, blogDirectory: string): BlogPost | null {
   const fullPath = path.join(blogDirectory, `${slug}.md`);
 
   if (!fs.existsSync(fullPath)) {
@@ -66,34 +47,92 @@ export function getBlogPostBySlug(slug: string): BlogPost | null {
   const fileContents = fs.readFileSync(fullPath, 'utf8');
   const { data, content } = matter(fileContents);
 
-  // Process markdown content to HTML
-  const contentHtml = processMarkdown(content);
+  return {
+    slug,
+    frontmatter: normalizeFrontmatter(data as Record<string, unknown>),
+    content: processMarkdown(content),
+  };
+}
+
+function readBlogPostSummary(slug: string, blogDirectory: string): BlogPost | null {
+  const fullPath = path.join(blogDirectory, `${slug}.md`);
+
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
+
+  const fileContents = fs.readFileSync(fullPath, 'utf8');
+  const { data } = matter(fileContents);
 
   return {
     slug,
-    frontmatter: {
-      title: data.title || '',
-      date: data.date || '',
-      excerpt: data.excerpt || '',
-      category: data.category || '',
-      tags: Array.isArray(data.tags) ? data.tags : [],
-      image: data.image || '',
-      author: data.author || '',
-      aiGeneratedContent: data['ai-generated-content'] === true || data.aiGeneratedContent === true,
-    },
-    content: contentHtml,
-  } as BlogPost;
+    frontmatter: normalizeFrontmatter(data as Record<string, unknown>),
+    content: '',
+  };
 }
 
-export function getAllBlogSlugs(): string[] {
-  if (!fs.existsSync(blogDirectory)) {
+export function getAllBlogPosts(blogDirectory?: string): BlogPost[] {
+  const dir = resolveBlogDirectory(blogDirectory);
+
+  if (!fs.existsSync(dir)) {
     return [];
   }
 
-  const fileNames = fs.readdirSync(blogDirectory).filter(
-    (fileName) => fileName.endsWith('.md')
-  );
+  const fileNames = fs.readdirSync(dir).filter((fileName) => fileName.endsWith('.md'));
+
+  const allPostsData = fileNames.map((fileName) => {
+    const slug = fileName.replace(/\.md$/, '');
+    return readBlogPost(slug, dir)!;
+  });
+
+  return sortPostsNewestFirst(allPostsData);
+}
+
+function sortPostsNewestFirst(posts: BlogPost[]): BlogPost[] {
+  return [...posts].sort((a, b) => {
+    const dateA = new Date(a.frontmatter.date).getTime();
+    const dateB = new Date(b.frontmatter.date).getTime();
+    return dateB - dateA;
+  });
+}
+
+export function getRecentBlogPosts(limit: number, blogDirectory?: string): BlogPost[] {
+  const dir = resolveBlogDirectory(blogDirectory);
+
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const fileNames = fs.readdirSync(dir).filter((fileName) => fileName.endsWith('.md'));
+
+  const summaries = fileNames.map((fileName) => {
+    const slug = fileName.replace(/\.md$/, '');
+    return readBlogPostSummary(slug, dir)!;
+  });
+
+  return sortPostsNewestFirst(summaries).slice(0, limit);
+}
+
+const getCachedBlogPostBySlug = cache((slug: string) => {
+  return readBlogPost(slug, resolveBlogDirectory());
+});
+
+export function getBlogPostBySlug(slug: string, blogDirectory?: string): BlogPost | null {
+  if (blogDirectory !== undefined) {
+    return readBlogPost(slug, blogDirectory);
+  }
+
+  return getCachedBlogPostBySlug(slug);
+}
+
+export function getAllBlogSlugs(blogDirectory?: string): string[] {
+  const dir = resolveBlogDirectory(blogDirectory);
+
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const fileNames = fs.readdirSync(dir).filter((fileName) => fileName.endsWith('.md'));
 
   return fileNames.map((fileName) => fileName.replace(/\.md$/, ''));
 }
-

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from 'next';
+import { site } from '@/data';
+import { getAllBlogPosts } from '@/lib/blog';
+
+export function buildSitemap(blogDirectory?: string): MetadataRoute.Sitemap {
+  const baseUrl = site.metadata.siteUrl;
+  const blogPosts = getAllBlogPosts(blogDirectory);
+  const lastModified = new Date();
+  const blogListingLastModified =
+    blogPosts.length > 0 ? new Date(blogPosts[0].frontmatter.date) : lastModified;
+
+  return [
+    {
+      url: baseUrl,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/portfolio`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/blog`,
+      lastModified: blogListingLastModified,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    ...blogPosts.map((post) => ({
+      url: `${baseUrl}/blog/${post.slug}`,
+      lastModified: new Date(post.frontmatter.date),
+      changeFrequency: 'yearly' as const,
+      priority: 0.6,
+    })),
+  ];
+}

--- a/src/test/fixtures/blog/camel-ai-flag.md
+++ b/src/test/fixtures/blog/camel-ai-flag.md
@@ -1,0 +1,12 @@
+---
+title: Camel AI Flag
+date: 2025-02-02
+excerpt: Post using camelCase AI frontmatter.
+category: Notes
+tags: []
+image: ""
+author: Test Author
+aiGeneratedContent: true
+---
+
+AI content flagged with camelCase key.

--- a/src/test/fixtures/blog/complete-post.md
+++ b/src/test/fixtures/blog/complete-post.md
@@ -1,0 +1,16 @@
+---
+title: Complete Post
+date: 2025-03-15
+excerpt: A complete blog post for testing.
+category: Engineering
+tags:
+  - testing
+  - blog
+image: /blog/complete-post/hero.webp
+author: Test Author
+aiGeneratedContent: true
+---
+
+# Hello
+
+This is **content**.

--- a/src/test/fixtures/blog/gfm-maths-post.md
+++ b/src/test/fixtures/blog/gfm-maths-post.md
@@ -1,0 +1,25 @@
+---
+title: GFM and Maths Post
+date: 2024-01-01
+excerpt: Exercises GFM tables and KaTeX through the blog reader.
+category: Mathematics
+tags:
+  - gfm
+  - maths
+image: ''
+author: Test Author
+---
+
+## Table
+
+| Column | Value |
+| ------ | ----- |
+| Alpha  | 1     |
+
+Inline maths: $E = mc^2$
+
+Block maths:
+
+$$
+\int_0^1 x^2 \, dx = \frac{1}{3}
+$$

--- a/src/test/fixtures/blog/kebab-ai-flag.md
+++ b/src/test/fixtures/blog/kebab-ai-flag.md
@@ -1,0 +1,12 @@
+---
+title: Kebab AI Flag
+date: 2025-02-01
+excerpt: Post using kebab-case AI frontmatter.
+category: Notes
+tags: []
+image: ""
+author: Test Author
+ai-generated-content: true
+---
+
+AI content flagged with kebab-case key.

--- a/src/test/fixtures/blog/minimal-post.md
+++ b/src/test/fixtures/blog/minimal-post.md
@@ -1,0 +1,6 @@
+---
+title: Minimal Post
+date: 2025-01-10
+---
+
+Body without optional frontmatter fields.

--- a/src/test/fixtures/blog/newer-post.md
+++ b/src/test/fixtures/blog/newer-post.md
@@ -1,0 +1,11 @@
+---
+title: Newer Post
+date: 2025-06-01
+excerpt: Newer post for sort order tests.
+category: Archive
+tags: []
+image: ""
+author: Test Author
+---
+
+Newer content.

--- a/src/test/fixtures/blog/older-post.md
+++ b/src/test/fixtures/blog/older-post.md
@@ -1,0 +1,11 @@
+---
+title: Older Post
+date: 2024-06-01
+excerpt: Older post for sort order tests.
+category: Archive
+tags: []
+image: ""
+author: Test Author
+---
+
+Older content.


### PR DESCRIPTION
## Summary

Implements the blog delivery pipeline refactor from #16 via child issues #26–#30:

- **Reader module (#26):** Single `normalizeFrontmatter` path, injectable fixture directory for Vitest, committed fixtures under `src/test/fixtures/blog/`, graceful empty/missing directory handling.
- **Presentation helpers (#27):** `blog-presentation.ts` centralises fallback image and date formatting; `BlogCard` and slug route use shared helpers and design-system typography.
- **Home performance (#28):** `getRecentBlogPosts(limit)` defers full HTML processing; Home teaser loads three posts instead of the full archive.
- **Sitemap & docs (#29):** `buildSitemap` extracted to `src/lib/sitemap.ts`; tests assert `/blog` listing and slug URLs/dates match reader output; `sync-blogs` contract documented in `docs/CODEBASE-CONVENTIONS.md`.
- **Slug page dedupe (#30):** `React.cache` on production `getBlogPostBySlug`; Open Graph uses `resolveBlogPostImage`; GFM + maths fixture through full reader path.

## Acceptance criteria

### #26 — Blog reader module and CI fixture tests

- [x] Single internal frontmatter normalisation function used by all reader entry points
- [x] Committed fixtures under `src/test/fixtures/blog/` (varied frontmatter, both AI key styles, no hero image)
- [x] Tests use injectable `blogDirectory` — not `public/blog`
- [x] Vitest asserts typed `BlogPost` output (title, dates, flags, slug, HTML presence)
- [x] Both AI frontmatter key styles normalise to `aiGeneratedContent`
- [x] `getAllBlogPosts` returns posts sorted newest-first
- [x] `getBlogPostBySlug` returns null for a missing slug
- [x] Missing or empty blog directory returns empty arrays or null without throwing
- [x] `/blog` listing route still uses `getAllBlogPosts()` (unchanged public API)

### #27 — Shared presentation helpers

- [x] Shared helpers for image resolution (including fallback) and date formatting
- [x] Fallback image path defined once in `blog-presentation.ts` (`blog-constants.ts` removed)
- [x] `BlogCard` uses shared helpers
- [x] Slug route article header uses shared helpers and `Heading` / `Text`
- [x] Consistent image fallback behaviour across cards and article headers
- [x] No change to blog reader public API

### #28 — Home page recent posts

- [x] `getRecentBlogPosts(limit)` returns N most recent posts without full HTML processing
- [x] Home page uses `getRecentBlogPosts(3)` instead of `getAllBlogPosts()`
- [x] Teaser still receives correct frontmatter for titles, excerpts, dates, and images
- [x] Graceful empty state when blog directory is missing (tested)
- [x] Blog listing page behaviour unchanged

### #29 — Sitemap consistency and sync documentation

- [x] `sitemap.test.ts` asserts `/blog` listing entry
- [x] Sitemap slug URLs and `lastModified` dates match reader output (fixture-driven)
- [x] `getAllBlogSlugs` remains available for static generation
- [x] `sync-blogs` contract documented in `docs/CODEBASE-CONVENTIONS.md`
- [x] No change to `scripts/sync-blogs.js`

### #30 — Single post page deduped load

- [x] `generateMetadata` and page render share `React.cache`-wrapped `getBlogPostBySlug`
- [x] Open Graph uses `resolveBlogPostImage` (shared with #27)
- [x] GFM + maths fixture test through full reader path
- [x] Article body still renders via `dangerouslySetInnerHTML` (policy unchanged)
- [x] KaTeX CSS import remains on slug route

## Test plan

- [x] `npm test` — 49 tests passing
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Verify `/blog` listing and a slug page locally with synced posts
- [x] Confirm Home blog teaser shows three recent posts after `node scripts/sync-blogs.js`

Closes #16, #26, #27, #28, #29, #30.
