### PR TITLE
Add public Labs shell with empty job-market state

### DIFF
--- a/src/app/labs/job-market/page.test.ts
+++ b/src/app/labs/job-market/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { metadata } from '@/app/labs/job-market/page';
+import { jobMarketLab, site } from '@/data';
+
+describe('Job market lab page metadata', () => {
+  it('derives title and description from job market lab page data', () => {
+    expect(metadata).toMatchObject({
+      title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+      description: jobMarketLab.description,
+      openGraph: {
+        title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+        description: jobMarketLab.description,
+        url: `${site.metadata.siteUrl}/labs/job-market`,
+        type: 'website',
+      },
+    });
+  });
+});

--- a/src/app/labs/job-market/page.tsx
+++ b/src/app/labs/job-market/page.tsx
@@ -1,0 +1,28 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { JobMarketLabSection } from '@/components/sections/labs/job-market-lab-section';
+import { getPageData, site } from '@/data';
+import { getPublishedJobMarketSnapshot } from '@/lib/job-market-lab';
+
+const jobMarketLab = getPageData('/labs/job-market');
+
+export const metadata: Metadata = {
+  title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+  description: jobMarketLab.description,
+  openGraph: {
+    title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+    description: jobMarketLab.description,
+    url: `${site.metadata.siteUrl}/labs/job-market`,
+    type: 'website',
+  },
+};
+
+export default async function JobMarketLabPage() {
+  const publication = await getPublishedJobMarketSnapshot();
+
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <JobMarketLabSection publication={publication} />
+    </SitePage>
+  );
+}

--- a/src/app/labs/page.test.ts
+++ b/src/app/labs/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { metadata } from '@/app/labs/page';
+import { labs, site } from '@/data';
+
+describe('Labs page metadata', () => {
+  it('derives title and description from labs page data', () => {
+    expect(metadata).toMatchObject({
+      title: `${labs.heading} - ${site.metadata.author}`,
+      description: labs.description,
+      openGraph: {
+        title: `${labs.heading} - ${site.metadata.author}`,
+        description: labs.description,
+        url: `${site.metadata.siteUrl}/labs`,
+        type: 'website',
+      },
+    });
+  });
+});

--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { LabsIndexSection } from '@/components/sections/labs/labs-index-section';
+import { getPageData, site } from '@/data';
+
+const labs = getPageData('/labs');
+
+export const metadata: Metadata = {
+  title: `${labs.heading} - ${site.metadata.author}`,
+  description: labs.description,
+  openGraph: {
+    title: `${labs.heading} - ${site.metadata.author}`,
+    description: labs.description,
+    url: `${site.metadata.siteUrl}/labs`,
+    type: 'website',
+  },
+};
+
+export default function LabsPage() {
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <LabsIndexSection />
+    </SitePage>
+  );
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -36,6 +36,27 @@ describe('sitemap', () => {
     });
   });
 
+  it('includes Labs index and job-market lab routes', () => {
+    const entries = sitemap();
+    const labsEntry = entries.find((entry) => entry.url === `${site.metadata.siteUrl}/labs`);
+    const jobMarketEntry = entries.find(
+      (entry) => entry.url === `${site.metadata.siteUrl}/labs/job-market`,
+    );
+
+    expect(labsEntry).toEqual({
+      url: `${site.metadata.siteUrl}/labs`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    });
+    expect(jobMarketEntry).toEqual({
+      url: `${site.metadata.siteUrl}/labs/job-market`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    });
+  });
+
   it('includes blog post URLs with lastModified dates from the reader module', () => {
     const posts = getAllBlogPosts(fixturesDir);
     const entries = buildSitemap(fixturesDir);

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -1,0 +1,29 @@
+import { Container, Section, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import type { PublishedJobMarketResult } from '@/lib/job-market-lab';
+
+interface JobMarketLabSectionProps {
+  publication: PublishedJobMarketResult;
+}
+
+export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mb-12 max-w-2xl space-y-4">
+          <SectionHeader animated={false}>{jobMarketLab.heading}</SectionHeader>
+          <Text variant="muted">{jobMarketLab.description}</Text>
+          <Text size="sm" variant="muted">
+            {jobMarketLab.corpusNote}
+          </Text>
+        </div>
+
+        {publication.status === 'empty' ? (
+          <div className="max-w-2xl space-y-2" role="status">
+            <Text>{jobMarketLab.emptyState}</Text>
+          </div>
+        ) : null}
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/labs/labs-index-section.tsx
+++ b/src/components/sections/labs/labs-index-section.tsx
@@ -1,0 +1,40 @@
+import {
+  Button,
+  Container,
+  MotionReveal,
+  Section,
+  SectionHeader,
+  Text,
+} from '@/components/ui';
+import { labs } from '@/data';
+
+export function LabsIndexSection() {
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mb-16 max-w-2xl space-y-4">
+          <SectionHeader animated={false}>{labs.heading}</SectionHeader>
+          <Text variant="muted">{labs.description}</Text>
+        </div>
+
+        <ul className="space-y-10">
+          {labs.labs.map((lab, index) => (
+            <MotionReveal key={lab.href} variant="fade-up" distance="sm" delay={index * 0.05}>
+              <li className="max-w-2xl space-y-4">
+                <SectionHeader size="md" animated={false} showLeftAccent={false}>
+                  {lab.title}
+                </SectionHeader>
+                <Text size="sm" variant="muted">
+                  {lab.description}
+                </Text>
+                <Button href={lab.href} variant="outline" size="sm">
+                  Open lab
+                </Button>
+              </li>
+            </MotionReveal>
+          ))}
+        </ul>
+      </Container>
+    </Section>
+  );
+}

--- a/src/data/common/navigation.json
+++ b/src/data/common/navigation.json
@@ -13,6 +13,10 @@
       "href": "/portfolio"
     },
     {
+      "label": "Labs",
+      "href": "/labs"
+    },
+    {
       "label": "Blog",
       "href": "/blog"
     }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2,6 +2,8 @@ import homeData from './pages/home.json';
 import portfolioData from './pages/portfolio.json';
 import aboutData from './pages/about.json';
 import blogData from './pages/blog.json';
+import labsData from './pages/labs.json';
+import jobMarketLabData from './pages/job-market-lab.json';
 import footerData from './common/footer.json';
 import navigationData from './common/navigation.json';
 import siteData from './common/site.json';
@@ -12,6 +14,8 @@ import type {
   PortfolioPageData,
   AboutPageData,
   BlogPageData,
+  LabsPageData,
+  JobMarketLabPageData,
   CareerProfile,
   FooterData,
   NavigationData,
@@ -23,6 +27,8 @@ import {
   assertValidCareerProfile,
   assertValidFooter,
   assertValidHomePage,
+  assertValidJobMarketLabPage,
+  assertValidLabsPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -33,6 +39,8 @@ validateDataFile('pages/home.json', homeData, assertValidHomePage);
 validateDataFile('pages/portfolio.json', portfolioData, assertValidPortfolioPage);
 validateDataFile('pages/about.json', aboutData, assertValidAboutPage);
 validateDataFile('pages/blog.json', blogData, assertValidBlogPage);
+validateDataFile('pages/labs.json', labsData, assertValidLabsPage);
+validateDataFile('pages/job-market-lab.json', jobMarketLabData, assertValidJobMarketLabPage);
 validateDataFile('common/footer.json', footerData, assertValidFooter);
 validateDataFile('common/navigation.json', navigationData, assertValidNavigation);
 validateDataFile('common/site.json', siteData, assertValidSite);
@@ -42,6 +50,8 @@ export const home = homeData as HomePageData;
 export const portfolio = portfolioData as PortfolioPageData;
 export const about = aboutData as AboutPageData;
 export const blog = blogData as BlogPageData;
+export const labs = labsData as LabsPageData;
+export const jobMarketLab = jobMarketLabData as JobMarketLabPageData;
 export const careerProfile = careerProfileData as CareerProfile;
 
 export { getHomeExperienceView, getAboutExperienceView } from './profile/experience-slices';
@@ -59,7 +69,18 @@ export function getPageData(route: '/home'): HomePageData;
 export function getPageData(route: '/about'): AboutPageData;
 export function getPageData(route: '/blog'): BlogPageData;
 export function getPageData(route: '/portfolio'): PortfolioPageData;
-export function getPageData(route: string): HomePageData | AboutPageData | BlogPageData | PortfolioPageData | null;
+export function getPageData(route: '/labs'): LabsPageData;
+export function getPageData(route: '/labs/job-market'): JobMarketLabPageData;
+export function getPageData(
+  route: string,
+):
+  | HomePageData
+  | AboutPageData
+  | BlogPageData
+  | PortfolioPageData
+  | LabsPageData
+  | JobMarketLabPageData
+  | null;
 export function getPageData(route: string) {
   switch (route) {
     case '/':
@@ -71,6 +92,10 @@ export function getPageData(route: string) {
       return portfolio;
     case '/about':
       return about;
+    case '/labs':
+      return labs;
+    case '/labs/job-market':
+      return jobMarketLab;
     default:
       return null;
   }

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -5,6 +5,8 @@ import {
   getCommonData,
   getPageData,
   home,
+  labs,
+  jobMarketLab,
   portfolio,
   footer,
   navigation,
@@ -18,6 +20,8 @@ describe('getPageData', () => {
     expect(getPageData('/about')).toBe(about);
     expect(getPageData('/blog')).toBe(blog);
     expect(getPageData('/portfolio')).toBe(portfolio);
+    expect(getPageData('/labs')).toBe(labs);
+    expect(getPageData('/labs/job-market')).toBe(jobMarketLab);
   });
 
   it('returns null for unknown routes', () => {
@@ -29,5 +33,9 @@ describe('getPageData', () => {
 describe('getCommonData', () => {
   it('returns footer, navigation, and site together', () => {
     expect(getCommonData()).toEqual({ footer, navigation, site });
+  });
+
+  it('includes a Labs navigation link to the Labs index', () => {
+    expect(navigation.links).toContainEqual({ label: 'Labs', href: '/labs' });
   });
 });

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -1,0 +1,6 @@
+{
+  "heading": "Job market signal lab",
+  "description": "High-level aggregates from a private financial-services job-description corpus. This is a portfolio demonstration, not live job-board coverage or career advice.",
+  "emptyState": "No published snapshot is available yet. Check back after the next corpus recompute.",
+  "corpusNote": "Figures shown here are aggregates only. Raw job descriptions and employer identity are never published."
+}

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Labs",
+  "description": "Interactive technical demos that show how I approach AI, data science, machine learning, and AWS full-stack work.",
+  "labs": [
+    {
+      "title": "Job market signal lab",
+      "description": "Aggregate labour-market signals from a private job-description corpus.",
+      "href": "/labs/job-market"
+    }
+  ]
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -128,6 +128,25 @@ export interface BlogPageData {
   allCategories: string;
 }
 
+export interface LabIndexItem {
+  title: string;
+  description: string;
+  href: string;
+}
+
+export interface LabsPageData {
+  heading: string;
+  description: string;
+  labs: LabIndexItem[];
+}
+
+export interface JobMarketLabPageData {
+  heading: string;
+  description: string;
+  emptyState: string;
+  corpusNote: string;
+}
+
 // Common/shared types
 export interface SocialLinks {
   github: string;

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -5,6 +5,8 @@ import {
   assertValidCareerProfile,
   assertValidFooter,
   assertValidHomePage,
+  assertValidJobMarketLabPage,
+  assertValidLabsPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -14,6 +16,8 @@ import homeData from '@/data/pages/home.json';
 import aboutData from '@/data/pages/about.json';
 import blogData from '@/data/pages/blog.json';
 import portfolioData from '@/data/pages/portfolio.json';
+import labsData from '@/data/pages/labs.json';
+import jobMarketLabData from '@/data/pages/job-market-lab.json';
 import footerData from '@/data/common/footer.json';
 import navigationData from '@/data/common/navigation.json';
 import siteData from '@/data/common/site.json';
@@ -41,6 +45,16 @@ describe('validateDataFile', () => {
     ).not.toThrow();
     expect(() =>
       validateDataFile('pages/portfolio.json', portfolioData, assertValidPortfolioPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('pages/labs.json', labsData, assertValidLabsPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile(
+        'pages/job-market-lab.json',
+        jobMarketLabData,
+        assertValidJobMarketLabPage,
+      ),
     ).not.toThrow();
     expect(() =>
       validateDataFile('common/footer.json', footerData, assertValidFooter),

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -117,6 +117,26 @@ export function assertValidPortfolioPage(data: unknown): void {
   );
 }
 
+export function assertValidLabsPage(data: unknown): void {
+  const page = requireRecord(data, 'labs');
+  requireString(page, 'heading', 'labs');
+  requireString(page, 'description', 'labs');
+  requireArray(page.labs, 'labs.labs').forEach((lab, index) => {
+    const item = requireRecord(lab, `labs.labs[${index}]`);
+    requireString(item, 'title', `labs.labs[${index}]`);
+    requireString(item, 'description', `labs.labs[${index}]`);
+    requireString(item, 'href', `labs.labs[${index}]`);
+  });
+}
+
+export function assertValidJobMarketLabPage(data: unknown): void {
+  const page = requireRecord(data, 'jobMarketLab');
+  requireString(page, 'heading', 'jobMarketLab');
+  requireString(page, 'description', 'jobMarketLab');
+  requireString(page, 'emptyState', 'jobMarketLab');
+  requireString(page, 'corpusNote', 'jobMarketLab');
+}
+
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getPublishedJobMarketSnapshot } from './job-market-lab';
+
+describe('getPublishedJobMarketSnapshot', () => {
+  it('returns empty when nothing is published', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () => null,
+    });
+
+    expect(result).toEqual({ status: 'empty' });
+  });
+
+  it('returns published when a snapshot is available', async () => {
+    const snapshot = {
+      documentCount: 3,
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () => snapshot,
+    });
+
+    expect(result).toEqual({ status: 'published', snapshot });
+  });
+
+  it('does not expose raw job description or employer identity fields', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () =>
+        ({
+          documentCount: 1,
+          publishedAt: '2026-07-01T00:00:00.000Z',
+          rawText: 'Acme Corp seeks a data scientist…',
+          source: 'confidential-board',
+          employer: 'Acme Corp',
+        }) as never,
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      snapshot: {
+        documentCount: 1,
+        publishedAt: '2026-07-01T00:00:00.000Z',
+      },
+    });
+  });
+});

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -1,0 +1,38 @@
+export type JobMarketSnapshot = {
+  documentCount: number;
+  publishedAt: string;
+};
+
+export type PublishedJobMarketResult =
+  | { status: 'empty' }
+  | { status: 'published'; snapshot: JobMarketSnapshot };
+
+export type FetchPublishedJobMarketSnapshot = () => Promise<JobMarketSnapshot | null>;
+
+export type GetPublishedJobMarketSnapshotDeps = {
+  fetchPublished?: FetchPublishedJobMarketSnapshot;
+};
+
+async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
+  // Guest publication query lands in a later slice; until then nothing is published.
+  return null;
+}
+
+export async function getPublishedJobMarketSnapshot(
+  deps: GetPublishedJobMarketSnapshotDeps = {},
+): Promise<PublishedJobMarketResult> {
+  const fetchPublished = deps.fetchPublished ?? defaultFetchPublished;
+  const snapshot = await fetchPublished();
+
+  if (snapshot == null) {
+    return { status: 'empty' };
+  }
+
+  return {
+    status: 'published',
+    snapshot: {
+      documentCount: snapshot.documentCount,
+      publishedAt: snapshot.publishedAt,
+    },
+  };
+}

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -35,6 +35,18 @@ export function buildSitemap(blogDirectory?: string): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/labs`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/labs/job-market`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
     ...blogPosts.map((post) => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: new Date(post.frontmatter.date),


### PR DESCRIPTION
## Summary
- Ships `/labs` and `/labs/job-market` as public pages with Labs in nav and sitemap, driven through the site data layer.
- Adds a `getPublishedJobMarketSnapshot` application-API facade that returns an intentional empty publication result (and never exposes raw JD fields) until the guest GraphQL path lands in #39.
- Covers empty/published-absent facade behaviour plus Labs page-data, metadata, and sitemap contract tests.

Closes #36

## Test plan
- [ ] `npx vitest run` — Labs facade, page-data, sitemap, and metadata tests pass
- [ ] Open `/labs` from the site nav and confirm the job-market lab link
- [ ] Open `/labs/job-market` unauthenticated and confirm the empty state (no errors, no raw JD text)
- [ ] Confirm Portfolio / photography routes are unchanged
- [ ] Confirm `/sitemap.xml` includes `/labs` and `/labs/job-market`


Made with [Cursor](https://cursor.com)