### PR TITLE
Job market lab: markdown ingest creates JobDescription metadata (#37)

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,12 +1,20 @@
 import { defineBackend } from '@aws-amplify/backend';
+import { EventType } from 'aws-cdk-lib/aws-s3';
+import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
 import { auth } from './auth/resource.js';
 import { data } from './data/resource.js';
 import { storage } from './storage/resource.js';
-import { labPlaceholder } from './functions/lab-placeholder/resource.js';
+import { jobMarketIngest } from './functions/job-market-ingest/resource.js';
 
-defineBackend({
+const backend = defineBackend({
   auth,
   data,
   storage,
-  labPlaceholder,
+  jobMarketIngest,
 });
+
+backend.storage.resources.bucket.addEventNotification(
+  EventType.OBJECT_CREATED,
+  new LambdaDestination(backend.jobMarketIngest.resources.lambda),
+  { prefix: 'raw/' },
+);

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,16 +1,24 @@
 import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
+import { jobMarketIngest } from '../functions/job-market-ingest/resource';
 
-/**
- * Data schema placeholder for the job market lab.
- * Models (JobDescription, AnalysisRun, CorpusSnapshot, LabPublication) land in later slices.
- */
-const schema = a.schema({
-  LabScaffold: a
-    .model({
-      label: a.string(),
-    })
-    .authorization((allow) => [allow.authenticated()]),
-});
+const schema = a
+  .schema({
+    JobDescription: a
+      .model({
+        s3Key: a.string().required(),
+        contentHash: a.string().required(),
+        collectedAt: a.datetime().required(),
+        status: a.enum(['active', 'archived']).required(),
+        title: a.string(),
+        seniority: a.string(),
+        roleFamily: a.string(),
+        source: a.string(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create', 'update', 'delete']),
+      ]),
+  })
+  .authorization((allow) => [allow.resource(jobMarketIngest)]);
 
 export type Schema = ClientSchema<typeof schema>;
 

--- a/amplify/functions/job-market-ingest/fixtures/invalid-yaml.md
+++ b/amplify/functions/job-market-ingest/fixtures/invalid-yaml.md
@@ -1,0 +1,6 @@
+---
+collectedAt: [this is: not: valid
+title: Broken
+---
+
+Body with invalid YAML frontmatter.

--- a/amplify/functions/job-market-ingest/fixtures/missing-collected-at.md
+++ b/amplify/functions/job-market-ingest/fixtures/missing-collected-at.md
@@ -1,0 +1,6 @@
+---
+title: Missing collectedAt
+seniority: junior
+---
+
+Body without a required collectedAt field.

--- a/amplify/functions/job-market-ingest/fixtures/missing-frontmatter.md
+++ b/amplify/functions/job-market-ingest/fixtures/missing-frontmatter.md
@@ -1,0 +1,3 @@
+# No frontmatter
+
+Just a markdown body with no YAML block.

--- a/amplify/functions/job-market-ingest/fixtures/valid-jd.md
+++ b/amplify/functions/job-market-ingest/fixtures/valid-jd.md
@@ -1,0 +1,9 @@
+---
+collectedAt: 2026-06-15T10:00:00.000Z
+title: Senior Data Scientist
+seniority: senior
+roleFamily: data-science
+source: confidential-board
+---
+
+We are looking for a senior data scientist to lead modelling work across credit risk portfolios.

--- a/amplify/functions/job-market-ingest/handler.ts
+++ b/amplify/functions/job-market-ingest/handler.ts
@@ -1,0 +1,87 @@
+import type { S3Handler } from 'aws-lambda';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { env } from '$amplify/env/job-market-ingest';
+import type { Schema } from '../../data/resource';
+import {
+  ingestJobDescription,
+  type JobDescriptionRecord,
+} from './ingest';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const s3 = new S3Client();
+
+async function upsertJobDescription(
+  record: JobDescriptionRecord,
+): Promise<void> {
+  const payload = {
+    id: record.id,
+    s3Key: record.s3Key,
+    contentHash: record.contentHash,
+    collectedAt: record.collectedAt,
+    status: record.status,
+    ...(record.title !== undefined ? { title: record.title } : {}),
+    ...(record.seniority !== undefined ? { seniority: record.seniority } : {}),
+    ...(record.roleFamily !== undefined ? { roleFamily: record.roleFamily } : {}),
+    ...(record.source !== undefined ? { source: record.source } : {}),
+  };
+
+  const existing = await client.models.JobDescription.get({ id: record.id });
+  if (existing.data) {
+    const { errors } = await client.models.JobDescription.update(payload);
+    if (errors?.length) {
+      throw new Error(errors.map((error) => error.message).join('; '));
+    }
+    return;
+  }
+
+  const { errors } = await client.models.JobDescription.create(payload);
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+function decodeS3Key(key: string): string {
+  return decodeURIComponent(key.replace(/\+/g, ' '));
+}
+
+export const handler: S3Handler = async (event) => {
+  for (const record of event.Records) {
+    const s3Key = decodeS3Key(record.s3.object.key);
+    if (!s3Key.startsWith('raw/')) {
+      continue;
+    }
+
+    const bucket = record.s3.bucket.name;
+    const object = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: s3Key }),
+    );
+    const body = await object.Body?.transformToString('utf-8');
+    if (!body) {
+      const message = `[job-market-ingest] Empty object body for ${s3Key}`;
+      console.error(message);
+      throw new Error(message);
+    }
+
+    const result = await ingestJobDescription(
+      { s3Key, body },
+      { upsertJobDescription },
+    );
+
+    if (result.status === 'rejected') {
+      const message = `[job-market-ingest] Rejected ${s3Key}: ${result.reason}`;
+      console.error(message);
+      throw new Error(message);
+    }
+
+    console.log(
+      `[job-market-ingest] Ingested ${s3Key} hash=${result.record.contentHash}`,
+    );
+  }
+};

--- a/amplify/functions/job-market-ingest/ingest.test.ts
+++ b/amplify/functions/job-market-ingest/ingest.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { ingestJobDescription } from './ingest';
+
+const fixturesDir = path.join(import.meta.dirname, 'fixtures');
+
+function readFixture(name: string): string {
+  return readFileSync(path.join(fixturesDir, name), 'utf8');
+}
+
+describe('ingestJobDescription', () => {
+  it('upserts an active JobDescription from valid frontmatter markdown', async () => {
+    const body = readFixture('valid-jd.md');
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/valid-jd.md', body },
+      { upsertJobDescription },
+    );
+
+    expect(result).toMatchObject({
+      status: 'ingested',
+      record: {
+        id: 'raw/valid-jd.md',
+        s3Key: 'raw/valid-jd.md',
+        collectedAt: '2026-06-15T10:00:00.000Z',
+        status: 'active',
+        title: 'Senior Data Scientist',
+        seniority: 'senior',
+        roleFamily: 'data-science',
+        source: 'confidential-board',
+      },
+    });
+    expect(result.status).toBe('ingested');
+    if (result.status === 'ingested') {
+      expect(result.record.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+    expect(upsertJobDescription).toHaveBeenCalledOnce();
+    expect(upsertJobDescription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'raw/valid-jd.md',
+        s3Key: 'raw/valid-jd.md',
+        status: 'active',
+        collectedAt: '2026-06-15T10:00:00.000Z',
+      }),
+    );
+  });
+
+  it('rejects missing frontmatter without upserting', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/missing-frontmatter.md', body: readFixture('missing-frontmatter.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Missing YAML frontmatter',
+    });
+    expect(upsertJobDescription).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing collectedAt without upserting', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/missing-collected-at.md', body: readFixture('missing-collected-at.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Frontmatter requires a valid collectedAt',
+    });
+    expect(upsertJobDescription).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid YAML frontmatter without upserting', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/invalid-yaml.md', body: readFixture('invalid-yaml.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result.status).toBe('rejected');
+    if (result.status === 'rejected') {
+      expect(result.reason.length).toBeGreaterThan(0);
+    }
+    expect(upsertJobDescription).not.toHaveBeenCalled();
+  });
+
+  it('changes contentHash when file contents change', async () => {
+    const s3Key = 'raw/valid-jd.md';
+    const original = readFixture('valid-jd.md');
+    const updated = `${original}\n\nUpdated requirement: PyTorch experience.\n`;
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const first = await ingestJobDescription(
+      { s3Key, body: original },
+      { upsertJobDescription },
+    );
+    const second = await ingestJobDescription(
+      { s3Key, body: updated },
+      { upsertJobDescription },
+    );
+
+    expect(first.status).toBe('ingested');
+    expect(second.status).toBe('ingested');
+    if (first.status === 'ingested' && second.status === 'ingested') {
+      expect(second.record.contentHash).not.toBe(first.record.contentHash);
+      expect(second.record.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it('does not start corpus recompute on ingest', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+    const startRecompute = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/valid-jd.md', body: readFixture('valid-jd.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result.status).toBe('ingested');
+    expect(upsertJobDescription).toHaveBeenCalledOnce();
+    expect(startRecompute).not.toHaveBeenCalled();
+  });
+});

--- a/amplify/functions/job-market-ingest/ingest.ts
+++ b/amplify/functions/job-market-ingest/ingest.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto';
+import matter from 'gray-matter';
+
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionRecord = {
+  id: string;
+  s3Key: string;
+  contentHash: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+};
+
+export type IngestResult =
+  | { status: 'ingested'; record: JobDescriptionRecord }
+  | { status: 'rejected'; reason: string };
+
+export type UpsertJobDescription = (
+  record: JobDescriptionRecord,
+) => Promise<void>;
+
+export type IngestJobDescriptionDeps = {
+  upsertJobDescription: UpsertJobDescription;
+};
+
+function optionalString(
+  value: unknown,
+): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function formatCollectedAt(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return undefined;
+    }
+    return parsed.toISOString();
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+
+  return undefined;
+}
+
+export async function ingestJobDescription(
+  input: { s3Key: string; body: string },
+  deps: IngestJobDescriptionDeps,
+): Promise<IngestResult> {
+  if (!input.body.startsWith('---')) {
+    return {
+      status: 'rejected',
+      reason: 'Missing YAML frontmatter',
+    };
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    ({ data } = matter(input.body) as { data: Record<string, unknown> });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid frontmatter';
+    return { status: 'rejected', reason: message };
+  }
+
+  const collectedAt = formatCollectedAt(data.collectedAt);
+  if (!collectedAt) {
+    return {
+      status: 'rejected',
+      reason: 'Frontmatter requires a valid collectedAt',
+    };
+  }
+
+  const record: JobDescriptionRecord = {
+    id: input.s3Key,
+    s3Key: input.s3Key,
+    contentHash: createHash('sha256').update(input.body, 'utf8').digest('hex'),
+    collectedAt,
+    status: 'active',
+    title: optionalString(data.title),
+    seniority: optionalString(data.seniority),
+    roleFamily: optionalString(data.roleFamily),
+    source: optionalString(data.source),
+  };
+
+  await deps.upsertJobDescription(record);
+
+  return { status: 'ingested', record };
+}

--- a/amplify/functions/job-market-ingest/resource.ts
+++ b/amplify/functions/job-market-ingest/resource.ts
@@ -1,0 +1,10 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * S3 ObjectCreated ingest for job-description markdown under raw/*.
+ * Does not start corpus recompute — that stays an admin on-demand action.
+ */
+export const jobMarketIngest = defineFunction({
+  name: 'job-market-ingest',
+  entry: './handler.ts',
+});

--- a/amplify/functions/job-market-ingest/wiring.test.ts
+++ b/amplify/functions/job-market-ingest/wiring.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('job market lab ingest wiring', () => {
+  const backendTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'backend.ts'),
+    'utf8',
+  );
+
+  it('registers the ingest function and raw/ ObjectCreated notification', () => {
+    expect(backendTs).toMatch(/jobMarketIngest/);
+    expect(backendTs).toMatch(/EventType\.OBJECT_CREATED/);
+    expect(backendTs).toMatch(/prefix:\s*'raw\/'/);
+  });
+
+  it('does not wire corpus recompute into the ingest path', () => {
+    expect(backendTs).not.toMatch(/recompute/i);
+    expect(backendTs).not.toMatch(/AnalysisRun/);
+  });
+});

--- a/amplify/functions/lab-placeholder/handler.ts
+++ b/amplify/functions/lab-placeholder/handler.ts
@@ -1,4 +1,0 @@
-export const handler = async () => ({
-  statusCode: 200,
-  body: 'job-market-lab-placeholder',
-});

--- a/amplify/functions/lab-placeholder/resource.ts
+++ b/amplify/functions/lab-placeholder/resource.ts
@@ -1,9 +1,0 @@
-import { defineFunction } from '@aws-amplify/backend';
-
-/**
- * Placeholder function so the Gen 2 functions directory is wired.
- * Ingest / recompute handlers replace this in later slices.
- */
-export const labPlaceholder = defineFunction({
-  name: 'job-market-lab-placeholder',
-});

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -1,13 +1,17 @@
 import { defineStorage } from '@aws-amplify/backend';
+import { jobMarketIngest } from '../functions/job-market-ingest/resource';
 
 /**
- * Job market lab storage skeleton.
- * Prefix layout (raw / embeddings / artefacts) is refined in ingest and recompute slices.
+ * Job market lab corpus storage.
+ * raw/* — markdown JDs (ingest trigger wired in backend.ts for this prefix only).
  */
 export const storage = defineStorage({
   name: 'jobMarketLab',
   access: (allow) => ({
-    'raw/*': [allow.authenticated.to(['read', 'write', 'delete'])],
+    'raw/*': [
+      allow.authenticated.to(['read', 'write', 'delete']),
+      allow.resource(jobMarketIngest).to(['read']),
+    ],
     'embeddings/*': [allow.authenticated.to(['read', 'write', 'delete'])],
     'artefacts/*': [allow.authenticated.to(['read', 'write', 'delete'])],
   }),

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -11,7 +11,9 @@ There is **no accidental double-deploy** from GitHub Actions: Actions do not pus
 
 ## Amplify Gen 2 backend
 
-Backend definitions live in `amplify/` (auth, data, storage, functions placeholders for the job market lab). Hosting deploys them via `npx ampx pipeline-deploy` in the `backend` phase of `amplify.yml`, then runs the existing frontend `preBuild` (blog sync) and `build`.
+Backend definitions live in `amplify/` (auth, data, storage, and the job-market ingest function for the lab). Hosting deploys them via `npx ampx pipeline-deploy` in the `backend` phase of `amplify.yml`, then runs the existing frontend `preBuild` (blog sync) and `build`.
+
+Script-first JD ingest: with sandbox/Hosting outputs present, `npm run ingest:jd -- path/to/file.md` uploads markdown to the `raw/` prefix; the ingest Lambda upserts `JobDescription` metadata and does not start recompute.
 
 | Environment | Outputs file |
 |-------------|----------------|

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Amplify sandbox / pipeline-deploy artefacts (gitignored)
+    ".amplify/**",
     // Legacy scripts (tracked separately as tech debt)
     "scripts/**",
   ]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hashadar_website",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1086.0",
         "@fontsource/zalando-sans-expanded": "^5.2.1",
         "aws-amplify": "^6.18.0",
         "clsx": "^2.1.1",
@@ -38,6 +39,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/aws-lambda": "^8.10.162",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3107,23 +3109,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -3139,23 +3124,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -6553,23 +6521,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -6585,23 +6536,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -8904,7 +8838,6 @@
       "version": "3.1000.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
       "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -9321,7 +9254,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1086.0.tgz",
       "integrity": "sha512-6+7mVMPKetZmmF2L1yRJ+rN9b1OwVgc5sju2mj8ixdxuGjtVZ0ekFlcWGBFMQT9gpFk55PPLBng/XRYO3qah5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.16",
@@ -9726,7 +9658,6 @@
       "version": "3.972.62",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
       "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,6 +3109,23 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -3124,6 +3141,23 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -6521,6 +6555,23 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -6536,6 +6587,23 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/semantic-conventions": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "sandbox": "npx ampx sandbox"
+    "sandbox": "npx ampx sandbox",
+    "ingest:jd": "node scripts/ingest-job-description.mjs"
   },
   "engines": {
     "node": ">=22"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1086.0",
     "@fontsource/zalando-sans-expanded": "^5.2.1",
     "aws-amplify": "^6.18.0",
     "clsx": "^2.1.1",
@@ -46,6 +48,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/aws-lambda": "^8.10.162",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/scripts/ingest-job-description.mjs
+++ b/scripts/ingest-job-description.mjs
@@ -1,0 +1,77 @@
+/**
+ * Upload a job-description markdown file to the lab raw/ corpus prefix.
+ *
+ * Requires amplify_outputs.json (from `npm run sandbox` or Hosting) and AWS
+ * credentials that can PutObject to the storage bucket. The S3 ObjectCreated
+ * trigger upserts JobDescription metadata; recompute is not started.
+ *
+ * Usage: node scripts/ingest-job-description.mjs <path-to.md> [optional-object-name.md]
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outputsPath = path.join(root, 'amplify_outputs.json');
+
+const filePath = process.argv[2];
+const objectName = process.argv[3];
+
+if (!filePath) {
+  console.error(
+    'Usage: node scripts/ingest-job-description.mjs <path-to.md> [optional-object-name.md]',
+  );
+  process.exit(1);
+}
+
+if (!existsSync(outputsPath)) {
+  console.error(
+    'amplify_outputs.json not found. Run `npm run sandbox` (or deploy) first.',
+  );
+  process.exit(1);
+}
+
+const outputs = JSON.parse(readFileSync(outputsPath, 'utf8'));
+const bucketName = outputs.storage?.bucket_name;
+const region = outputs.storage?.aws_region;
+
+if (!bucketName || !region) {
+  console.error(
+    'amplify_outputs.json is missing storage.bucket_name / storage.aws_region.',
+  );
+  process.exit(1);
+}
+
+const absolutePath = path.resolve(filePath);
+if (!existsSync(absolutePath)) {
+  console.error(`File not found: ${absolutePath}`);
+  process.exit(1);
+}
+
+const body = readFileSync(absolutePath);
+const keyName = objectName ?? path.basename(absolutePath);
+if (!keyName.toLowerCase().endsWith('.md')) {
+  console.error('Object name must end with .md');
+  process.exit(1);
+}
+
+const key = `raw/${keyName}`;
+const client = new S3Client({ region });
+
+await client.send(
+  new PutObjectCommand({
+    Bucket: bucketName,
+    Key: key,
+    Body: body,
+    ContentType: 'text/markdown; charset=utf-8',
+  }),
+);
+
+console.log(`Uploaded s3://${bucketName}/${key}`);
+console.log(
+  'Ingest Lambda will upsert JobDescription metadata if frontmatter is valid.',
+);


### PR DESCRIPTION
## Summary
- Adds `ingestJobDescription` seam that parses required YAML frontmatter, hashes full file contents, and upserts active `JobDescription` metadata (body stays in S3 only).
- Wires Amplify `JobDescription` model, S3 `raw/` ObjectCreated → ingest Lambda, and `npm run ingest:jd` upload script; invalid frontmatter fails fast with no upsert and does not start recompute.
- Replaces the Gen 2 lab-placeholder function; seam tests cover valid/invalid fixtures, contentHash changes, and ingest wiring without recompute.

Closes #37

## Test plan
- [ ] `npm test` (includes ingest fixture success/failure and wiring tests)
- [ ] `npm run typecheck` and `npm run lint`
- [ ] Optional sandbox: `npm run sandbox`, then `npm run ingest:jd -- amplify/functions/job-market-ingest/fixtures/valid-jd.md` and confirm an active JobDescription row
- [ ] Optional: upload `missing-frontmatter.md` / `invalid-yaml.md` and confirm Lambda fails visibly with no active row
- [ ] Confirm uploads do not create an AnalysisRun / start recompute
