### PR TITLE
Fix Amplify Gen 2 backend ESM imports for Hosting deploy

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,8 +1,8 @@
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource';
-import { data } from './data/resource';
-import { storage } from './storage/resource';
-import { labPlaceholder } from './functions/lab-placeholder/resource';
+import { auth } from './auth/resource.js';
+import { data } from './data/resource.js';
+import { storage } from './storage/resource.js';
+import { labPlaceholder } from './functions/lab-placeholder/resource.js';
 
 defineBackend({
   auth,


### PR DESCRIPTION
## Summary
- Amplify Hosting `ampx pipeline-deploy` failed with `Cannot find module '.../amplify/auth/resource'` because Gen 2 synthesises backend TypeScript as ESM and requires `.js` extensions on relative imports.
- Align `amplify/backend.ts` with the official Amplify Next template import style.

## Test plan
- [ ] Re-run Amplify Hosting build on `main` after merge
- [ ] Confirm backend phase synthesises and deploys past `pipeline-deploy`
- [ ] Confirm frontend blog sync + `npm run build` still run
