### PR TITLE
Job market lab: soft archive and 18-month age hygiene (#38)

### DIFF
--- a/src/lib/job-market-corpus.test.ts
+++ b/src/lib/job-market-corpus.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  archiveJobDescription,
+  prepareActiveCorpusForAnalysis,
+  restoreJobDescription,
+  type JobDescriptionCorpusRecord,
+} from './job-market-corpus';
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('archiveJobDescription', () => {
+  it('soft-archives an active JobDescription so it no longer counts as active for analysis', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['jd-1', doc({ id: 'jd-1' })],
+      ['jd-2', doc({ id: 'jd-2' })],
+    ]);
+
+    const result = await archiveJobDescription('jd-1', {
+      getJobDescription: async (id) => store.get(id) ?? null,
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'archived',
+      record: expect.objectContaining({ id: 'jd-1', status: 'archived' }),
+    });
+    expect(store.get('jd-1')?.status).toBe('archived');
+    expect(store.has('jd-1')).toBe(true);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+    });
+
+    expect(active.map((record) => record.id)).toEqual(['jd-2']);
+  });
+
+  it('keeps soft-archived records recoverable without hard delete', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['jd-1', doc({ id: 'jd-1', status: 'archived' })],
+    ]);
+
+    const restored = await restoreJobDescription('jd-1', {
+      getJobDescription: async (id) => store.get(id) ?? null,
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+    });
+
+    expect(restored).toEqual({
+      status: 'restored',
+      record: expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    });
+    expect(store.get('jd-1')).toEqual(
+      expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    );
+  });
+});
+
+describe('prepareActiveCorpusForAnalysis', () => {
+  it('auto-archives documents older than the configured age window during the sweep', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      [
+        'old',
+        doc({
+          id: 'old',
+          collectedAt: '2024-01-01T00:00:00.000Z',
+        }),
+      ],
+      [
+        'fresh',
+        doc({
+          id: 'fresh',
+          collectedAt: '2026-06-01T00:00:00.000Z',
+        }),
+      ],
+    ]);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+      maxAgeMonths: 18,
+    });
+
+    expect(store.get('old')?.status).toBe('archived');
+    expect(store.get('fresh')?.status).toBe('active');
+    expect(active.map((record) => record.id)).toEqual(['fresh']);
+  });
+
+  it('excludes archived documents from the active analysis corpus', async () => {
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [
+        doc({ id: 'active-1', status: 'active' }),
+        doc({ id: 'archived-1', status: 'archived' }),
+        doc({ id: 'active-2', status: 'active' }),
+      ],
+      saveJobDescription: async () => undefined,
+      now: new Date('2026-07-14T00:00:00.000Z'),
+    });
+
+    expect(active.map((record) => record.id)).toEqual(['active-1', 'active-2']);
+  });
+
+  it('treats the age window as exclusive of the exact cutoff instant', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      [
+        'on-cutoff',
+        doc({
+          id: 'on-cutoff',
+          // Exactly 18 months before now
+          collectedAt: '2025-01-14T00:00:00.000Z',
+        }),
+      ],
+    ]);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+      maxAgeMonths: 18,
+    });
+
+    expect(store.get('on-cutoff')?.status).toBe('active');
+    expect(active.map((record) => record.id)).toEqual(['on-cutoff']);
+  });
+});

--- a/src/lib/job-market-corpus.ts
+++ b/src/lib/job-market-corpus.ts
@@ -1,0 +1,120 @@
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionCorpusRecord = {
+  id: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+  s3Key?: string;
+  contentHash?: string;
+};
+
+export const DEFAULT_MAX_AGE_MONTHS = 18;
+
+export type ArchiveJobDescriptionDeps = {
+  getJobDescription: (id: string) => Promise<JobDescriptionCorpusRecord | null>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+};
+
+export type ArchiveJobDescriptionResult =
+  | { status: 'archived'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_archived'; record: JobDescriptionCorpusRecord };
+
+export type PrepareActiveCorpusDeps = {
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export function selectActiveCorpus(
+  records: JobDescriptionCorpusRecord[],
+): JobDescriptionCorpusRecord[] {
+  return records.filter((record) => record.status === 'active');
+}
+
+export function isOlderThanAgeWindow(
+  collectedAt: string,
+  now: Date,
+  maxAgeMonths: number = DEFAULT_MAX_AGE_MONTHS,
+): boolean {
+  const collected = new Date(collectedAt);
+  if (Number.isNaN(collected.getTime())) {
+    return false;
+  }
+
+  const cutoff = new Date(now);
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - maxAgeMonths);
+  return collected.getTime() < cutoff.getTime();
+}
+
+export type RestoreJobDescriptionResult =
+  | { status: 'restored'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_active'; record: JobDescriptionCorpusRecord };
+
+export async function archiveJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<ArchiveJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'archived') {
+    return { status: 'already_archived', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'archived',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'archived', record };
+}
+
+export async function restoreJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<RestoreJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'active') {
+    return { status: 'already_active', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'active',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'restored', record };
+}
+
+export async function prepareActiveCorpusForAnalysis(
+  deps: PrepareActiveCorpusDeps,
+): Promise<JobDescriptionCorpusRecord[]> {
+  const now = deps.now ?? new Date();
+  const maxAgeMonths = deps.maxAgeMonths ?? DEFAULT_MAX_AGE_MONTHS;
+  const records = await deps.listJobDescriptions();
+
+  for (const record of records) {
+    if (
+      record.status === 'active' &&
+      isOlderThanAgeWindow(record.collectedAt, now, maxAgeMonths)
+    ) {
+      await deps.saveJobDescription({ ...record, status: 'archived' });
+    }
+  }
+
+  const refreshed = await deps.listJobDescriptions();
+  return selectActiveCorpus(refreshed);
+}

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -13,6 +13,16 @@ export type GetPublishedJobMarketSnapshotDeps = {
   fetchPublished?: FetchPublishedJobMarketSnapshot;
 };
 
+export {
+  archiveJobDescription,
+  restoreJobDescription,
+  prepareActiveCorpusForAnalysis,
+  selectActiveCorpus,
+  DEFAULT_MAX_AGE_MONTHS,
+  type JobDescriptionCorpusRecord,
+  type JobDescriptionStatus,
+} from './job-market-corpus';
+
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
   // Guest publication query lands in a later slice; until then nothing is published.
   return null;


### PR DESCRIPTION
## Summary
- Adds corpus hygiene seam for soft-archive / restore of JobDescription records without hard delete.
- Analysis preparation auto-archives documents older than the configurable age window (default 18 months) and returns only the active corpus.
- Exposes archive APIs through the job-market lab application facade for later admin/recompute slices.

Closes #38

## Test plan
- [ ] `npm test -- src/lib/job-market-corpus.test.ts` passes (archive, restore, age threshold, exclusion)
- [ ] `npm test` full suite remains green
- [ ] `npm run typecheck` passes
- [ ] Confirm soft-archived records remain in the store (not deleted)
- [ ] Confirm documents older than 18 months are archived during `prepareActiveCorpusForAnalysis`

Made with [Cursor](https://cursor.com)