### PR TITLE
Collapse shell, deepen data layer, motion and prose primitives (#17–#20)

### DIFF
--- a/docs/CODEBASE-CONVENTIONS.md
+++ b/docs/CODEBASE-CONVENTIONS.md
@@ -99,15 +99,16 @@ Obsidian → private Git repo → Amplify build → `node scripts/sync-blogs.js`
 ### 5.3 Client vs server
 
 - **`"use client"`:** Add only when the component or a child uses hooks, browser APIs, or event handlers. Keep server components as the default for pages and static sections.
-- **Hooks:** Keep in `src/hooks/`. For `prefers-reduced-motion`, use `usePrefersReducedMotion()` from `@/hooks/use-prefers-reduced-motion` and gate all motion (Framer Motion) on it to avoid animating when the user prefers reduced motion.
+- **Hooks:** Keep in `src/hooks/`. Prefer `MotionReveal` for section reveals; use `usePrefersReducedMotion()` from `@/hooks/use-prefers-reduced-motion` only for bespoke motion (e.g. hero springs) that the primitive cannot express.
 
 ---
 
 ## 6. Motion and accessibility
 
-- **Framer Motion:** Use for scroll and viewport-based animations. Always branch on `usePrefersReducedMotion()`: when true, use zero duration or no transform (e.g. `opacity: 1`, `y: 0`) so no motion is applied.
-- **Pattern:** `initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}`, `transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.6, ease: "easeOut" }}`, and similar. Do not animate when the user prefers reduced motion.
-- **Focus:** Rely on the global focus-visible styles in `globals.css` for keyboard navigation; do not remove outline without an explicit, visible replacement.
+- **`MotionReveal`:** Prefer `@/components/ui` `MotionReveal` for standard reveals. Pass `variant` (`fade-up` | `fade` | `slide-in` | `none`), optional `delay`, `distance` (`sm` | `md` | `lg`), and `inView` (default true). The primitive owns `usePrefersReducedMotion` and skips spatial animation when reduced motion is preferred.
+- **Special cases:** Home hero springs, parallax, and infinite pulses may keep a local hook — do not recreate reduced-motion ternaries for ordinary fade/slide reveals.
+- **Backgrounds / hovers:** Decorative background loops and micro-interactions may stay outside `MotionReveal`; still respect reduced motion where practical.
+
 
 ---
 
@@ -115,12 +116,12 @@ Obsidian → private Git repo → Amplify build → `node scripts/sync-blogs.js`
 
 ### 7.1 Pages and layout
 
-- **Metadata:** Export `metadata` or use `generateMetadata` for every route. Use `site` from `@/data` for base title, description, and URLs.
-- **Layout:** Root layout provides font, theme script, and SEO (e.g. structured data). Each page that needs header/footer includes `<Header />` and `<FooterSection />` explicitly (no shared layout wrapper for them in the current structure).
+- **Metadata:** Export `metadata` or use `generateMetadata` for every route. Use `site` from `@/data` for base title, description, and URLs. Prefer page JSON fields (e.g. `portfolio.heading` / `portfolio.description`) when they exist so SEO matches on-page copy.
+- **Layout:** Root layout provides font, theme script, and SEO (e.g. structured data). Public routes wrap body content in `SitePage` (`@/components/layout/site-page`), which owns skip link, header, `main#main-content`, and the self-loaded footer. Pass `mainClassName` for route-specific spacing (e.g. `min-h-screen pt-20` on content pages). Authenticated layouts (e.g. future `/finance`) should be separate siblings, not copies of the public shell. See `docs/adr/0001-site-page-shell.md`.
 
 ### 7.2 Dynamic imports
 
-- Use `next/dynamic` when a section is below the fold or heavy and not needed for first paint. Prefer a consistent strategy per route type (e.g. home vs content pages) so the codebase does not mix ad-hoc decisions. Document in this file or in code comments if the strategy is “dynamic for all below-fold sections on home only”.
+- Use `next/dynamic` when a section is below the fold or heavy and not needed for first paint. **Footer:** always rendered statically via `SitePage` (no per-route lazy footer). **Home / About:** lazy-load below-the-fold sections only; keep hero eager.
 
 ### 7.3 Images
 

--- a/docs/adr/0001-site-page-shell.md
+++ b/docs/adr/0001-site-page-shell.md
@@ -1,0 +1,19 @@
+# ADR 0001: Site page shell
+
+## Status
+
+Accepted
+
+## Context
+
+Every public route duplicated skip link, header, main landmark, and footer wiring. Footer also required callers to pass contact props while already importing navigation and site from the data layer. CODEBASE-CONVENTIONS previously required explicit Header/Footer per page to avoid a root-layout chrome that would also wrap future authenticated routes.
+
+## Decision
+
+Introduce `SitePage` as a shared public-page shell component (not a root App Router layout). Footer loads its own common data via `getCommonData()`. Routes supply children and optional `mainClassName` only.
+
+## Consequences
+
+- Public pages no longer prop-drill footer contact fields.
+- Authenticated layouts can remain separate without inheriting public chrome from `app/layout.tsx`.
+- Conventions §7.1 documents `SitePage` as the public seam.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from "next";
-import { Header, SkipToContent } from "@/components/ui";
 import dynamic from "next/dynamic";
-import { site, footer, about, careerProfile, getAboutCareerViews } from "@/data";
+import { SitePage } from "@/components/layout/site-page";
+import { site, about, careerProfile, getAboutCareerViews } from "@/data";
 import { AboutHeroSection } from "@/components/sections/about/about-hero-section";
 
-const AboutProfessionalSection = dynamic(() => import("@/components/sections/about/about-professional-section").then(mod => ({ default: mod.AboutProfessionalSection })), {
+const AboutProfessionalSection = dynamic(() => import("@/components/sections/shared/prose-section").then(mod => ({ default: mod.ProseSection })), {
   loading: () => <div className="min-h-[400px]" />,
 });
 
@@ -17,10 +17,6 @@ const EducationListing = dynamic(() => import("@/components/sections/shared/educ
 });
 
 const CertificationsListing = dynamic(() => import("@/components/sections/shared/certifications-listing").then(mod => ({ default: mod.CertificationsListing })), {
-  loading: () => <div className="min-h-[400px]" />,
-});
-
-const FooterSection = dynamic(() => import("@/components/sections/footer-section").then(mod => ({ default: mod.FooterSection })), {
   loading: () => <div className="min-h-[400px]" />,
 });
 
@@ -39,18 +35,12 @@ export default function AboutPage() {
   const careerViews = getAboutCareerViews(careerProfile);
 
   return (
-    <>
-      <SkipToContent />
-      <Header />
-      <main id="main-content" className="bg-[var(--background)]">
-        <AboutHeroSection {...about.hero} />
-        <AboutProfessionalSection {...about.professional} />
-        <ExperienceListing {...careerViews.experience} variant="about-experience" />
-        <EducationListing {...careerViews.education} />
-        <CertificationsListing {...careerViews.certifications} />
-        <FooterSection {...footer.contact} />
-      </main>
-    </>
+    <SitePage>
+      <AboutHeroSection {...about.hero} />
+      <AboutProfessionalSection {...about.professional} />
+      <ExperienceListing {...careerViews.experience} variant="about-experience" />
+      <EducationListing {...careerViews.education} />
+      <CertificationsListing {...careerViews.certifications} />
+    </SitePage>
   );
 }
-

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,15 +2,15 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import "katex/dist/katex.min.css";
-import { Header, SkipToContent, Container, Section, Breadcrumb, Heading, Text } from "@/components/ui";
-import { FooterSection } from "@/components/sections/footer-section";
+import { Container, Section, Breadcrumb, Heading, Text } from "@/components/ui";
+import { SitePage } from "@/components/layout/site-page";
 import { getBlogPostBySlug, getAllBlogSlugs } from "@/lib/blog";
 import {
   formatBlogArticleDate,
   hasBlogPostHeroImage,
   resolveBlogPostImage,
 } from "@/lib/blog-presentation";
-import { site, footer } from "@/data";
+import { site } from "@/data";
 
 interface BlogPostPageProps {
   params: Promise<{ slug: string }>;
@@ -67,40 +67,31 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const formattedDate = formatBlogArticleDate(post.frontmatter.date);
 
   return (
-    <>
-      <SkipToContent />
-      <Header />
-      <main id="main-content" className="bg-[var(--background)] min-h-screen pt-20">
-        <Section className="py-12">
-          <Container>
-            <div className="max-w-5xl mx-auto">
-              {/* Breadcrumb */}
-              <Breadcrumb
-                items={[
-                  { label: "Home", href: "/" },
-                  { label: "Blog", href: "/blog" },
-                  { label: post.frontmatter.title },
-                ]}
-                className="mb-8"
-              />
+    <SitePage mainClassName="min-h-screen pt-20">
+      <Section className="py-12">
+        <Container>
+          <div className="max-w-5xl mx-auto">
+            <Breadcrumb
+              items={[
+                { label: "Home", href: "/" },
+                { label: "Blog", href: "/blog" },
+                { label: post.frontmatter.title },
+              ]}
+              className="mb-8"
+            />
 
-              {/* Article */}
-              <article className="w-full">
-              {/* Header */}
+            <article className="w-full">
               <header className="mb-8">
-                {/* Category */}
                 <div className="mb-4">
                   <span className="text-[var(--primary)] font-medium text-sm uppercase tracking-wide">
                     {post.frontmatter.category}
                   </span>
                 </div>
 
-                {/* Title */}
                 <Heading as="h1" size="lg" className="mb-6">
                   {post.frontmatter.title}
                 </Heading>
 
-                {/* Meta info */}
                 <div className="mb-8">
                   <div className="flex flex-wrap items-center gap-4 mb-3">
                     <Text as="span" size="xs" variant="muted">
@@ -148,7 +139,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                   )}
                 </div>
 
-                {/* Featured Image */}
                 {hasBlogPostHeroImage(post.frontmatter.image) && (
                   <div className="relative aspect-[16/9] overflow-hidden rounded-lg mb-8 bg-[var(--muted)]">
                     <Image
@@ -163,18 +153,15 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 )}
               </header>
 
-              {/* Content */}
               <div
                 className="blog-content mb-12"
                 dangerouslySetInnerHTML={{ __html: post.content }}
               />
-              </article>
-            </div>
-          </Container>
-        </Section>
-        <FooterSection {...footer.contact} />
-      </main>
-    </>
+            </article>
+          </div>
+        </Container>
+      </Section>
+    </SitePage>
   );
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from "next";
-import { Header, SkipToContent } from "@/components/ui";
+import { SitePage } from "@/components/layout/site-page";
 import { BlogGrid } from "@/components/sections/blog/blog-grid";
-import { FooterSection } from "@/components/sections/footer-section";
 import { getAllBlogPosts } from "@/lib/blog";
-import { site, footer, blog } from "@/data";
+import { site, blog } from "@/data";
 
 export const metadata: Metadata = {
   title: `Blog - ${site.metadata.author}`,
@@ -20,14 +19,8 @@ export default function BlogPage() {
   const posts = getAllBlogPosts();
 
   return (
-    <>
-      <SkipToContent />
-      <Header />
-      <main id="main-content" className="bg-[var(--background)] min-h-screen pt-20">
-        <BlogGrid posts={posts} />
-        <FooterSection {...footer.contact} />
-      </main>
-    </>
+    <SitePage mainClassName="min-h-screen pt-20">
+      <BlogGrid posts={posts} />
+    </SitePage>
   );
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 import dynamic from "next/dynamic";
-import { Header, SkipToContent } from "@/components/ui";
+import { SitePage } from "@/components/layout/site-page";
 import { HeroSection } from "@/components/sections/homepage/hero-section";
-import { home, footer, careerProfile, getHomeExperienceView } from "@/data";
+import { home, careerProfile, getHomeExperienceView } from "@/data";
 import { getRecentBlogPosts } from "@/lib/blog";
 
-// Lazy load below-the-fold sections for better performance
-const AboutSection = dynamic(() => import("@/components/sections/homepage/about-section").then(mod => ({ default: mod.AboutSection })), {
+const AboutSection = dynamic(() => import("@/components/sections/shared/prose-section").then(mod => ({ default: mod.ProseSection })), {
   loading: () => <div className="min-h-screen" />,
 });
 
@@ -21,25 +20,16 @@ const BlogSection = dynamic(() => import("@/components/sections/homepage/blog-se
   loading: () => <div className="min-h-[600px]" />,
 });
 
-const FooterSection = dynamic(() => import("@/components/sections/footer-section").then(mod => ({ default: mod.FooterSection })), {
-  loading: () => <div className="min-h-[400px]" />,
-});
-
 export default function Home() {
   const blogPosts = getRecentBlogPosts(3);
 
   return (
-    <>
-      <SkipToContent />
-      <Header />
-      <main id="main-content" className="bg-[var(--background)]">
-        <HeroSection {...home.hero} />
-        <AboutSection {...home.about} />
-        <PhotographySection {...home.photography} />
-        <BlogSection {...home.blog} posts={blogPosts} />
-        <ExperienceListing {...getHomeExperienceView(careerProfile)} id="experience" />
-        <FooterSection {...footer.contact} />
-      </main>
-    </>
+    <SitePage>
+      <HeroSection {...home.hero} />
+      <AboutSection id="about" {...home.about} />
+      <PhotographySection {...home.photography} />
+      <BlogSection {...home.blog} posts={blogPosts} />
+      <ExperienceListing {...getHomeExperienceView(careerProfile)} id="experience" />
+    </SitePage>
   );
 }

--- a/src/app/portfolio/page.test.ts
+++ b/src/app/portfolio/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { metadata } from '@/app/portfolio/page';
+import { portfolio, site } from '@/data';
+
+describe('Portfolio page metadata', () => {
+  it('derives title and description from portfolio page data', () => {
+    expect(metadata).toMatchObject({
+      title: `${portfolio.heading} - ${site.metadata.author}`,
+      description: portfolio.description,
+      openGraph: {
+        title: `${portfolio.heading} - ${site.metadata.author}`,
+        description: portfolio.description,
+        url: `${site.metadata.siteUrl}/portfolio`,
+        type: 'website',
+      },
+    });
+  });
+});

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,15 +1,16 @@
 import { Metadata } from "next";
-import { Header, SkipToContent } from "@/components/ui";
+import { SitePage } from "@/components/layout/site-page";
 import { PortfolioGrid } from "@/components/sections/portfolio/portfolio-grid";
-import { FooterSection } from "@/components/sections/footer-section";
-import { site, footer } from "@/data";
+import { getPageData, site } from "@/data";
+
+const portfolio = getPageData("/portfolio");
 
 export const metadata: Metadata = {
-  title: `Photography Portfolio - ${site.metadata.author}`,
-  description: "Explore my photography portfolio featuring portraiture and travel photography.",
+  title: `${portfolio.heading} - ${site.metadata.author}`,
+  description: portfolio.description,
   openGraph: {
-    title: `Photography Portfolio - ${site.metadata.author}`,
-    description: "Explore my photography portfolio featuring portraiture and travel photography.",
+    title: `${portfolio.heading} - ${site.metadata.author}`,
+    description: portfolio.description,
     url: `${site.metadata.siteUrl}/portfolio`,
     type: "website",
   },
@@ -17,14 +18,8 @@ export const metadata: Metadata = {
 
 export default function PortfolioPage() {
   return (
-    <>
-      <SkipToContent />
-      <Header />
-      <main id="main-content" className="bg-[var(--background)] min-h-screen pt-20">
-        <PortfolioGrid />
-        <FooterSection {...footer.contact} />
-      </main>
-    </>
+    <SitePage mainClassName="min-h-screen pt-20">
+      <PortfolioGrid />
+    </SitePage>
   );
 }
-

--- a/src/components/layout/site-page.test.tsx
+++ b/src/components/layout/site-page.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { footer, navigation } from '@/data';
+import { SitePage } from '@/components/layout/site-page';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('SitePage', () => {
+  it('renders the main landmark with children and a self-loaded footer', () => {
+    render(
+      <SitePage>
+        <p>Page body</p>
+      </SitePage>,
+    );
+
+    const main = document.getElementById('main-content');
+    expect(main).toBeInTheDocument();
+    expect(main?.tagName).toBe('MAIN');
+    expect(screen.getByText('Page body')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: footer.contact.email })).toHaveAttribute(
+      'href',
+      `mailto:${footer.contact.email}`,
+    );
+
+    const siteFooter = screen.getByRole('contentinfo');
+    expect(
+      within(siteFooter).getByRole('link', { name: navigation.links[0].label }),
+    ).toHaveAttribute('href', navigation.links[0].href);
+  });
+
+  it('applies optional mainClassName to the main landmark', () => {
+    const { container } = render(
+      <SitePage mainClassName="min-h-screen pt-20">
+        <p>Spaced body</p>
+      </SitePage>,
+    );
+
+    expect(container.querySelector('#main-content')).toHaveClass(
+      'bg-[var(--background)]',
+      'min-h-screen',
+      'pt-20',
+    );
+  });
+});

--- a/src/components/layout/site-page.tsx
+++ b/src/components/layout/site-page.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import { Header, SkipToContent } from "@/components/ui";
+import { FooterSection } from "@/components/sections/footer-section";
+import { cn } from "@/lib/utils";
+
+export interface SitePageProps {
+  children: ReactNode;
+  /** Extra classes on the main landmark (e.g. `min-h-screen pt-20`). */
+  mainClassName?: string;
+}
+
+export function SitePage({ children, mainClassName }: SitePageProps) {
+  return (
+    <>
+      <SkipToContent />
+      <Header />
+      <main id="main-content" className={cn("bg-[var(--background)]", mainClassName)}>
+        {children}
+        <FooterSection />
+      </main>
+    </>
+  );
+}

--- a/src/components/sections/about/about-hero-section.tsx
+++ b/src/components/sections/about/about-hero-section.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Heading, Container, Section, SectionBackground } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { Heading, Container, Section, SectionBackground, MotionReveal } from "@/components/ui";
 
 interface AboutHeroSectionProps {
   name: string;
@@ -10,39 +8,27 @@ interface AboutHeroSectionProps {
 }
 
 export function AboutHeroSection({ name, title }: AboutHeroSectionProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-
   return (
     <Section className="relative overflow-hidden pt-28 md:pt-36 pb-20">
       <SectionBackground variant="about-experience" />
-      
+
       <Container>
         <div className="max-w-4xl mx-auto text-center space-y-8">
-          <motion.div
-            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, ease: "easeOut" }}
-          >
+          <MotionReveal variant="fade-up" distance="md" inView={false}>
             <Heading size="xl" className="text-[var(--foreground)] mb-4">
               {name}
             </Heading>
-          </motion.div>
+          </MotionReveal>
 
-          <motion.div
-            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay: 0.2, ease: "easeOut" }}
-            className="relative"
-          >
+          <MotionReveal variant="fade-up" distance="sm" delay={0.2} inView={false} className="relative">
             <div className="absolute left-1/2 -translate-x-1/2 -top-4 w-16 h-px bg-[var(--primary)] transform -skew-x-12 opacity-40" />
             <Heading size="sm" as="h2" className="text-[var(--primary)] tracking-[0.25em] capitalize relative">
               {title}
             </Heading>
             <div className="absolute left-1/2 -translate-x-1/2 -bottom-4 w-12 h-px bg-[var(--primary)] transform skew-x-12 opacity-30" />
-          </motion.div>
+          </MotionReveal>
         </div>
       </Container>
     </Section>
   );
 }
-

--- a/src/components/sections/about/about-professional-section.tsx
+++ b/src/components/sections/about/about-professional-section.tsx
@@ -1,63 +1,9 @@
 "use client";
 
-import { SectionHeader, Text, Container, Section, SectionBackground } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { ProseSection, type ProseSectionProps } from "@/components/sections/shared/prose-section";
 
-interface AboutProfessionalSectionProps {
-  heading: string;
-  content: string | string[];
+export type AboutProfessionalSectionProps = Omit<ProseSectionProps, "cta" | "id">;
+
+export function AboutProfessionalSection(props: AboutProfessionalSectionProps) {
+  return <ProseSection {...props} />;
 }
-
-export function AboutProfessionalSection({ heading, content }: AboutProfessionalSectionProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-  const contentArray = Array.isArray(content) ? content : [content];
-
-  return (
-    <Section className="relative overflow-hidden">
-      <SectionBackground variant="about-experience" />
-      
-      <Container>
-        <div className="space-y-16">
-          <SectionHeader showRightAccent showBottomAccent>
-            {heading}
-          </SectionHeader>
-
-          <motion.div
-            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay: 0.2, ease: "easeOut" }}
-            viewport={{ once: true }}
-            className="relative max-w-4xl mx-auto"
-          >
-            <div className="absolute inset-0 border-2 border-[var(--primary)] opacity-20 transform -rotate-1" 
-                 style={{
-                   clipPath: 'polygon(0 0, calc(100% - 30px) 0, 100% 30px, 100% 100%, 30px 100%, 0 calc(100% - 30px))'
-                 }} />
-            
-            <div className="absolute top-0 left-0 w-20 h-px bg-[var(--primary)] transform -skew-x-12 opacity-50" />
-            <div className="absolute bottom-0 right-0 w-32 h-px bg-[var(--primary)] transform skew-x-12 opacity-30" />
-            
-            <div className="p-8 md:p-16 lg:p-20 relative z-10">
-              <div className="space-y-6">
-                {contentArray.map((paragraph, index) => (
-                  <Text 
-                    key={index}
-                    size="lg" 
-                    className="leading-relaxed text-[var(--foreground)]"
-                  >
-                    {paragraph}
-                  </Text>
-                ))}
-              </div>
-            </div>
-            
-            <div className="absolute top-6 right-6 w-8 h-8 border-2 border-[var(--primary)] transform rotate-45 opacity-30" />
-            <div className="absolute bottom-6 left-6 w-6 h-6 bg-[var(--primary)] transform -rotate-12 opacity-10" />
-          </motion.div>
-        </div>
-      </Container>
-    </Section>
-  );
-}
-

--- a/src/components/sections/blog/blog-grid.tsx
+++ b/src/components/sections/blog/blog-grid.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { SectionHeader, Container, Section, BlogCard } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { SectionHeader, Container, Section, BlogCard, MotionReveal } from "@/components/ui";
 import { blog } from "@/data";
 import type { BlogPost } from "@/data/types";
 
@@ -14,7 +12,6 @@ interface BlogGridProps {
 type SortOption = "latest" | "oldest" | "title";
 
 export function BlogGrid({ posts }: BlogGridProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
   const [sortOption, setSortOption] = useState<SortOption>("latest");
 
@@ -132,15 +129,12 @@ export function BlogGrid({ posts }: BlogGridProps) {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {filteredAndSortedPosts.map((post, index) => (
-              <motion.div
+              <MotionReveal
                 key={post.slug}
-                initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={prefersReducedMotion ? { duration: 0 } : { 
-                  duration: 0.5, 
-                  delay: index * 0.05,
-                  ease: "easeOut" 
-                }}
+                variant="fade-up"
+                distance="sm"
+                delay={index * 0.05}
+                inView={false}
               >
                 <BlogCard
                   slug={post.slug}
@@ -152,7 +146,7 @@ export function BlogGrid({ posts }: BlogGridProps) {
                   image={post.frontmatter.image}
                   priority={index < 6}
                 />
-              </motion.div>
+              </MotionReveal>
             ))}
           </div>
         )}

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -11,44 +11,32 @@ import {
   SocialLink,
   Text,
 } from "@/components/ui";
-import { navigation, site } from "@/data";
+import { getCommonData } from "@/data";
 
-interface FooterSectionProps {
-  heading: string;
-  description: string;
-  navigationTitle: string;
-  socialTitle: string;
-  email: string;
-  social: {
-    github: string;
-    linkedin: string;
-  };
-  copyright: string;
-}
+export function FooterSection() {
+  const { footer, navigation, site } = getCommonData();
+  const {
+    heading,
+    description,
+    navigationTitle,
+    socialTitle,
+    email,
+    social,
+    copyright,
+  } = footer.contact;
 
-export function FooterSection({
-  heading,
-  description,
-  navigationTitle,
-  socialTitle,
-  email,
-  social,
-  copyright,
-}: FooterSectionProps) {
   return (
     <footer className="relative overflow-hidden bg-[var(--background)] border-t border-[var(--border)]">
       <FooterBackground />
-      
+
       <Container>
         <div className="py-20 space-y-16">
-          {/* Main content grid */}
           <div className="grid md:grid-cols-3 gap-12 md:gap-16">
-            {/* Contact section */}
             <FooterColumn title={heading} delay={0}>
               <Text className="leading-relaxed text-[var(--foreground)]">
                 {description}
               </Text>
-              
+
               <div className="space-y-3">
                 <Text className="font-medium text-[var(--primary)]">
                   <a href={`mailto:${email}`} className="hover:underline transition-colors duration-300">
@@ -58,7 +46,6 @@ export function FooterSection({
               </div>
             </FooterColumn>
 
-            {/* Navigation links */}
             <FooterColumn title={navigationTitle} delay={0.2}>
               <nav className="space-y-3 relative z-10">
                 {navigation.links.map((link) => (
@@ -69,16 +56,15 @@ export function FooterSection({
               </nav>
             </FooterColumn>
 
-            {/* Social links */}
             <FooterColumn title={socialTitle} delay={0.4}>
               <div className="flex gap-4 relative z-10">
-                <SocialLink 
-                  href={social.linkedin} 
+                <SocialLink
+                  href={social.linkedin}
                   icon={<LinkedInIcon />}
                   label="LinkedIn"
                 />
-                <SocialLink 
-                  href={social.github} 
+                <SocialLink
+                  href={social.github}
                   icon={<GitHubIcon />}
                   label="GitHub"
                 />
@@ -86,7 +72,6 @@ export function FooterSection({
             </FooterColumn>
           </div>
 
-          {/* Bottom section with brand name */}
           <FooterBrand brandName={site.brandName} copyright={copyright} />
         </div>
       </Container>

--- a/src/components/sections/homepage/about-section.tsx
+++ b/src/components/sections/homepage/about-section.tsx
@@ -1,78 +1,9 @@
 "use client";
 
-import { SectionHeader, Text, Container, Section, SectionBackground, Button } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { ProseSection, type ProseSectionProps } from "@/components/sections/shared/prose-section";
 
-interface AboutSectionProps {
-  heading: string;
-  content: string | string[];
-  cta?: {
-    label: string;
-    href: string;
-  };
-}
+export type AboutSectionProps = ProseSectionProps;
 
-export function AboutSection({ heading, content, cta }: AboutSectionProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-  
-  return (
-    <Section id="about" className="relative overflow-hidden">
-      <SectionBackground variant="about-experience" />
-      
-      <Container>
-        <div className="space-y-16">
-          {/* Header with angular styling */}
-          <SectionHeader showRightAccent showBottomAccent>
-            {heading}
-          </SectionHeader>
-
-          {/* Content - Simplified single column */}
-          <motion.div
-            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay: 0.2, ease: "easeOut" }}
-            viewport={{ once: true }}
-            className="relative max-w-4xl mx-auto"
-          >
-            {/* Angular border effect */}
-            <div className="absolute inset-0 border-2 border-[var(--primary)] opacity-20 transform -rotate-1 pointer-events-none" 
-                 style={{
-                   clipPath: 'polygon(0 0, calc(100% - 30px) 0, 100% 30px, 100% 100%, 30px 100%, 0 calc(100% - 30px))'
-                 }} />
-            
-            {/* Accent lines */}
-            <div className="absolute top-0 left-0 w-20 h-px bg-[var(--primary)] transform -skew-x-12 opacity-50 pointer-events-none" />
-            <div className="absolute bottom-0 right-0 w-32 h-px bg-[var(--primary)] transform skew-x-12 opacity-30 pointer-events-none" />
-            
-            {/* Content with padding */}
-            <div className="p-8 md:p-16 lg:p-20 relative z-10">
-              <Text size="lg" className="leading-relaxed text-[var(--foreground)]">
-                {Array.isArray(content) ? content.join(" ") : content}
-              </Text>
-            </div>
-            
-            {/* Corner accents */}
-            <div className="absolute top-6 right-6 w-8 h-8 border-2 border-[var(--primary)] transform rotate-45 opacity-30 pointer-events-none" />
-            <div className="absolute bottom-6 left-6 w-6 h-6 bg-[var(--primary)] transform -rotate-12 opacity-10 pointer-events-none" />
-          </motion.div>
-
-          {/* Button */}
-          <motion.div
-            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.6, delay: 0.4, ease: "easeOut" }}
-            viewport={{ once: true }}
-            className="flex justify-center relative z-10"
-          >
-            {cta && (
-              <Button href={cta.href} variant="primary" size="md">
-                {cta.label}
-              </Button>
-            )}
-          </motion.div>
-        </div>
-      </Container>
-    </Section>
-  );
+export function AboutSection(props: AboutSectionProps) {
+  return <ProseSection id="about" {...props} />;
 }

--- a/src/components/sections/homepage/blog-section.tsx
+++ b/src/components/sections/homepage/blog-section.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { SectionHeader, Text, Container, Section, SectionBackground, Button, BlogCard } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import {
+  SectionHeader,
+  Text,
+  Container,
+  Section,
+  SectionBackground,
+  Button,
+  BlogCard,
+  MotionReveal,
+} from "@/components/ui";
 import type { BlogPost } from "@/data/types";
 
 interface BlogSectionProps {
@@ -25,7 +32,6 @@ export function BlogSection({
   posts: allPosts,
   maxPosts = 3,
 }: BlogSectionProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
   const posts = allPosts.slice(0, maxPosts);
 
   return (
@@ -34,12 +40,10 @@ export function BlogSection({
 
       <Container>
         <div className="space-y-12 md:space-y-16">
-          {/* Header */}
           <SectionHeader animated={false} showBottomAccent>
             {heading}
           </SectionHeader>
 
-          {/* Description */}
           {description && (
             <div className="max-w-2xl mx-auto text-center">
               <Text size="lg" className="text-[var(--foreground)]/80">
@@ -48,20 +52,14 @@ export function BlogSection({
             </div>
           )}
 
-          {/* Blog Posts Grid */}
           {posts.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {posts.map((post, index) => (
-                <motion.div
+                <MotionReveal
                   key={post.slug}
-                  initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={prefersReducedMotion ? { duration: 0 } : { 
-                    duration: 0.5, 
-                    delay: index * 0.1,
-                    ease: "easeOut" 
-                  }}
-                  viewport={{ once: true }}
+                  variant="fade-up"
+                  distance="sm"
+                  delay={index * 0.1}
                 >
                   <BlogCard
                     slug={post.slug}
@@ -73,7 +71,7 @@ export function BlogSection({
                     image={post.frontmatter.image}
                     priority={index < 3}
                   />
-                </motion.div>
+                </MotionReveal>
               ))}
             </div>
           ) : (
@@ -84,23 +82,20 @@ export function BlogSection({
             </div>
           )}
 
-          {/* Button */}
           {allPosts.length > 0 && cta && (
-            <motion.div
-              initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.6, delay: 0.4, ease: "easeOut" }}
-              viewport={{ once: true }}
+            <MotionReveal
+              variant="fade-up"
+              distance="sm"
+              delay={0.4}
               className="flex justify-center pt-8 relative z-10"
             >
               <Button href={cta.href} variant="primary" size="md">
                 {cta.label}
               </Button>
-            </motion.div>
+            </MotionReveal>
           )}
         </div>
       </Container>
     </Section>
   );
 }
-

--- a/src/components/sections/portfolio/portfolio-grid.tsx
+++ b/src/components/sections/portfolio/portfolio-grid.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { SectionHeader, Container, Section, PhotoCard, Lightbox } from "@/components/ui";
+import { SectionHeader, Container, Section, PhotoCard, Lightbox, MotionReveal } from "@/components/ui";
 import { portfolio } from "@/data";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 import { useState, useEffect } from "react";
 
 export function PortfolioGrid() {
-  const prefersReducedMotion = usePrefersReducedMotion();
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
@@ -57,15 +54,12 @@ export function PortfolioGrid() {
         {/* 3-Column Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {portfolio.images.map((image, index) => (
-            <motion.div
+            <MotionReveal
               key={index}
-              initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={prefersReducedMotion ? { duration: 0 } : { 
-                duration: 0.5, 
-                delay: index * 0.1,
-                ease: "easeOut" 
-              }}
+              variant="fade-up"
+              distance="sm"
+              delay={index * 0.1}
+              inView={false}
             >
               <PhotoCard
                 src={image.src}
@@ -78,14 +72,13 @@ export function PortfolioGrid() {
                 priority={index < 9}
                 onClick={() => openLightbox(index)}
                 onMouseEnter={() => {
-                  // Preload lightbox image on hover for instant opening
                   if (typeof window !== 'undefined') {
                     const img = new window.Image();
                     img.src = image.src;
                   }
                 }}
               />
-            </motion.div>
+            </MotionReveal>
           ))}
         </div>
       </Container>

--- a/src/components/sections/shared/certifications-listing.tsx
+++ b/src/components/sections/shared/certifications-listing.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { Heading, Text, Container, Section, SectionBackground, SectionHeader } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import {
+  Heading,
+  Text,
+  Container,
+  Section,
+  SectionBackground,
+  SectionHeader,
+  MotionReveal,
+} from "@/components/ui";
 import type { CertificationsSection } from "@/data/types";
 
 export function CertificationsListing({ heading, items }: CertificationsSection) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-
   return (
     <Section className="relative overflow-hidden">
       <SectionBackground variant="about-experience" />
@@ -20,16 +24,10 @@ export function CertificationsListing({ heading, items }: CertificationsSection)
 
           <div className="max-w-4xl mx-auto space-y-12">
             {items.map((item, index) => (
-              <motion.div
+              <MotionReveal
                 key={item.name}
-                initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -50 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                transition={
-                  prefersReducedMotion
-                    ? { duration: 0 }
-                    : { duration: 0.8, delay: index * 0.2, ease: "easeOut" }
-                }
-                viewport={{ once: true }}
+                variant="slide-in"
+                delay={index * 0.2}
                 className="relative"
               >
                 <div className="relative group">
@@ -66,7 +64,7 @@ export function CertificationsListing({ heading, items }: CertificationsSection)
                     <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
                   </div>
                 </div>
-              </motion.div>
+              </MotionReveal>
             ))}
           </div>
         </div>

--- a/src/components/sections/shared/education-listing.tsx
+++ b/src/components/sections/shared/education-listing.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { Heading, Text, Container, Section, SectionBackground, SectionHeader } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import {
+  Heading,
+  Text,
+  Container,
+  Section,
+  SectionBackground,
+  SectionHeader,
+  MotionReveal,
+} from "@/components/ui";
 import type { EducationSection } from "@/data/types";
 
 export function EducationListing({ heading, entries }: EducationSection) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-
   return (
     <Section id="education" className="relative overflow-hidden">
       <SectionBackground variant="about-experience" />
@@ -20,16 +24,10 @@ export function EducationListing({ heading, entries }: EducationSection) {
 
           <div className="max-w-4xl mx-auto space-y-12">
             {entries.map((entry, index) => (
-              <motion.div
+              <MotionReveal
                 key={`${entry.institution}-${entry.qualification}`}
-                initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -50 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                transition={
-                  prefersReducedMotion
-                    ? { duration: 0 }
-                    : { duration: 0.8, delay: index * 0.2, ease: "easeOut" }
-                }
-                viewport={{ once: true }}
+                variant="slide-in"
+                delay={index * 0.2}
                 className="relative"
               >
                 <div className="relative group">
@@ -57,7 +55,7 @@ export function EducationListing({ heading, entries }: EducationSection) {
                     <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
                   </div>
                 </div>
-              </motion.div>
+              </MotionReveal>
             ))}
           </div>
         </div>

--- a/src/components/sections/shared/experience-listing.tsx
+++ b/src/components/sections/shared/experience-listing.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { Heading, Text, Container, Section, SectionBackground, SectionHeader } from "@/components/ui";
-import { motion } from "framer-motion";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import {
+  Heading,
+  Text,
+  Container,
+  Section,
+  SectionBackground,
+  SectionHeader,
+  MotionReveal,
+} from "@/components/ui";
 import type { ExperienceSection } from "@/data/types";
 
 interface ExperienceListingProps extends ExperienceSection {
@@ -11,19 +17,17 @@ interface ExperienceListingProps extends ExperienceSection {
   id?: string;
 }
 
-export function ExperienceListing({ 
-  heading, 
-  companies, 
+export function ExperienceListing({
+  heading,
+  companies,
   variant = "about-experience",
   showHeader = true,
-  id
+  id,
 }: ExperienceListingProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-  
   return (
     <Section id={id} className="relative overflow-hidden">
       <SectionBackground variant={variant} />
-      
+
       <Container>
         <div className="space-y-16">
           {showHeader && (
@@ -31,23 +35,18 @@ export function ExperienceListing({
               {heading}
             </SectionHeader>
           )}
-          
+
           <div className="max-w-4xl mx-auto space-y-16">
             {companies.map((company, companyIndex) => (
-              <motion.div
+              <MotionReveal
                 key={company.name}
-                initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -50 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay: companyIndex * 0.3, ease: "easeOut" }}
-                viewport={{ once: true }}
+                variant="slide-in"
+                delay={companyIndex * 0.3}
                 className="relative"
               >
-                {/* Company container */}
                 <div className="relative group">
-                  {/* Main angular border */}
                   <div className="absolute left-0 top-0 bottom-0 w-2 bg-[var(--primary)] opacity-20 transform skew-x-12" />
-                  
-                  {/* Company header */}
+
                   <div className="pl-12 pb-8">
                     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-6">
                       <div className="space-y-1">
@@ -58,37 +57,26 @@ export function ExperienceListing({
                           {company.location}
                         </Text>
                       </div>
-                      
-                      {/* Company-level angular accent */}
+
                       <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-40" />
                     </div>
-                    
-                    {/* Roles container */}
+
                     <div className="space-y-8">
                       {company.roles.map((role, roleIndex) => (
-                        <motion.div
+                        <MotionReveal
                           key={`${company.name}-${role.role}`}
-                          initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-                          whileInView={{ opacity: 1, y: 0 }}
-                          transition={prefersReducedMotion ? { duration: 0 } : { 
-                            duration: 0.6, 
-                            delay: (companyIndex * 0.3) + (roleIndex * 0.15), 
-                            ease: "easeOut" 
-                          }}
-                          viewport={{ once: true }}
+                          variant="fade-up"
+                          distance="sm"
+                          delay={companyIndex * 0.3 + roleIndex * 0.15}
                           className="relative group/role"
                         >
-                          {/* Role connecting line */}
                           {roleIndex > 0 && (
                             <div className="absolute -left-8 top-0 w-px h-8 bg-[var(--primary)] opacity-30" />
                           )}
-                          
-                          {/* Role content */}
+
                           <div className="pl-8 space-y-3 relative">
-                            {/* Role angular accent */}
                             <div className="absolute -left-6 top-2 w-3 h-3 border border-[var(--primary)] transform rotate-45 opacity-0 group-hover/role:opacity-100 transition-opacity duration-300" />
-                            
-                            {/* Role header */}
+
                             <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2">
                               <div className="space-y-1">
                                 <Heading size="sm" as="h3" className="text-[var(--foreground)]">
@@ -101,21 +89,19 @@ export function ExperienceListing({
                                 </Text>
                               </div>
                             </div>
-                            
-                            {/* Role description */}
+
                             <Text className="leading-relaxed text-sm">
                               {role.description}
                             </Text>
-                            
-                            {/* Bottom accent line */}
+
                             <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
                           </div>
-                        </motion.div>
+                        </MotionReveal>
                       ))}
                     </div>
                   </div>
                 </div>
-              </motion.div>
+              </MotionReveal>
             ))}
           </div>
         </div>
@@ -123,4 +109,3 @@ export function ExperienceListing({
     </Section>
   );
 }
-

--- a/src/components/sections/shared/prose-section.test.tsx
+++ b/src/components/sections/shared/prose-section.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ProseSection } from '@/components/sections/shared/prose-section';
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  mockPrefersReducedMotion(false);
+});
+
+describe('ProseSection', () => {
+  it('renders a single string as one paragraph', () => {
+    render(
+      <ProseSection heading="About" content="Hello from the prose section." />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'About' })).toBeInTheDocument();
+    expect(screen.getByText('Hello from the prose section.')).toBeInTheDocument();
+  });
+
+  it('renders array content as multiple paragraphs', () => {
+    render(
+      <ProseSection
+        heading="Professional"
+        content={['First paragraph.', 'Second paragraph.']}
+      />,
+    );
+
+    expect(screen.getByText('First paragraph.')).toBeInTheDocument();
+    expect(screen.getByText('Second paragraph.')).toBeInTheDocument();
+  });
+
+  it('renders an optional CTA link', () => {
+    render(
+      <ProseSection
+        heading="About"
+        content="Body copy."
+        cta={{ label: 'Learn more about me', href: '/about' }}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Learn more about me' })).toHaveAttribute(
+      'href',
+      '/about',
+    );
+  });
+
+  it('remains visible when reduced motion is preferred', () => {
+    mockPrefersReducedMotion(true);
+
+    render(
+      <ProseSection heading="About" content="Accessible copy." id="about" />,
+    );
+
+    expect(screen.getByText('Accessible copy.')).toBeVisible();
+    expect(document.getElementById('about')).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/shared/prose-section.tsx
+++ b/src/components/sections/shared/prose-section.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  SectionHeader,
+  Text,
+  Container,
+  Section,
+  SectionBackground,
+  Button,
+  MotionReveal,
+} from "@/components/ui";
+import type { AboutSection } from "@/data/types";
+
+export interface ProseSectionProps extends AboutSection {
+  id?: string;
+  className?: string;
+}
+
+export function ProseSection({
+  heading,
+  content,
+  cta,
+  id,
+  className,
+}: ProseSectionProps) {
+  const paragraphs = Array.isArray(content) ? content : [content];
+
+  return (
+    <Section id={id} className={`relative overflow-hidden ${className ?? ""}`.trim()}>
+      <SectionBackground variant="about-experience" />
+
+      <Container>
+        <div className="space-y-16">
+          <SectionHeader showRightAccent showBottomAccent>
+            {heading}
+          </SectionHeader>
+
+          <MotionReveal variant="fade-up" distance="md" delay={0.2} className="relative max-w-4xl mx-auto">
+            <div
+              className="absolute inset-0 border-2 border-[var(--primary)] opacity-20 transform -rotate-1 pointer-events-none"
+              style={{
+                clipPath:
+                  "polygon(0 0, calc(100% - 30px) 0, 100% 30px, 100% 100%, 30px 100%, 0 calc(100% - 30px))",
+              }}
+            />
+
+            <div className="absolute top-0 left-0 w-20 h-px bg-[var(--primary)] transform -skew-x-12 opacity-50 pointer-events-none" />
+            <div className="absolute bottom-0 right-0 w-32 h-px bg-[var(--primary)] transform skew-x-12 opacity-30 pointer-events-none" />
+
+            <div className="p-8 md:p-16 lg:p-20 relative z-10">
+              <div className="space-y-6">
+                {paragraphs.map((paragraph, index) => (
+                  <Text
+                    key={index}
+                    size="lg"
+                    className="leading-relaxed text-[var(--foreground)]"
+                  >
+                    {paragraph}
+                  </Text>
+                ))}
+              </div>
+            </div>
+
+            <div className="absolute top-6 right-6 w-8 h-8 border-2 border-[var(--primary)] transform rotate-45 opacity-30 pointer-events-none" />
+            <div className="absolute bottom-6 left-6 w-6 h-6 bg-[var(--primary)] transform -rotate-12 opacity-10 pointer-events-none" />
+          </MotionReveal>
+
+          {cta && (
+            <MotionReveal
+              variant="fade-up"
+              distance="sm"
+              delay={0.4}
+              className="flex justify-center relative z-10"
+            >
+              <Button href={cta.href} variant="primary" size="md">
+                {cta.label}
+              </Button>
+            </MotionReveal>
+          )}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/ui/footer/footer-brand.tsx
+++ b/src/components/ui/footer/footer-brand.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
 import { Heading } from "@/components/ui/typography/heading";
 import { Text } from "@/components/ui/typography/text";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { MotionReveal } from "@/components/ui/motion-reveal";
 
 interface FooterBrandProps {
   brandName: string;
@@ -11,33 +10,27 @@ interface FooterBrandProps {
 }
 
 export function FooterBrand({ brandName, copyright }: FooterBrandProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-  
   return (
-    <motion.div
-      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 30 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay: 0.6, ease: "easeOut" }}
-      viewport={{ once: true }}
+    <MotionReveal
+      variant="fade-up"
+      distance="md"
+      delay={0.6}
       className="border-t border-[var(--border)] pt-12"
     >
       <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
-        {/* Large brand name */}
         <div className="relative flex-shrink-0">
           <Heading size="xl" className="text-[var(--foreground)] font-black tracking-tight">
             {brandName}
           </Heading>
           <div className="absolute -bottom-2 -right-2 w-8 h-8 bg-[var(--primary)] opacity-10 transform rotate-45" />
         </div>
-        
-        {/* Copyright */}
+
         <div className="md:text-right flex-shrink-0">
           <Text variant="muted" className="text-sm whitespace-nowrap">
             {copyright}
           </Text>
         </div>
       </div>
-    </motion.div>
+    </MotionReveal>
   );
 }
-

--- a/src/components/ui/footer/footer-column.tsx
+++ b/src/components/ui/footer/footer-column.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
 import { Heading } from "@/components/ui/typography/heading";
+import { MotionReveal } from "@/components/ui/motion-reveal";
 import { ReactNode } from "react";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 
 interface FooterColumnProps {
   title: string;
@@ -12,16 +11,8 @@ interface FooterColumnProps {
 }
 
 export function FooterColumn({ title, children, delay = 0 }: FooterColumnProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-  
   return (
-    <motion.div
-      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 50 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay, ease: "easeOut" }}
-      viewport={{ once: true }}
-      className="space-y-6"
-    >
+    <MotionReveal variant="fade-up" distance="lg" delay={delay} className="space-y-6">
       <div className="relative">
         <div className="absolute -left-4 top-0 w-1 h-full bg-[var(--primary)] transform -skew-y-12" />
         <Heading size="md" className="relative">
@@ -30,7 +21,6 @@ export function FooterColumn({ title, children, delay = 0 }: FooterColumnProps) 
         </Heading>
       </div>
       {children}
-    </motion.div>
+    </MotionReveal>
   );
 }
-

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,6 +2,8 @@
 export { Heading } from "./typography/heading";
 export { Text } from "./typography/text";
 export { SectionHeader } from "./section-header";
+export { MotionReveal } from "./motion-reveal";
+export type { MotionRevealVariant, MotionRevealDistance, MotionRevealProps } from "./motion-reveal";
 
 // Interactive
 export { Button } from "./button";

--- a/src/components/ui/motion-reveal.test.tsx
+++ b/src/components/ui/motion-reveal.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MotionReveal } from '@/components/ui/motion-reveal';
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  mockPrefersReducedMotion(false);
+});
+
+describe('MotionReveal', () => {
+  it('shows children immediately when reduced motion is preferred', () => {
+    mockPrefersReducedMotion(true);
+
+    render(
+      <MotionReveal>
+        <p>Visible content</p>
+      </MotionReveal>,
+    );
+
+    const content = screen.getByText('Visible content');
+    expect(content).toBeVisible();
+    expect(content.parentElement).not.toHaveStyle({ opacity: '0' });
+  });
+
+  it('renders children as a static wrapper when variant is none', () => {
+    mockPrefersReducedMotion(false);
+
+    render(
+      <MotionReveal variant="none">
+        <p>Static content</p>
+      </MotionReveal>,
+    );
+
+    expect(screen.getByText('Static content')).toBeVisible();
+  });
+});

--- a/src/components/ui/motion-reveal.tsx
+++ b/src/components/ui/motion-reveal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { motion } from "framer-motion";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+
+export type MotionRevealVariant = "fade-up" | "fade" | "slide-in" | "none";
+export type MotionRevealDistance = "sm" | "md" | "lg";
+
+export interface MotionRevealProps {
+  children: ReactNode;
+  variant?: MotionRevealVariant;
+  delay?: number;
+  className?: string;
+  /** When true (default), reveal on scroll with whileInView; otherwise animate on mount. */
+  inView?: boolean;
+  distance?: MotionRevealDistance;
+}
+
+const FADE_UP_DISTANCE: Record<MotionRevealDistance, number> = {
+  sm: 20,
+  md: 30,
+  lg: 50,
+};
+
+export function MotionReveal({
+  children,
+  variant = "fade-up",
+  delay = 0,
+  className,
+  inView = true,
+  distance = "md",
+}: MotionRevealProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  if (variant === "none" || prefersReducedMotion) {
+    return <div className={className}>{children}</div>;
+  }
+
+  const initial =
+    variant === "fade"
+      ? { opacity: 0 }
+      : variant === "slide-in"
+        ? { opacity: 0, x: -50 }
+        : { opacity: 0, y: FADE_UP_DISTANCE[distance] };
+
+  const visible =
+    variant === "fade"
+      ? { opacity: 1 }
+      : variant === "slide-in"
+        ? { opacity: 1, x: 0 }
+        : { opacity: 1, y: 0 };
+
+  const transition = { duration: 0.8, delay, ease: "easeOut" as const };
+
+  if (inView) {
+    return (
+      <motion.div
+        className={className}
+        initial={initial}
+        whileInView={visible}
+        transition={transition}
+        viewport={{ once: true }}
+      >
+        {children}
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={initial}
+      animate={visible}
+      transition={transition}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
 import { Heading } from "@/components/ui/typography/heading";
 import { ReactNode } from "react";
-import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { MotionReveal } from "@/components/ui/motion-reveal";
 
 interface SectionHeaderProps {
   children: ReactNode;
@@ -28,7 +27,6 @@ export function SectionHeader({
   animated = true,
   delay = 0,
 }: SectionHeaderProps) {
-  const prefersReducedMotion = usePrefersReducedMotion();
   const alignmentClasses = {
     left: "",
     center: "text-center",
@@ -37,22 +35,16 @@ export function SectionHeader({
 
   const content = (
     <div className={`relative w-full ${alignmentClasses[align]}`}>
-      {/* Left vertical accent line */}
       {showLeftAccent && (
         <div className="absolute -left-4 top-0 w-1 h-full bg-[var(--primary)] transform -skew-y-12 hidden sm:block" />
       )}
-      
-      {/* Right bottom horizontal accent line */}
+
       {showRightAccent && (
         <div className="absolute -right-4 bottom-0 w-16 h-px bg-[var(--primary)] transform skew-x-12 opacity-30 hidden sm:block" />
       )}
-      
-      <Heading 
-        size={size} 
-        className={`relative w-full ${className}`}
-      >
+
+      <Heading size={size} className={`relative w-full ${className}`}>
         {children}
-        {/* Bottom right decorative square */}
         {showBottomAccent && (
           <div className="absolute -bottom-2 -right-2 w-8 h-8 bg-[var(--primary)] opacity-10 transform rotate-45 hidden sm:block" />
         )}
@@ -65,14 +57,8 @@ export function SectionHeader({
   }
 
   return (
-    <motion.div
-      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 50 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.8, delay, ease: "easeOut" }}
-      viewport={{ once: true }}
-    >
+    <MotionReveal variant="fade-up" distance="lg" delay={delay}>
       {content}
-    </motion.div>
+    </MotionReveal>
   );
 }
-

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,6 +1,6 @@
 # Content Data Structure
 
-This directory contains all content data for the website, organized for scalability and maintainability.
+This directory contains all content data for the website, organised for scalability and maintainability.
 
 ## Directory Structure
 
@@ -18,136 +18,69 @@ src/data/
 │   ├── certifications-slices.ts
 │   └── about-career-slices.ts
 ├── common/          # Shared content across pages
-│   ├── footer.json      # Footer contact info and social links
-│   ├── navigation.json  # Navigation menu items
-│   └── site.json        # Site metadata and branding
+│   ├── footer.json
+│   ├── navigation.json
+│   └── site.json
 ├── types.ts         # TypeScript type definitions
-├── index.ts         # Data exports and helper functions
+├── validate.ts      # Runtime shape checks at the data boundary
+├── index.ts         # Validated exports and helpers
 └── README.md        # This file
 ```
 
+## Public API
+
+Prefer these entry points when wiring routes, layout, sitemap, and metadata:
+
+```typescript
+import {
+  getPageData,
+  getCommonData,
+  careerProfile,
+  getHomeExperienceView,
+  getAboutCareerViews,
+} from "@/data";
+
+const home = getPageData("/");
+const about = getPageData("/about");
+const { footer, navigation, site } = getCommonData();
+```
+
+Named exports (`home`, `about`, `portfolio`, `blog`, `footer`, `navigation`, `site`, `careerProfile`) remain available and are the same validated objects returned by the helpers.
+
+`SitePage` / `FooterSection` load common data via `getCommonData()` — routes should not prop-drill footer contact fields.
+
+There is no `cv` export; career structured content lives in `careerProfile`.
+
 ## Career profile
 
-Structured career content (experience, education, certifications) lives in `profile/career-profile.json`. Page-specific views are composed via slice helpers:
+Structured career content lives in `profile/career-profile.json`. Page-specific views are composed via slice helpers:
 
 ```typescript
 import { careerProfile, getHomeExperienceView, getAboutCareerViews } from "@/data";
 
-// Home page experience teaser
 <ExperienceListing {...getHomeExperienceView(careerProfile)} />
 
-// About page career sections (experience, education, certifications)
 const careerViews = getAboutCareerViews(careerProfile);
-<ExperienceListing {...careerViews.experience} />
-<EducationListing {...careerViews.education} />
-<CertificationsListing {...careerViews.certifications} />
 ```
 
-Page JSON under `pages/` holds shell content only (headings, hero copy, CTAs). It does not duplicate career structured data.
+Page JSON under `pages/` holds shell content only. It does not duplicate career structured data.
 
-## Usage
+## Validation
 
-### Import data in your components:
-
-```typescript
-// Import specific data
-import { home, footer, navigation, site } from "@/data";
-
-// Use in a component
-<HeroSection {...home.hero} />
-<FooterSection {...footer.contact} />
-```
-
-### Using helper functions:
-
-```typescript
-import { getPageData, getCommonData } from "@/data";
-
-// Get page data by route
-const pageData = getPageData('/');
-
-// Get all common data at once
-const { footer, navigation, site } = getCommonData();
-```
+JSON files are validated when `@/data` is imported (and covered by `src/data/validate.test.ts`). Invalid shapes throw with the file path in the message so content edits fail fast in `npm test` / `npm run build`.
 
 ## Adding New Pages
 
-1. **Create a new page data file** in `src/data/pages/`:
-   ```json
-   // src/data/pages/blog.json
-   {
-     "title": "My Blog",
-     "posts": [...]
-   }
-   ```
-
-2. **Define types** in `src/data/types.ts`:
-   ```typescript
-   export interface BlogPageData {
-     title: string;
-     posts: Post[];
-   }
-   ```
-
-3. **Export in** `src/data/index.ts`:
-   ```typescript
-   import blogData from './pages/blog.json';
-   export const blog = blogData as BlogPageData;
-   ```
-
-4. **Update the helper** in `src/data/index.ts`:
-   ```typescript
-   export function getPageData(route: string) {
-     switch (route) {
-       case '/': return home;
-       case '/blog': return blog;
-       default: return null;
-     }
-   }
-   ```
+1. Create `src/data/pages/<page>.json`
+2. Add types in `src/data/types.ts`
+3. Add an assert in `validate.ts` and call `validateDataFile` from `index.ts`
+4. Export the named constant and extend `getPageData`
+5. Add the route to `src/app/sitemap.ts` / `src/lib/sitemap.ts`
+6. Wrap the page in `SitePage`
 
 ## Adding New Common Content
 
-For content shared across multiple pages (like headers, footers, etc.):
-
 1. Create a JSON file in `src/data/common/`
-2. Define its TypeScript type in `src/data/types.ts`
-3. Import and export it in `src/data/index.ts`
-
-## Future Enhancements
-
-### Multi-language Support
-
-When ready for internationalization, restructure as:
-
-```
-src/data/
-├── locales/
-│   ├── en/
-│   │   ├── pages/
-│   │   └── common/
-│   └── fr/
-│       ├── pages/
-│       └── common/
-└── ...
-```
-
-### Content Management System (CMS)
-
-The current structure is compatible with:
-- Contentful
-- Sanity
-- Strapi
-- Any headless CMS
-
-Simply replace JSON imports with API calls in `src/data/index.ts`.
-
-## Benefits of This Structure
-
-- **Separation of Concerns**: Page content vs. shared content
-- **Type Safety**: Full TypeScript support
-- **Scalability**: Easy to add new pages
-- **Maintainability**: Clear organization
-- **DRY**: Shared content defined once
-- **Future-proof**: Ready for i18n and CMS integration
-
+2. Define its type in `src/data/types.ts`
+3. Validate and export it in `index.ts`
+4. Include it in `getCommonData()` when it is shared chrome (footer / nav / site)

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -17,8 +17,27 @@ import type {
   NavigationData,
   SiteData,
 } from './types';
+import {
+  assertValidAboutPage,
+  assertValidBlogPage,
+  assertValidCareerProfile,
+  assertValidFooter,
+  assertValidHomePage,
+  assertValidNavigation,
+  assertValidPortfolioPage,
+  assertValidSite,
+  validateDataFile,
+} from './validate';
 
-// Page data exports
+validateDataFile('pages/home.json', homeData, assertValidHomePage);
+validateDataFile('pages/portfolio.json', portfolioData, assertValidPortfolioPage);
+validateDataFile('pages/about.json', aboutData, assertValidAboutPage);
+validateDataFile('pages/blog.json', blogData, assertValidBlogPage);
+validateDataFile('common/footer.json', footerData, assertValidFooter);
+validateDataFile('common/navigation.json', navigationData, assertValidNavigation);
+validateDataFile('common/site.json', siteData, assertValidSite);
+validateDataFile('profile/career-profile.json', careerProfileData, assertValidCareerProfile);
+
 export const home = homeData as HomePageData;
 export const portfolio = portfolioData as PortfolioPageData;
 export const about = aboutData as AboutPageData;
@@ -31,12 +50,16 @@ export { getAboutEducationView } from './profile/education-slices';
 export { getAboutCareerViews } from './profile/about-career-slices';
 export type { AboutCareerViews } from './profile/about-career-slices';
 
-// Common data exports
 export const footer = footerData as FooterData;
 export const navigation = navigationData as NavigationData;
 export const site = siteData as SiteData;
 
-// Helper function to get page data by route
+export function getPageData(route: '/'): HomePageData;
+export function getPageData(route: '/home'): HomePageData;
+export function getPageData(route: '/about'): AboutPageData;
+export function getPageData(route: '/blog'): BlogPageData;
+export function getPageData(route: '/portfolio'): PortfolioPageData;
+export function getPageData(route: string): HomePageData | AboutPageData | BlogPageData | PortfolioPageData | null;
 export function getPageData(route: string) {
   switch (route) {
     case '/':
@@ -53,7 +76,6 @@ export function getPageData(route: string) {
   }
 }
 
-// Helper function to get all common data at once
 export function getCommonData() {
   return {
     footer,
@@ -62,6 +84,4 @@ export function getCommonData() {
   };
 }
 
-// Export all types
 export type * from './types';
-

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  about,
+  blog,
+  getCommonData,
+  getPageData,
+  home,
+  portfolio,
+  footer,
+  navigation,
+  site,
+} from '@/data';
+
+describe('getPageData', () => {
+  it('returns the matching page data for every public route', () => {
+    expect(getPageData('/')).toBe(home);
+    expect(getPageData('/home')).toBe(home);
+    expect(getPageData('/about')).toBe(about);
+    expect(getPageData('/blog')).toBe(blog);
+    expect(getPageData('/portfolio')).toBe(portfolio);
+  });
+
+  it('returns null for unknown routes', () => {
+    expect(getPageData('/finance')).toBeNull();
+    expect(getPageData('/missing')).toBeNull();
+  });
+});
+
+describe('getCommonData', () => {
+  it('returns footer, navigation, and site together', () => {
+    expect(getCommonData()).toEqual({ footer, navigation, site });
+  });
+});

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidAboutPage,
+  assertValidBlogPage,
+  assertValidCareerProfile,
+  assertValidFooter,
+  assertValidHomePage,
+  assertValidNavigation,
+  assertValidPortfolioPage,
+  assertValidSite,
+  validateDataFile,
+} from '@/data/validate';
+import homeData from '@/data/pages/home.json';
+import aboutData from '@/data/pages/about.json';
+import blogData from '@/data/pages/blog.json';
+import portfolioData from '@/data/pages/portfolio.json';
+import footerData from '@/data/common/footer.json';
+import navigationData from '@/data/common/navigation.json';
+import siteData from '@/data/common/site.json';
+import careerProfileData from '@/data/profile/career-profile.json';
+
+describe('validateDataFile', () => {
+  it('accepts golden home page JSON', () => {
+    expect(() =>
+      validateDataFile('pages/home.json', homeData, assertValidHomePage),
+    ).not.toThrow();
+  });
+
+  it('rejects malformed home page JSON with the file identifier', () => {
+    expect(() =>
+      validateDataFile('pages/home.json', { about: {} }, assertValidHomePage),
+    ).toThrow(/pages\/home\.json/);
+  });
+
+  it('accepts all golden content JSON files', () => {
+    expect(() =>
+      validateDataFile('pages/about.json', aboutData, assertValidAboutPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('pages/blog.json', blogData, assertValidBlogPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('pages/portfolio.json', portfolioData, assertValidPortfolioPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('common/footer.json', footerData, assertValidFooter),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('common/navigation.json', navigationData, assertValidNavigation),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('common/site.json', siteData, assertValidSite),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile(
+        'profile/career-profile.json',
+        careerProfileData,
+        assertValidCareerProfile,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -1,0 +1,193 @@
+type AssertFn = (data: unknown) => void;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function requireString(record: Record<string, unknown>, key: string, context: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    fail(`${context}: expected non-empty string "${key}"`);
+  }
+  return value;
+}
+
+function requireRecord(value: unknown, context: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    fail(`${context}: expected an object`);
+  }
+  return value;
+}
+
+function requireArray(value: unknown, context: string): unknown[] {
+  if (!Array.isArray(value)) {
+    fail(`${context}: expected an array`);
+  }
+  return value;
+}
+
+function assertCta(value: unknown, context: string): void {
+  const cta = requireRecord(value, context);
+  requireString(cta, 'label', context);
+  requireString(cta, 'href', context);
+}
+
+function assertAboutSection(value: unknown, context: string): void {
+  const section = requireRecord(value, context);
+  requireString(section, 'heading', context);
+  const content = section.content;
+  const contentOk =
+    typeof content === 'string' ||
+    (Array.isArray(content) && content.every((item) => typeof item === 'string'));
+  if (!contentOk) {
+    fail(`${context}: content must be a string or string array`);
+  }
+  if (section.cta !== undefined) {
+    assertCta(section.cta, `${context}.cta`);
+  }
+}
+
+function assertPhotoItem(value: unknown, context: string): void {
+  const item = requireRecord(value, context);
+  requireString(item, 'src', context);
+  requireString(item, 'alt', context);
+  requireString(item, 'title', context);
+}
+
+export function validateDataFile(
+  file: string,
+  data: unknown,
+  assertShape: AssertFn,
+): void {
+  try {
+    assertShape(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid data in ${file}: ${message}`);
+  }
+}
+
+export function assertValidHomePage(data: unknown): void {
+  const page = requireRecord(data, 'home');
+  const hero = requireRecord(page.hero, 'home.hero');
+  requireString(hero, 'name', 'home.hero');
+  requireString(hero, 'title', 'home.hero');
+  assertAboutSection(page.about, 'home.about');
+  const photography = requireRecord(page.photography, 'home.photography');
+  requireString(photography, 'heading', 'home.photography');
+  requireArray(photography.images, 'home.photography.images').forEach((image, index) =>
+    assertPhotoItem(image, `home.photography.images[${index}]`),
+  );
+  const blog = requireRecord(page.blog, 'home.blog');
+  requireString(blog, 'heading', 'home.blog');
+}
+
+export function assertValidAboutPage(data: unknown): void {
+  const page = requireRecord(data, 'about');
+  const hero = requireRecord(page.hero, 'about.hero');
+  requireString(hero, 'name', 'about.hero');
+  requireString(hero, 'title', 'about.hero');
+  assertAboutSection(page.professional, 'about.professional');
+}
+
+export function assertValidBlogPage(data: unknown): void {
+  const page = requireRecord(data, 'blog');
+  requireString(page, 'heading', 'blog');
+  requireString(page, 'description', 'blog');
+  requireString(page, 'emptyState', 'blog');
+  requireString(page, 'filterLabel', 'blog');
+  requireString(page, 'sortLabel', 'blog');
+  requireString(page, 'allCategories', 'blog');
+  const sortOptions = requireRecord(page.sortOptions, 'blog.sortOptions');
+  requireString(sortOptions, 'latest', 'blog.sortOptions');
+  requireString(sortOptions, 'oldest', 'blog.sortOptions');
+  requireString(sortOptions, 'title', 'blog.sortOptions');
+}
+
+export function assertValidPortfolioPage(data: unknown): void {
+  const page = requireRecord(data, 'portfolio');
+  requireString(page, 'heading', 'portfolio');
+  requireString(page, 'description', 'portfolio');
+  requireArray(page.images, 'portfolio.images').forEach((image, index) =>
+    assertPhotoItem(image, `portfolio.images[${index}]`),
+  );
+}
+
+export function assertValidFooter(data: unknown): void {
+  const footer = requireRecord(data, 'footer');
+  const contact = requireRecord(footer.contact, 'footer.contact');
+  requireString(contact, 'heading', 'footer.contact');
+  requireString(contact, 'description', 'footer.contact');
+  requireString(contact, 'navigationTitle', 'footer.contact');
+  requireString(contact, 'socialTitle', 'footer.contact');
+  requireString(contact, 'email', 'footer.contact');
+  requireString(contact, 'copyright', 'footer.contact');
+  const social = requireRecord(contact.social, 'footer.contact.social');
+  requireString(social, 'github', 'footer.contact.social');
+  requireString(social, 'linkedin', 'footer.contact.social');
+}
+
+export function assertValidNavigation(data: unknown): void {
+  const navigation = requireRecord(data, 'navigation');
+  requireArray(navigation.links, 'navigation.links').forEach((link, index) => {
+    const item = requireRecord(link, `navigation.links[${index}]`);
+    requireString(item, 'label', `navigation.links[${index}]`);
+    requireString(item, 'href', `navigation.links[${index}]`);
+  });
+}
+
+export function assertValidSite(data: unknown): void {
+  const site = requireRecord(data, 'site');
+  requireString(site, 'brandName', 'site');
+  requireString(site, 'locale', 'site');
+  const metadata = requireRecord(site.metadata, 'site.metadata');
+  requireString(metadata, 'title', 'site.metadata');
+  requireString(metadata, 'description', 'site.metadata');
+  requireString(metadata, 'author', 'site.metadata');
+  requireString(metadata, 'siteUrl', 'site.metadata');
+  requireString(metadata, 'socialHandle', 'site.metadata');
+  const person = requireRecord(site.person, 'site.person');
+  requireString(person, 'jobTitle', 'site.person');
+  requireString(person, 'worksFor', 'site.person');
+  requireString(person, 'alumniOf', 'site.person');
+  requireString(person, 'profileDateCreated', 'site.person');
+  requireArray(person.knowsAbout, 'site.person.knowsAbout').forEach((topic, index) => {
+    if (typeof topic !== 'string') {
+      fail(`site.person.knowsAbout[${index}]: expected string`);
+    }
+  });
+}
+
+export function assertValidCareerProfile(data: unknown): void {
+  const profile = requireRecord(data, 'careerProfile');
+  const experience = requireRecord(profile.experience, 'careerProfile.experience');
+  requireArray(experience.companies, 'careerProfile.experience.companies').forEach(
+    (company, index) => {
+      const item = requireRecord(company, `careerProfile.experience.companies[${index}]`);
+      requireString(item, 'name', `careerProfile.experience.companies[${index}]`);
+      requireString(item, 'location', `careerProfile.experience.companies[${index}]`);
+      requireArray(item.roles, `careerProfile.experience.companies[${index}].roles`);
+    },
+  );
+  const education = requireRecord(profile.education, 'careerProfile.education');
+  requireArray(education.entries, 'careerProfile.education.entries').forEach((entry, index) => {
+    const item = requireRecord(entry, `careerProfile.education.entries[${index}]`);
+    requireString(item, 'institution', `careerProfile.education.entries[${index}]`);
+    requireString(item, 'qualification', `careerProfile.education.entries[${index}]`);
+    requireString(item, 'period', `careerProfile.education.entries[${index}]`);
+    requireString(item, 'description', `careerProfile.education.entries[${index}]`);
+  });
+  const certifications = requireRecord(profile.certifications, 'careerProfile.certifications');
+  requireArray(certifications.items, 'careerProfile.certifications.items').forEach(
+    (item, index) => {
+      const cert = requireRecord(item, `careerProfile.certifications.items[${index}]`);
+      requireString(cert, 'name', `careerProfile.certifications.items[${index}]`);
+      requireString(cert, 'issuer', `careerProfile.certifications.items[${index}]`);
+      requireString(cert, 'issued', `careerProfile.certifications.items[${index}]`);
+    },
+  );
+}

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from 'next';
-import { site } from '@/data';
+import { getCommonData } from '@/data';
 import { getAllBlogPosts } from '@/lib/blog';
 
 export function buildSitemap(blogDirectory?: string): MetadataRoute.Sitemap {
+  const { site } = getCommonData();
   const baseUrl = site.metadata.siteUrl;
   const blogPosts = getAllBlogPosts(blogDirectory);
   const lastModified = new Date();


### PR DESCRIPTION
## Summary
- **#17** Introduce `SitePage` shell (skip link, header, main landmark, self-loaded footer); migrate all public routes; portfolio metadata from `portfolio.json`; ADR + conventions update.
- **#19** Deepen `getPageData` / `getCommonData` as the real data API; runtime JSON validation at import; README aligned with reality.
- **#20** Add `MotionReveal` primitive and migrate reveal call sites; `SectionHeader` owns motion via the primitive; home hero keeps bespoke springs.
- **#18** Consolidate angular prose into `ProseSection`; Home/About thin wrappers and dynamic imports use the shared module.

## Test plan
- [x] `npm test` (64 tests passed)
- [x] `npm run typecheck`
- [x] Spot-check Home, About, Blog, Portfolio layouts and footer
- [x] Confirm reduced-motion shows content immediately

Made with [Cursor](https://cursor.com)