### PR TITLE
Job market lab: owner sign-in and on-demand recompute publishes snapshot (#39)

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -1,9 +1,9 @@
+/**
+ * Soft-disable Cognito self-registration in defineAuth comments;
+ * enforce allowAdminCreateUserOnly via backend.ts CDK override (#39).
+ */
 import { defineAuth } from '@aws-amplify/backend';
 
-/**
- * Job market lab auth skeleton.
- * Later slices tighten this (self-sign-up disabled, invited admin only — #39).
- */
 export const auth = defineAuth({
   loginWith: {
     email: true,

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,20 +1,61 @@
 import { defineBackend } from '@aws-amplify/backend';
 import { EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { auth } from './auth/resource.js';
 import { data } from './data/resource.js';
 import { storage } from './storage/resource.js';
 import { jobMarketIngest } from './functions/job-market-ingest/resource.js';
+import { jobMarketRecompute } from './functions/job-market-recompute/resource.js';
+import { jobMarketAnalyse } from './functions/job-market-analyse/resource.js';
+import { jobMarketPublication } from './functions/job-market-publication/resource.js';
 
 const backend = defineBackend({
   auth,
   data,
   storage,
   jobMarketIngest,
+  jobMarketRecompute,
+  jobMarketAnalyse,
+  jobMarketPublication,
 });
+
+// Owner-only Cognito: disable self-sign-up (admin invite / AdminCreateUser only).
+const { cfnUserPool } = backend.auth.resources.cfnResources;
+cfnUserPool.adminCreateUserConfig = {
+  allowAdminCreateUserOnly: true,
+};
 
 backend.storage.resources.bucket.addEventNotification(
   EventType.OBJECT_CREATED,
   new LambdaDestination(backend.jobMarketIngest.resources.lambda),
   { prefix: 'raw/' },
+);
+
+const bucketName = backend.storage.resources.bucket.bucketName;
+const analyseFunctionName = backend.jobMarketAnalyse.resources.lambda.functionName;
+
+backend.jobMarketRecompute.addEnvironment(
+  'JOB_MARKET_ANALYSE_FUNCTION_NAME',
+  analyseFunctionName,
+);
+backend.jobMarketRecompute.addEnvironment('MAX_ACTIVE_DOCS', '150');
+backend.jobMarketAnalyse.addEnvironment('JOB_MARKET_BUCKET_NAME', bucketName);
+
+backend.jobMarketAnalyse.resources.lambda.grantInvoke(
+  backend.jobMarketRecompute.resources.lambda,
+);
+backend.storage.resources.bucket.grantRead(
+  backend.jobMarketAnalyse.resources.lambda,
+);
+backend.storage.resources.bucket.grantWrite(
+  backend.jobMarketAnalyse.resources.lambda,
+);
+
+backend.jobMarketAnalyse.resources.lambda.addToRolePolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ['bedrock:InvokeModel'],
+    resources: ['*'],
+  }),
 );

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,5 +1,8 @@
 import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
 import { jobMarketIngest } from '../functions/job-market-ingest/resource';
+import { jobMarketRecompute } from '../functions/job-market-recompute/resource';
+import { jobMarketAnalyse } from '../functions/job-market-analyse/resource';
+import { jobMarketPublication } from '../functions/job-market-publication/resource';
 
 const schema = a
   .schema({
@@ -17,8 +20,65 @@ const schema = a
       .authorization((allow) => [
         allow.authenticated.to(['read', 'create', 'update', 'delete']),
       ]),
+
+    AnalysisRun: a
+      .model({
+        status: a
+          .enum(['queued', 'running', 'succeeded', 'failed'])
+          .required(),
+        docsConsidered: a.integer(),
+        docsEmbedded: a.integer(),
+        docsCacheHit: a.integer(),
+        clusterCount: a.integer(),
+        bedrockInputTokens: a.integer(),
+        estimatedCostUsd: a.float(),
+        errorMessage: a.string(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create', 'update']),
+      ]),
+
+    CorpusSnapshot: a
+      .model({
+        runId: a.id().required(),
+        payload: a.json().required(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create']),
+      ]),
+
+    LabPublication: a
+      .model({
+        currentSnapshotId: a.id().required(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create', 'update']),
+      ]),
+
+    startJobMarketRecompute: a
+      .mutation()
+      .returns(
+        a.customType({
+          status: a.string().required(),
+          runId: a.string(),
+          reason: a.string(),
+        }),
+      )
+      .authorization((allow) => [allow.authenticated()])
+      .handler(a.handler.function(jobMarketRecompute)),
+
+    getPublishedJobMarketSnapshot: a
+      .query()
+      .returns(a.json())
+      .authorization((allow) => [allow.guest(), allow.authenticated()])
+      .handler(a.handler.function(jobMarketPublication)),
   })
-  .authorization((allow) => [allow.resource(jobMarketIngest)]);
+  .authorization((allow) => [
+    allow.resource(jobMarketIngest),
+    allow.resource(jobMarketRecompute),
+    allow.resource(jobMarketAnalyse),
+    allow.resource(jobMarketPublication),
+  ]);
 
 export type Schema = ClientSchema<typeof schema>;
 

--- a/amplify/functions/job-market-analyse/analyse.test.ts
+++ b/amplify/functions/job-market-analyse/analyse.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  analyseCorpus,
+  MAX_CLUSTER_K,
+  MAX_PROJECTION_POINTS,
+  MAX_SKILLS,
+  type AnalyzableDocument,
+} from './analyse';
+
+const docs: AnalyzableDocument[] = [
+  {
+    id: 'jd-1',
+    contentHash: 'hash-1',
+    markdown:
+      'We need Python, SQL, and teamwork. Senior data scientist role with modelling.',
+    seniority: 'senior',
+    roleFamily: 'data-science',
+  },
+  {
+    id: 'jd-2',
+    contentHash: 'hash-2',
+    markdown: 'Looking for Python, Tableau, and communication skills.',
+    seniority: 'mid',
+    roleFamily: 'analytics',
+  },
+  {
+    id: 'jd-3',
+    contentHash: 'hash-1',
+    markdown:
+      'We need Python, SQL, and teamwork. Senior data scientist role with modelling.',
+    seniority: 'senior',
+    roleFamily: 'data-science',
+  },
+];
+
+describe('analyseCorpus', () => {
+  it('publishes a snapshot within caps and accounts for embedding cache hits', async () => {
+    const embed = vi.fn(async (text: string) => ({
+      vector: Array.from({ length: 8 }, (_, index) => (text.length + index) / 100),
+      inputTokens: 12,
+      estimatedCostUsd: 0.0001,
+    }));
+    const cacheGet = vi.fn(async (contentHash: string) =>
+      contentHash === 'hash-1'
+        ? Array.from({ length: 8 }, (_, index) => index / 10)
+        : null,
+    );
+    const cachePut = vi.fn(async () => undefined);
+
+    const result = await analyseCorpus(docs, {
+      embed,
+      getCachedEmbedding: cacheGet,
+      putCachedEmbedding: cachePut,
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.snapshot.skills.length).toBeLessThanOrEqual(MAX_SKILLS);
+    expect(result.snapshot.projection.length).toBeLessThanOrEqual(
+      MAX_PROJECTION_POINTS,
+    );
+    expect(result.snapshot.clusters.length).toBeLessThanOrEqual(MAX_CLUSTER_K);
+    expect(result.snapshot.documentCount).toBe(3);
+    expect(result.snapshot.publishedAt).toBe('2026-07-14T12:00:00.000Z');
+    expect(result.snapshot).not.toHaveProperty('rawText');
+    expect(result.snapshot).not.toHaveProperty('source');
+    expect(result.snapshot.skills.every((skill) => typeof skill.name === 'string')).toBe(
+      true,
+    );
+    expect(result.metrics).toMatchObject({
+      docsConsidered: 3,
+      docsCacheHit: 2,
+      docsEmbedded: 1,
+    });
+    expect(result.metrics.bedrockInputTokens).toBeGreaterThan(0);
+    expect(result.metrics.estimatedCostUsd).toBeGreaterThan(0);
+    expect(embed).toHaveBeenCalledOnce();
+    expect(cachePut).toHaveBeenCalledOnce();
+  });
+});

--- a/amplify/functions/job-market-analyse/analyse.ts
+++ b/amplify/functions/job-market-analyse/analyse.ts
@@ -1,0 +1,297 @@
+export const MAX_SKILLS = 40;
+export const MAX_PROJECTION_POINTS = 200;
+export const MAX_CLUSTER_K = 12;
+
+export type AnalyzableDocument = {
+  id: string;
+  contentHash: string;
+  markdown: string;
+  seniority?: string;
+  roleFamily?: string;
+  title?: string;
+};
+
+export type SkillFrequency = {
+  name: string;
+  count: number;
+};
+
+export type TaxonomyBucket = {
+  name: string;
+  count: number;
+};
+
+export type ClusterSummary = {
+  id: number;
+  size: number;
+  label: string;
+};
+
+export type ProjectionPoint = {
+  x: number;
+  y: number;
+  clusterId: number;
+};
+
+export type CorpusSnapshotPayload = {
+  documentCount: number;
+  publishedAt: string;
+  skills: SkillFrequency[];
+  seniority: TaxonomyBucket[];
+  roleFamily: TaxonomyBucket[];
+  clusters: ClusterSummary[];
+  projection: ProjectionPoint[];
+};
+
+export type AnalysisMetrics = {
+  docsConsidered: number;
+  docsEmbedded: number;
+  docsCacheHit: number;
+  clusterCount: number;
+  bedrockInputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type EmbedResult = {
+  vector: number[];
+  inputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type AnalyseCorpusDeps = {
+  embed: (text: string) => Promise<EmbedResult>;
+  getCachedEmbedding: (contentHash: string) => Promise<number[] | null>;
+  putCachedEmbedding: (contentHash: string, vector: number[]) => Promise<void>;
+  now?: Date;
+  maxSkills?: number;
+  maxProjectionPoints?: number;
+  maxClusters?: number;
+  cluster?: (
+    vectors: number[][],
+    k: number,
+  ) => { assignments: number[]; centroids: number[][] };
+};
+
+export type AnalyseCorpusResult = {
+  snapshot: CorpusSnapshotPayload;
+  metrics: AnalysisMetrics;
+};
+
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'the',
+  'to',
+  'we',
+  'with',
+  'you',
+  'your',
+  'need',
+  'looking',
+  'role',
+  'skills',
+]);
+
+export function extractSkillFrequencies(
+  documents: AnalyzableDocument[],
+  maxSkills: number = MAX_SKILLS,
+): SkillFrequency[] {
+  const counts = new Map<string, number>();
+
+  for (const document of documents) {
+    const tokens = document.markdown
+      .toLowerCase()
+      .match(/[a-z][a-z0-9+.#-]{1,}/g) ?? [];
+    const seen = new Set<string>();
+    for (const token of tokens) {
+      if (STOPWORDS.has(token) || seen.has(token)) {
+        continue;
+      }
+      seen.add(token);
+      counts.set(token, (counts.get(token) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, maxSkills);
+}
+
+function taxonomyBreakdown(
+  documents: AnalyzableDocument[],
+  field: 'seniority' | 'roleFamily',
+): TaxonomyBucket[] {
+  const counts = new Map<string, number>();
+  for (const document of documents) {
+    const value = document[field];
+    if (!value) {
+      continue;
+    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function euclidean(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    const delta = (a[index] ?? 0) - (b[index] ?? 0);
+    sum += delta * delta;
+  }
+  return Math.sqrt(sum);
+}
+
+/** Swap-ready default clusterer (k-means). */
+export function kMeansCluster(
+  vectors: number[][],
+  k: number,
+  maxIterations: number = 25,
+): { assignments: number[]; centroids: number[][] } {
+  if (vectors.length === 0) {
+    return { assignments: [], centroids: [] };
+  }
+
+  const clusterCount = Math.max(1, Math.min(k, vectors.length, MAX_CLUSTER_K));
+  const dimensions = vectors[0]?.length ?? 0;
+  const centroids = vectors.slice(0, clusterCount).map((vector) => [...vector]);
+  const assignments = new Array<number>(vectors.length).fill(0);
+
+  for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+    let moved = false;
+    for (let index = 0; index < vectors.length; index += 1) {
+      let best = 0;
+      let bestDistance = Number.POSITIVE_INFINITY;
+      for (let centroidIndex = 0; centroidIndex < centroids.length; centroidIndex += 1) {
+        const distance = euclidean(vectors[index]!, centroids[centroidIndex]!);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          best = centroidIndex;
+        }
+      }
+      if (assignments[index] !== best) {
+        assignments[index] = best;
+        moved = true;
+      }
+    }
+
+    const sums = centroids.map(() => new Array<number>(dimensions).fill(0));
+    const counts = new Array<number>(centroids.length).fill(0);
+    for (let index = 0; index < vectors.length; index += 1) {
+      const clusterId = assignments[index]!;
+      counts[clusterId] += 1;
+      const vector = vectors[index]!;
+      for (let dim = 0; dim < dimensions; dim += 1) {
+        sums[clusterId]![dim] += vector[dim] ?? 0;
+      }
+    }
+    for (let centroidIndex = 0; centroidIndex < centroids.length; centroidIndex += 1) {
+      if (counts[centroidIndex] === 0) {
+        continue;
+      }
+      centroids[centroidIndex] = sums[centroidIndex]!.map(
+        (value) => value / counts[centroidIndex]!,
+      );
+    }
+
+    if (!moved) {
+      break;
+    }
+  }
+
+  return { assignments, centroids };
+}
+
+export async function analyseCorpus(
+  documents: AnalyzableDocument[],
+  deps: AnalyseCorpusDeps,
+): Promise<AnalyseCorpusResult> {
+  const maxSkills = deps.maxSkills ?? MAX_SKILLS;
+  const maxProjectionPoints = deps.maxProjectionPoints ?? MAX_PROJECTION_POINTS;
+  const maxClusters = deps.maxClusters ?? MAX_CLUSTER_K;
+  const cluster = deps.cluster ?? kMeansCluster;
+  const now = deps.now ?? new Date();
+
+  const vectors: number[][] = [];
+  let docsCacheHit = 0;
+  let docsEmbedded = 0;
+  let bedrockInputTokens = 0;
+  let estimatedCostUsd = 0;
+
+  for (const document of documents) {
+    const cached = await deps.getCachedEmbedding(document.contentHash);
+    if (cached) {
+      docsCacheHit += 1;
+      vectors.push(cached);
+      continue;
+    }
+
+    const embedded = await deps.embed(document.markdown);
+    docsEmbedded += 1;
+    bedrockInputTokens += embedded.inputTokens;
+    estimatedCostUsd += embedded.estimatedCostUsd;
+    await deps.putCachedEmbedding(document.contentHash, embedded.vector);
+    vectors.push(embedded.vector);
+  }
+
+  const k = Math.min(
+    maxClusters,
+    Math.max(1, Math.round(Math.sqrt(documents.length || 1))),
+  );
+  const { assignments } = cluster(vectors, k);
+
+  const clusterSizes = new Map<number, number>();
+  for (const assignment of assignments) {
+    clusterSizes.set(assignment, (clusterSizes.get(assignment) ?? 0) + 1);
+  }
+
+  const clusters = [...clusterSizes.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([id, size]) => ({
+      id,
+      size,
+      label: `Theme ${id + 1}`,
+    }));
+
+  const projection = documents.slice(0, maxProjectionPoints).map((document, index) => ({
+    x: vectors[index]?.[0] ?? 0,
+    y: vectors[index]?.[1] ?? 0,
+    clusterId: assignments[index] ?? 0,
+  }));
+
+  return {
+    snapshot: {
+      documentCount: documents.length,
+      publishedAt: now.toISOString(),
+      skills: extractSkillFrequencies(documents, maxSkills),
+      seniority: taxonomyBreakdown(documents, 'seniority'),
+      roleFamily: taxonomyBreakdown(documents, 'roleFamily'),
+      clusters,
+      projection,
+    },
+    metrics: {
+      docsConsidered: documents.length,
+      docsEmbedded,
+      docsCacheHit,
+      clusterCount: clusters.length,
+      bedrockInputTokens,
+      estimatedCostUsd,
+    },
+  };
+}

--- a/amplify/functions/job-market-analyse/corpus.ts
+++ b/amplify/functions/job-market-analyse/corpus.ts
@@ -1,0 +1,122 @@
+/** Lambda-local copy of corpus hygiene (facade source of truth: src/lib/job-market-corpus.ts). */
+
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionCorpusRecord = {
+  id: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+  s3Key?: string;
+  contentHash?: string;
+};
+
+export const DEFAULT_MAX_AGE_MONTHS = 18;
+
+export type ArchiveJobDescriptionDeps = {
+  getJobDescription: (id: string) => Promise<JobDescriptionCorpusRecord | null>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+};
+
+export type ArchiveJobDescriptionResult =
+  | { status: 'archived'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_archived'; record: JobDescriptionCorpusRecord };
+
+export type PrepareActiveCorpusDeps = {
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export function selectActiveCorpus(
+  records: JobDescriptionCorpusRecord[],
+): JobDescriptionCorpusRecord[] {
+  return records.filter((record) => record.status === 'active');
+}
+
+export function isOlderThanAgeWindow(
+  collectedAt: string,
+  now: Date,
+  maxAgeMonths: number = DEFAULT_MAX_AGE_MONTHS,
+): boolean {
+  const collected = new Date(collectedAt);
+  if (Number.isNaN(collected.getTime())) {
+    return false;
+  }
+
+  const cutoff = new Date(now);
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - maxAgeMonths);
+  return collected.getTime() < cutoff.getTime();
+}
+
+export type RestoreJobDescriptionResult =
+  | { status: 'restored'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_active'; record: JobDescriptionCorpusRecord };
+
+export async function archiveJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<ArchiveJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'archived') {
+    return { status: 'already_archived', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'archived',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'archived', record };
+}
+
+export async function restoreJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<RestoreJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'active') {
+    return { status: 'already_active', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'active',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'restored', record };
+}
+
+export async function prepareActiveCorpusForAnalysis(
+  deps: PrepareActiveCorpusDeps,
+): Promise<JobDescriptionCorpusRecord[]> {
+  const now = deps.now ?? new Date();
+  const maxAgeMonths = deps.maxAgeMonths ?? DEFAULT_MAX_AGE_MONTHS;
+  const records = await deps.listJobDescriptions();
+
+  for (const record of records) {
+    if (
+      record.status === 'active' &&
+      isOlderThanAgeWindow(record.collectedAt, now, maxAgeMonths)
+    ) {
+      await deps.saveJobDescription({ ...record, status: 'archived' });
+    }
+  }
+
+  const refreshed = await deps.listJobDescriptions();
+  return selectActiveCorpus(refreshed);
+}

--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -1,0 +1,231 @@
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import type { Handler } from 'aws-lambda';
+import { env } from '$amplify/env/job-market-analyse';
+import type { Schema } from '../../data/resource';
+import { executeAnalysisRun } from './run';
+import type { AnalysisRunRecord } from '../job-market-recompute/orchestrator';
+import type { StoredCorpusSnapshot } from './run';
+import type { JobDescriptionCorpusRecord } from './corpus';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const s3 = new S3Client({});
+const bedrock = new BedrockRuntimeClient({});
+
+const PUBLICATION_ID = 'current';
+
+type AnalyseEvent = {
+  runId: string;
+};
+
+async function listJobDescriptions(): Promise<JobDescriptionCorpusRecord[]> {
+  const { data, errors } = await client.models.JobDescription.list();
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return (data ?? []).map((record) => ({
+    id: record.id,
+    collectedAt: record.collectedAt,
+    status: record.status as JobDescriptionCorpusRecord['status'],
+    s3Key: record.s3Key,
+    contentHash: record.contentHash,
+    title: record.title ?? undefined,
+    seniority: record.seniority ?? undefined,
+    roleFamily: record.roleFamily ?? undefined,
+    source: record.source ?? undefined,
+  }));
+}
+
+async function saveJobDescription(
+  record: JobDescriptionCorpusRecord,
+): Promise<void> {
+  const { errors } = await client.models.JobDescription.update({
+    id: record.id,
+    status: record.status,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+async function loadMarkdown(s3Key: string): Promise<string> {
+  const object = await s3.send(
+    new GetObjectCommand({
+      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Key: s3Key,
+    }),
+  );
+  const body = await object.Body?.transformToString('utf-8');
+  if (!body) {
+    throw new Error(`Empty object body for ${s3Key}`);
+  }
+  return body;
+}
+
+async function getCachedEmbedding(contentHash: string): Promise<number[] | null> {
+  try {
+    const object = await s3.send(
+      new GetObjectCommand({
+        Bucket: env.JOB_MARKET_BUCKET_NAME,
+        Key: `embeddings/${contentHash}.json`,
+      }),
+    );
+    const body = await object.Body?.transformToString('utf-8');
+    if (!body) {
+      return null;
+    }
+    const parsed = JSON.parse(body) as { vector?: number[] };
+    return Array.isArray(parsed.vector) ? parsed.vector : null;
+  } catch {
+    return null;
+  }
+}
+
+async function putCachedEmbedding(
+  contentHash: string,
+  vector: number[],
+): Promise<void> {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Key: `embeddings/${contentHash}.json`,
+      Body: JSON.stringify({ vector }),
+      ContentType: 'application/json',
+    }),
+  );
+}
+
+async function embed(text: string) {
+  const modelId = env.BEDROCK_MODEL_ID;
+  const response = await bedrock.send(
+    new InvokeModelCommand({
+      modelId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        inputText: text.slice(0, 8000),
+        dimensions: 256,
+        normalize: true,
+      }),
+    }),
+  );
+  const payload = JSON.parse(new TextDecoder().decode(response.body)) as {
+    embedding?: number[];
+    inputTextTokenCount?: number;
+  };
+  if (!payload.embedding) {
+    throw new Error('Bedrock embedding response did not include a vector');
+  }
+  const inputTokens = payload.inputTextTokenCount ?? Math.ceil(text.length / 4);
+  // Titan embed rough cost placeholder for metrics (USD per 1k input tokens).
+  const estimatedCostUsd = (inputTokens / 1000) * 0.0001;
+  return {
+    vector: payload.embedding,
+    inputTokens,
+    estimatedCostUsd,
+  };
+}
+
+async function saveSnapshot(
+  snapshot: StoredCorpusSnapshot,
+): Promise<StoredCorpusSnapshot> {
+  const { errors } = await client.models.CorpusSnapshot.create({
+    id: snapshot.id,
+    runId: snapshot.runId,
+    payload: snapshot.payload,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return snapshot;
+}
+
+async function updateRun(run: AnalysisRunRecord): Promise<AnalysisRunRecord> {
+  const { errors } = await client.models.AnalysisRun.update({
+    id: run.id,
+    status: run.status,
+    docsConsidered: run.docsConsidered,
+    docsEmbedded: run.docsEmbedded,
+    docsCacheHit: run.docsCacheHit,
+    clusterCount: run.clusterCount,
+    bedrockInputTokens: run.bedrockInputTokens,
+    estimatedCostUsd: run.estimatedCostUsd,
+    errorMessage: run.errorMessage,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return run;
+}
+
+async function updatePublication(publication: {
+  currentSnapshotId: string;
+}): Promise<void> {
+  const existing = await client.models.LabPublication.get({ id: PUBLICATION_ID });
+  if (existing.data) {
+    const { errors } = await client.models.LabPublication.update({
+      id: PUBLICATION_ID,
+      currentSnapshotId: publication.currentSnapshotId,
+    });
+    if (errors?.length) {
+      throw new Error(errors.map((error) => error.message).join('; '));
+    }
+    return;
+  }
+  const { errors } = await client.models.LabPublication.create({
+    id: PUBLICATION_ID,
+    currentSnapshotId: publication.currentSnapshotId,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+async function getPublication() {
+  const { data } = await client.models.LabPublication.get({ id: PUBLICATION_ID });
+  if (!data) {
+    return null;
+  }
+  return { currentSnapshotId: data.currentSnapshotId };
+}
+
+export const handler: Handler<AnalyseEvent> = async (event) => {
+  const runId = event.runId;
+  if (!runId) {
+    throw new Error('runId is required');
+  }
+
+  const result = await executeAnalysisRun({
+    runId,
+    listJobDescriptions,
+    saveJobDescription,
+    loadMarkdown,
+    embed,
+    getCachedEmbedding,
+    putCachedEmbedding,
+    saveSnapshot,
+    updateRun,
+    updatePublication,
+    getPublication,
+  });
+
+  if (result.status === 'failed') {
+    console.error(`[job-market-analyse] Run ${runId} failed: ${result.reason}`);
+  } else {
+    console.log(
+      `[job-market-analyse] Run ${runId} succeeded snapshot=${result.snapshot.id}`,
+    );
+  }
+
+  return result;
+};

--- a/amplify/functions/job-market-analyse/resource.ts
+++ b/amplify/functions/job-market-analyse/resource.ts
@@ -1,0 +1,15 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Analysis worker: Bedrock embeddings (contentHash cache), descriptive stats, k-means.
+ * Invoked asynchronously by the recompute orchestrator — not guest-callable.
+ */
+export const jobMarketAnalyse = defineFunction({
+  name: 'job-market-analyse',
+  entry: './handler.ts',
+  timeoutSeconds: 300,
+  memoryMB: 1024,
+  environment: {
+    BEDROCK_MODEL_ID: 'amazon.titan-embed-text-v2:0',
+  },
+});

--- a/amplify/functions/job-market-analyse/run.test.ts
+++ b/amplify/functions/job-market-analyse/run.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JobDescriptionCorpusRecord } from './corpus';
+import { executeAnalysisRun } from './run';
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    s3Key: `raw/${overrides.id}.md`,
+    contentHash: `hash-${overrides.id}`,
+    ...overrides,
+  };
+}
+
+describe('executeAnalysisRun', () => {
+  it('excludes archived documents from analysis and publishes on success', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['active', doc({ id: 'active', title: 'Active role', seniority: 'senior' })],
+      ['archived', doc({ id: 'archived', status: 'archived', title: 'Old role' })],
+    ]);
+    const publication = { currentSnapshotId: 'snap-old' };
+    const snapshots = new Map<string, unknown>();
+    const runs = new Map<string, { id: string; status: string }>([
+      ['run-1', { id: 'run-1', status: 'queued' }],
+    ]);
+
+    const result = await executeAnalysisRun({
+      runId: 'run-1',
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      loadMarkdown: async (s3Key) =>
+        s3Key.includes('archived')
+          ? 'ARCHIVED SHOULD NOT APPEAR python'
+          : 'Python SQL modelling experience required',
+      embed: async () => ({
+        vector: [0.1, 0.2, 0.3, 0.4],
+        inputTokens: 8,
+        estimatedCostUsd: 0.0002,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      saveSnapshot: async (snapshot) => {
+        snapshots.set(snapshot.id, snapshot);
+        return snapshot;
+      },
+      updateRun: async (run) => {
+        runs.set(run.id, run);
+        return run;
+      },
+      updatePublication: async (next) => {
+        publication.currentSnapshotId = next.currentSnapshotId;
+      },
+      getPublication: async () => publication,
+      createSnapshotId: () => 'snap-new',
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(publication.currentSnapshotId).toBe('snap-new');
+    expect(snapshots.get('snap-new')).toMatchObject({
+      id: 'snap-new',
+      payload: expect.objectContaining({
+        documentCount: 1,
+      }),
+    });
+    expect(JSON.stringify(snapshots.get('snap-new'))).not.toMatch(/ARCHIVED SHOULD NOT APPEAR/i);
+    expect(runs.get('run-1')).toMatchObject({
+      status: 'succeeded',
+      docsConsidered: 1,
+    });
+  });
+
+  it('keeps the last good publication when a run fails', async () => {
+    const publication = { currentSnapshotId: 'snap-good' };
+    const updatePublication = vi.fn();
+
+    const result = await executeAnalysisRun({
+      runId: 'run-fail',
+      listJobDescriptions: async () => [doc({ id: 'active' })],
+      saveJobDescription: async () => undefined,
+      loadMarkdown: async () => {
+        throw new Error('S3 unavailable');
+      },
+      embed: async () => ({
+        vector: [0.1, 0.2],
+        inputTokens: 1,
+        estimatedCostUsd: 0.0001,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      saveSnapshot: async (snapshot) => snapshot,
+      updateRun: async (run) => run,
+      updatePublication,
+      getPublication: async () => publication,
+      createSnapshotId: () => 'snap-should-not-publish',
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      reason: 'S3 unavailable',
+    });
+    expect(publication.currentSnapshotId).toBe('snap-good');
+    expect(updatePublication).not.toHaveBeenCalled();
+  });
+});

--- a/amplify/functions/job-market-analyse/run.ts
+++ b/amplify/functions/job-market-analyse/run.ts
@@ -1,0 +1,120 @@
+import {
+  prepareActiveCorpusForAnalysis,
+  type JobDescriptionCorpusRecord,
+} from './corpus';
+import {
+  analyseCorpus,
+  type AnalyseCorpusDeps,
+  type CorpusSnapshotPayload,
+} from './analyse';
+import type { AnalysisRunRecord } from '../job-market-recompute/orchestrator';
+
+export type StoredCorpusSnapshot = {
+  id: string;
+  runId: string;
+  payload: CorpusSnapshotPayload;
+  createdAt: string;
+};
+
+export type LabPublicationPointer = {
+  currentSnapshotId: string;
+};
+
+export type ExecuteAnalysisRunDeps = {
+  runId: string;
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  loadMarkdown: (s3Key: string) => Promise<string>;
+  embed: AnalyseCorpusDeps['embed'];
+  getCachedEmbedding: AnalyseCorpusDeps['getCachedEmbedding'];
+  putCachedEmbedding: AnalyseCorpusDeps['putCachedEmbedding'];
+  saveSnapshot: (snapshot: StoredCorpusSnapshot) => Promise<StoredCorpusSnapshot>;
+  updateRun: (run: AnalysisRunRecord) => Promise<AnalysisRunRecord>;
+  updatePublication: (publication: LabPublicationPointer) => Promise<void>;
+  getPublication: () => Promise<LabPublicationPointer | null>;
+  createSnapshotId?: () => string;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export type ExecuteAnalysisRunResult =
+  | { status: 'succeeded'; snapshot: StoredCorpusSnapshot; run: AnalysisRunRecord }
+  | { status: 'failed'; reason: string };
+
+export async function executeAnalysisRun(
+  deps: ExecuteAnalysisRunDeps,
+): Promise<ExecuteAnalysisRunResult> {
+  const now = deps.now ?? new Date();
+
+  try {
+    await deps.updateRun({
+      id: deps.runId,
+      status: 'running',
+      createdAt: now.toISOString(),
+    });
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: deps.listJobDescriptions,
+      saveJobDescription: deps.saveJobDescription,
+      now,
+      maxAgeMonths: deps.maxAgeMonths,
+    });
+
+    const analyzable: Array<{
+      id: string;
+      contentHash: string;
+      markdown: string;
+      seniority?: string;
+      roleFamily?: string;
+      title?: string;
+    }> = [];
+    for (const record of active) {
+      const s3Key = record.s3Key ?? record.id;
+      const markdown = await deps.loadMarkdown(s3Key);
+      analyzable.push({
+        id: record.id,
+        contentHash: record.contentHash ?? record.id,
+        markdown,
+        seniority: record.seniority,
+        roleFamily: record.roleFamily,
+        title: record.title,
+      });
+    }
+
+    const analysis = await analyseCorpus(analyzable, {
+      embed: deps.embed,
+      getCachedEmbedding: deps.getCachedEmbedding,
+      putCachedEmbedding: deps.putCachedEmbedding,
+      now,
+    });
+
+    const snapshot: StoredCorpusSnapshot = {
+      id: deps.createSnapshotId?.() ?? `snap-${now.toISOString()}`,
+      runId: deps.runId,
+      payload: analysis.snapshot,
+      createdAt: now.toISOString(),
+    };
+
+    await deps.saveSnapshot(snapshot);
+    await deps.updatePublication({ currentSnapshotId: snapshot.id });
+
+    const run: AnalysisRunRecord = {
+      id: deps.runId,
+      status: 'succeeded',
+      createdAt: now.toISOString(),
+      ...analysis.metrics,
+    };
+    await deps.updateRun(run);
+
+    return { status: 'succeeded', snapshot, run };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'Analysis failed';
+    await deps.updateRun({
+      id: deps.runId,
+      status: 'failed',
+      createdAt: now.toISOString(),
+      errorMessage: reason,
+    });
+    return { status: 'failed', reason };
+  }
+}

--- a/amplify/functions/job-market-ingest/wiring.test.ts
+++ b/amplify/functions/job-market-ingest/wiring.test.ts
@@ -14,8 +14,14 @@ describe('job market lab ingest wiring', () => {
     expect(backendTs).toMatch(/prefix:\s*'raw\/'/);
   });
 
-  it('does not wire corpus recompute into the ingest path', () => {
-    expect(backendTs).not.toMatch(/recompute/i);
-    expect(backendTs).not.toMatch(/AnalysisRun/);
+  it('does not start recompute from the S3 ObjectCreated ingest notification', () => {
+    const notificationBlock =
+      backendTs.match(
+        /addEventNotification\([\s\S]*?\);\s*/,
+      )?.[0] ?? '';
+
+    expect(notificationBlock).toMatch(/jobMarketIngest\.resources\.lambda/);
+    expect(notificationBlock).not.toMatch(/jobMarketRecompute/);
+    expect(notificationBlock).not.toMatch(/AnalysisRun/);
   });
 });

--- a/amplify/functions/job-market-publication/handler.ts
+++ b/amplify/functions/job-market-publication/handler.ts
@@ -1,0 +1,31 @@
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { env } from '$amplify/env/job-market-publication';
+import type { Schema } from '../../data/resource';
+import type { CorpusSnapshotPayload } from '../job-market-analyse/analyse';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const PUBLICATION_ID = 'current';
+
+export const handler: Schema['getPublishedJobMarketSnapshot']['functionHandler'] =
+  async () => {
+    const publication = await client.models.LabPublication.get({
+      id: PUBLICATION_ID,
+    });
+    const snapshotId = publication.data?.currentSnapshotId;
+    if (!snapshotId) {
+      return null;
+    }
+
+    const snapshot = await client.models.CorpusSnapshot.get({ id: snapshotId });
+    if (!snapshot.data?.payload) {
+      return null;
+    }
+
+    return snapshot.data.payload as CorpusSnapshotPayload;
+  };

--- a/amplify/functions/job-market-publication/resource.ts
+++ b/amplify/functions/job-market-publication/resource.ts
@@ -1,0 +1,9 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Guest-readable publication query: LabPublication pointer → CorpusSnapshot payload.
+ */
+export const jobMarketPublication = defineFunction({
+  name: 'job-market-publication',
+  entry: './handler.ts',
+});

--- a/amplify/functions/job-market-recompute/handler.ts
+++ b/amplify/functions/job-market-recompute/handler.ts
@@ -1,0 +1,93 @@
+import type { Schema } from '../../data/resource';
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+import { env } from '$amplify/env/job-market-recompute';
+import {
+  DEFAULT_MAX_ACTIVE_DOCS,
+  startRecompute,
+  type AnalysisRunRecord,
+} from './orchestrator';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const lambda = new LambdaClient({});
+
+async function listInFlightRuns(): Promise<AnalysisRunRecord[]> {
+  const { data, errors } = await client.models.AnalysisRun.list({
+    filter: {
+      or: [
+        { status: { eq: 'queued' } },
+        { status: { eq: 'running' } },
+      ],
+    },
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return (data ?? []).map((run) => ({
+    id: run.id,
+    status: run.status as AnalysisRunRecord['status'],
+    createdAt: run.createdAt,
+  }));
+}
+
+async function countActiveDocuments(): Promise<number> {
+  const { data, errors } = await client.models.JobDescription.list({
+    filter: { status: { eq: 'active' } },
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return data?.length ?? 0;
+}
+
+async function createRun(run: AnalysisRunRecord): Promise<AnalysisRunRecord> {
+  const { data, errors } = await client.models.AnalysisRun.create({
+    id: run.id,
+    status: run.status,
+  });
+  if (errors?.length || !data) {
+    throw new Error(errors?.map((error) => error.message).join('; ') ?? 'Failed to create run');
+  }
+  return {
+    id: data.id,
+    status: data.status as AnalysisRunRecord['status'],
+    createdAt: data.createdAt,
+  };
+}
+
+async function invokeWorker(runId: string): Promise<void> {
+  const functionName = env.JOB_MARKET_ANALYSE_FUNCTION_NAME;
+  if (!functionName) {
+    throw new Error('JOB_MARKET_ANALYSE_FUNCTION_NAME is not configured');
+  }
+
+  await lambda.send(
+    new InvokeCommand({
+      FunctionName: functionName,
+      InvocationType: 'Event',
+      Payload: Buffer.from(JSON.stringify({ runId })),
+    }),
+  );
+}
+
+export const handler: Schema['startJobMarketRecompute']['functionHandler'] = async () => {
+  const result = await startRecompute({
+    listInFlightRuns,
+    countActiveDocuments,
+    createRun,
+    invokeWorker,
+    maxActiveDocs: Number(env.MAX_ACTIVE_DOCS ?? DEFAULT_MAX_ACTIVE_DOCS),
+  });
+
+  if (result.status === 'rejected') {
+    return { status: 'rejected', reason: result.reason };
+  }
+
+  return { status: 'started', runId: result.run.id };
+};

--- a/amplify/functions/job-market-recompute/orchestrator.test.ts
+++ b/amplify/functions/job-market-recompute/orchestrator.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MAX_ACTIVE_DOCS,
+  startRecompute,
+  type AnalysisRunRecord,
+} from './orchestrator';
+
+describe('startRecompute', () => {
+  it('rejects a second start while a run is queued or running (single-flight)', async () => {
+    const runs: AnalysisRunRecord[] = [
+      {
+        id: 'run-1',
+        status: 'running',
+        createdAt: '2026-07-14T10:00:00.000Z',
+      },
+    ];
+
+    const result = await startRecompute({
+      listInFlightRuns: async () =>
+        runs.filter((run) => run.status === 'queued' || run.status === 'running'),
+      countActiveDocuments: async () => 3,
+      createRun: vi.fn(),
+      invokeWorker: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
+    });
+  });
+
+  it('refuses recompute when the active corpus exceeds the document cap', async () => {
+    const result = await startRecompute({
+      listInFlightRuns: async () => [],
+      countActiveDocuments: async () => DEFAULT_MAX_ACTIVE_DOCS + 1,
+      createRun: vi.fn(),
+      invokeWorker: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: `Active corpus exceeds the ${DEFAULT_MAX_ACTIVE_DOCS}-document cap (${DEFAULT_MAX_ACTIVE_DOCS + 1} active)`,
+    });
+  });
+
+  it('starts a queued run and invokes the worker when the corpus is within caps', async () => {
+    const createRun = vi.fn(async (run: AnalysisRunRecord) => run);
+    const invokeWorker = vi.fn(async () => undefined);
+
+    const result = await startRecompute({
+      listInFlightRuns: async () => [],
+      countActiveDocuments: async () => 2,
+      createRun,
+      invokeWorker,
+      now: new Date('2026-07-14T12:00:00.000Z'),
+      createId: () => 'run-new',
+    });
+
+    expect(result).toEqual({
+      status: 'started',
+      run: {
+        id: 'run-new',
+        status: 'queued',
+        createdAt: '2026-07-14T12:00:00.000Z',
+      },
+    });
+    expect(createRun).toHaveBeenCalledOnce();
+    expect(invokeWorker).toHaveBeenCalledWith('run-new');
+  });
+});

--- a/amplify/functions/job-market-recompute/orchestrator.ts
+++ b/amplify/functions/job-market-recompute/orchestrator.ts
@@ -1,0 +1,67 @@
+export type AnalysisRunStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed';
+
+export type AnalysisRunRecord = {
+  id: string;
+  status: AnalysisRunStatus;
+  createdAt: string;
+  docsConsidered?: number;
+  docsEmbedded?: number;
+  docsCacheHit?: number;
+  clusterCount?: number;
+  bedrockInputTokens?: number;
+  estimatedCostUsd?: number;
+  errorMessage?: string;
+};
+
+export const DEFAULT_MAX_ACTIVE_DOCS = 150;
+
+export type StartRecomputeResult =
+  | { status: 'started'; run: AnalysisRunRecord }
+  | { status: 'rejected'; reason: string };
+
+export type StartRecomputeDeps = {
+  listInFlightRuns: () => Promise<AnalysisRunRecord[]>;
+  countActiveDocuments: () => Promise<number>;
+  createRun: (run: AnalysisRunRecord) => Promise<AnalysisRunRecord>;
+  invokeWorker: (runId: string) => Promise<void>;
+  now?: Date;
+  maxActiveDocs?: number;
+  createId?: () => string;
+};
+
+export async function startRecompute(
+  deps: StartRecomputeDeps,
+): Promise<StartRecomputeResult> {
+  const inFlight = await deps.listInFlightRuns();
+  if (inFlight.length > 0) {
+    return {
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
+    };
+  }
+
+  const maxActiveDocs = deps.maxActiveDocs ?? DEFAULT_MAX_ACTIVE_DOCS;
+  const activeCount = await deps.countActiveDocuments();
+  if (activeCount > maxActiveDocs) {
+    return {
+      status: 'rejected',
+      reason: `Active corpus exceeds the ${maxActiveDocs}-document cap (${activeCount} active)`,
+    };
+  }
+
+  const now = deps.now ?? new Date();
+  const run: AnalysisRunRecord = {
+    id: deps.createId?.() ?? `run-${now.toISOString()}`,
+    status: 'queued',
+    createdAt: now.toISOString(),
+  };
+
+  const created = await deps.createRun(run);
+  await deps.invokeWorker(created.id);
+
+  return { status: 'started', run: created };
+}

--- a/amplify/functions/job-market-recompute/resource.ts
+++ b/amplify/functions/job-market-recompute/resource.ts
@@ -1,0 +1,11 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Owner-only on-demand recompute orchestrator.
+ * Creates an AnalysisRun (single-flight + active-doc caps) and invokes the analyse worker.
+ */
+export const jobMarketRecompute = defineFunction({
+  name: 'job-market-recompute',
+  entry: './handler.ts',
+  timeoutSeconds: 60,
+});

--- a/amplify/functions/job-market-recompute/wiring.test.ts
+++ b/amplify/functions/job-market-recompute/wiring.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('job market recompute wiring', () => {
+  const backendTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'backend.ts'),
+    'utf8',
+  );
+  const authTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'auth', 'resource.ts'),
+    'utf8',
+  );
+  const dataTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'data', 'resource.ts'),
+    'utf8',
+  );
+
+  it('disables Cognito self-sign-up (admin create only)', () => {
+    expect(backendTs).toMatch(/allowAdminCreateUserOnly:\s*true/);
+    expect(authTs).toMatch(/loginWith:\s*\{[\s\S]*email:\s*true/);
+  });
+
+  it('wires recompute orchestration to the analyse worker', () => {
+    expect(backendTs).toMatch(/jobMarketRecompute/);
+    expect(backendTs).toMatch(/jobMarketAnalyse/);
+    expect(backendTs).toMatch(/JOB_MARKET_ANALYSE_FUNCTION_NAME/);
+    expect(backendTs).toMatch(/grantInvoke/);
+  });
+
+  it('exposes guest publication query and authenticated recompute mutation', () => {
+    expect(dataTs).toMatch(/getPublishedJobMarketSnapshot/);
+    expect(dataTs).toMatch(/startJobMarketRecompute/);
+    expect(dataTs).toMatch(/allow\.guest\(\)/);
+    expect(dataTs).toMatch(/AnalysisRun/);
+    expect(dataTs).toMatch(/CorpusSnapshot/);
+    expect(dataTs).toMatch(/LabPublication/);
+  });
+});

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -1,9 +1,11 @@
 import { defineStorage } from '@aws-amplify/backend';
 import { jobMarketIngest } from '../functions/job-market-ingest/resource';
+import { jobMarketAnalyse } from '../functions/job-market-analyse/resource';
 
 /**
  * Job market lab corpus storage.
  * raw/* — markdown JDs (ingest trigger wired in backend.ts for this prefix only).
+ * embeddings/* — contentHash embedding cache for the analyse worker.
  */
 export const storage = defineStorage({
   name: 'jobMarketLab',
@@ -11,8 +13,12 @@ export const storage = defineStorage({
     'raw/*': [
       allow.authenticated.to(['read', 'write', 'delete']),
       allow.resource(jobMarketIngest).to(['read']),
+      allow.resource(jobMarketAnalyse).to(['read']),
     ],
-    'embeddings/*': [allow.authenticated.to(['read', 'write', 'delete'])],
+    'embeddings/*': [
+      allow.authenticated.to(['read', 'write', 'delete']),
+      allow.resource(jobMarketAnalyse).to(['read', 'write']),
+    ],
     'artefacts/*': [allow.authenticated.to(['read', 'write', 'delete'])],
   }),
 });

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -15,6 +15,21 @@ Backend definitions live in `amplify/` (auth, data, storage, and the job-market 
 
 Script-first JD ingest: with sandbox/Hosting outputs present, `npm run ingest:jd -- path/to/file.md` uploads markdown to the `raw/` prefix; the ingest Lambda upserts `JobDescription` metadata and does not start recompute.
 
+Owner recompute (Cognito email/password, self-sign-up disabled via `allowAdminCreateUserOnly`): authenticated `startJobMarketRecompute` creates a single-flight `AnalysisRun` (refuses above 150 active docs), then asynchronously invokes the analyse worker. The worker reads active markdown from S3, uses Bedrock embeddings with a `embeddings/{contentHash}.json` cache, writes `CorpusSnapshot` + run metrics, and updates `LabPublication` only on success. Guests read aggregates only via `getPublishedJobMarketSnapshot`.
+
+### Minimal CloudWatch cost / alerting path
+
+After the Gen 2 backend is deployed, configure these in the AWS console (names only; no committed secrets):
+
+| Alarm / metric | Where | Suggested use |
+|----------------|--------|----------------|
+| `AWS/Lambda` `Errors` on `job-market-analyse` | CloudWatch alarm | Page on repeated worker failures |
+| `AWS/Lambda` `Duration` / `Throttles` on analyse + recompute | CloudWatch alarm | Catch runaway or concurrency issues |
+| `AWS/Bedrock` `Invocations` / model invocation latency | CloudWatch metrics (region of Bedrock) | Spot unexpected embed volume |
+| Estimated cost from `AnalysisRun.estimatedCostUsd` | App metric / log filter on analyse success logs | Spot spend anomalies before the next recompute |
+
+V1 does not ship a dedicated billing budget in CDK; create a Billing → Budgets alert for Bedrock + Lambda in the account that hosts the Amplify app if spend sensitivity is high. Run-level token/cost fields on `AnalysisRun` are the product-side source of truth for per-recompute cost.
+
 | Environment | Outputs file |
 |-------------|----------------|
 | **GitHub Actions / marketing-only local** | `amplify_outputs.json` is absent (gitignored). `readAmplifyOutputs()` returns null; `configureSiteAmplify` no-ops so public pages stay up. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,6 +3111,23 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -3126,6 +3143,23 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -6523,6 +6557,23 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -6538,6 +6589,23 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/semantic-conventions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "hashadar_website",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
+        "@aws-sdk/client-lambda": "^3.1086.0",
         "@aws-sdk/client-s3": "^3.1086.0",
         "@fontsource/zalando-sans-expanded": "^5.2.1",
         "aws-amplify": "^6.18.0",
@@ -3109,23 +3111,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -3141,23 +3126,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -6555,23 +6523,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -6587,23 +6538,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -8998,6 +8932,46 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1086.0.tgz",
+      "integrity": "sha512-IuzaMjeJ3P7UnVamYnKlNoR/DAZqybRX4zYEqH7giwm31DuluB2qplydyjSxF07H3/5iuc6lCUbMI7pD/m0yng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.67",
+        "@aws-sdk/eventstream-handler-node": "^3.972.26",
+        "@aws-sdk/middleware-eventstream": "^3.972.22",
+        "@aws-sdk/middleware-websocket": "^3.972.39",
+        "@aws-sdk/token-providers": "3.1086.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1086.0.tgz",
+      "integrity": "sha512-/d1uB//QrUnIuHmYsB+VByGvezOwiICHZU1JFxLxCcDrmR/zZlfV5sjh91SPvRiK04ckL3GhPeO6L2qG33TKeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cloudcontrol": {
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudcontrol/-/client-cloudcontrol-3.1086.0.tgz",
@@ -9241,7 +9215,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1086.0.tgz",
       "integrity": "sha512-IxsHC4BM1nrSBhJJvZe9ELpPmEl8ZeSZLKoc7sACU2icKqMMF1X06Q78s7NSSoafuTI8xRnFKh7BRHfaGNLvGA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -9650,6 +9623,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
+      "integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/lib-storage": {
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1086.0.tgz",
@@ -9669,6 +9657,21 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3.1086.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
+      "integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
@@ -9737,6 +9740,24 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
+      "integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "node": ">=22"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
+    "@aws-sdk/client-lambda": "^3.1086.0",
     "@aws-sdk/client-s3": "^3.1086.0",
     "@fontsource/zalando-sans-expanded": "^5.2.1",
     "aws-amplify": "^6.18.0",

--- a/src/lib/job-market-corpus.test.ts
+++ b/src/lib/job-market-corpus.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  archiveJobDescription,
+  prepareActiveCorpusForAnalysis,
+  restoreJobDescription,
+  type JobDescriptionCorpusRecord,
+} from './job-market-corpus';
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('archiveJobDescription', () => {
+  it('soft-archives an active JobDescription so it no longer counts as active for analysis', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['jd-1', doc({ id: 'jd-1' })],
+      ['jd-2', doc({ id: 'jd-2' })],
+    ]);
+
+    const result = await archiveJobDescription('jd-1', {
+      getJobDescription: async (id) => store.get(id) ?? null,
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'archived',
+      record: expect.objectContaining({ id: 'jd-1', status: 'archived' }),
+    });
+    expect(store.get('jd-1')?.status).toBe('archived');
+    expect(store.has('jd-1')).toBe(true);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+    });
+
+    expect(active.map((record) => record.id)).toEqual(['jd-2']);
+  });
+
+  it('keeps soft-archived records recoverable without hard delete', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['jd-1', doc({ id: 'jd-1', status: 'archived' })],
+    ]);
+
+    const restored = await restoreJobDescription('jd-1', {
+      getJobDescription: async (id) => store.get(id) ?? null,
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+    });
+
+    expect(restored).toEqual({
+      status: 'restored',
+      record: expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    });
+    expect(store.get('jd-1')).toEqual(
+      expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    );
+  });
+});
+
+describe('prepareActiveCorpusForAnalysis', () => {
+  it('auto-archives documents older than the configured age window during the sweep', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      [
+        'old',
+        doc({
+          id: 'old',
+          collectedAt: '2024-01-01T00:00:00.000Z',
+        }),
+      ],
+      [
+        'fresh',
+        doc({
+          id: 'fresh',
+          collectedAt: '2026-06-01T00:00:00.000Z',
+        }),
+      ],
+    ]);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+      maxAgeMonths: 18,
+    });
+
+    expect(store.get('old')?.status).toBe('archived');
+    expect(store.get('fresh')?.status).toBe('active');
+    expect(active.map((record) => record.id)).toEqual(['fresh']);
+  });
+
+  it('excludes archived documents from the active analysis corpus', async () => {
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [
+        doc({ id: 'active-1', status: 'active' }),
+        doc({ id: 'archived-1', status: 'archived' }),
+        doc({ id: 'active-2', status: 'active' }),
+      ],
+      saveJobDescription: async () => undefined,
+      now: new Date('2026-07-14T00:00:00.000Z'),
+    });
+
+    expect(active.map((record) => record.id)).toEqual(['active-1', 'active-2']);
+  });
+
+  it('treats the age window as exclusive of the exact cutoff instant', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      [
+        'on-cutoff',
+        doc({
+          id: 'on-cutoff',
+          // Exactly 18 months before now
+          collectedAt: '2025-01-14T00:00:00.000Z',
+        }),
+      ],
+    ]);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+      maxAgeMonths: 18,
+    });
+
+    expect(store.get('on-cutoff')?.status).toBe('active');
+    expect(active.map((record) => record.id)).toEqual(['on-cutoff']);
+  });
+});

--- a/src/lib/job-market-corpus.ts
+++ b/src/lib/job-market-corpus.ts
@@ -1,0 +1,120 @@
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionCorpusRecord = {
+  id: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+  s3Key?: string;
+  contentHash?: string;
+};
+
+export const DEFAULT_MAX_AGE_MONTHS = 18;
+
+export type ArchiveJobDescriptionDeps = {
+  getJobDescription: (id: string) => Promise<JobDescriptionCorpusRecord | null>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+};
+
+export type ArchiveJobDescriptionResult =
+  | { status: 'archived'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_archived'; record: JobDescriptionCorpusRecord };
+
+export type PrepareActiveCorpusDeps = {
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export function selectActiveCorpus(
+  records: JobDescriptionCorpusRecord[],
+): JobDescriptionCorpusRecord[] {
+  return records.filter((record) => record.status === 'active');
+}
+
+export function isOlderThanAgeWindow(
+  collectedAt: string,
+  now: Date,
+  maxAgeMonths: number = DEFAULT_MAX_AGE_MONTHS,
+): boolean {
+  const collected = new Date(collectedAt);
+  if (Number.isNaN(collected.getTime())) {
+    return false;
+  }
+
+  const cutoff = new Date(now);
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - maxAgeMonths);
+  return collected.getTime() < cutoff.getTime();
+}
+
+export type RestoreJobDescriptionResult =
+  | { status: 'restored'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_active'; record: JobDescriptionCorpusRecord };
+
+export async function archiveJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<ArchiveJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'archived') {
+    return { status: 'already_archived', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'archived',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'archived', record };
+}
+
+export async function restoreJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<RestoreJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'active') {
+    return { status: 'already_active', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'active',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'restored', record };
+}
+
+export async function prepareActiveCorpusForAnalysis(
+  deps: PrepareActiveCorpusDeps,
+): Promise<JobDescriptionCorpusRecord[]> {
+  const now = deps.now ?? new Date();
+  const maxAgeMonths = deps.maxAgeMonths ?? DEFAULT_MAX_AGE_MONTHS;
+  const records = await deps.listJobDescriptions();
+
+  for (const record of records) {
+    if (
+      record.status === 'active' &&
+      isOlderThanAgeWindow(record.collectedAt, now, maxAgeMonths)
+    ) {
+      await deps.saveJobDescription({ ...record, status: 'archived' });
+    }
+  }
+
+  const refreshed = await deps.listJobDescriptions();
+  return selectActiveCorpus(refreshed);
+}

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getPublishedJobMarketSnapshot } from './job-market-lab';
+import {
+  getPublishedJobMarketSnapshot,
+  startJobMarketRecompute,
+} from './job-market-lab';
 
 describe('getPublishedJobMarketSnapshot', () => {
   it('returns empty when nothing is published', async () => {
@@ -14,6 +17,11 @@ describe('getPublishedJobMarketSnapshot', () => {
     const snapshot = {
       documentCount: 3,
       publishedAt: '2026-07-01T00:00:00.000Z',
+      skills: [{ name: 'python', count: 3 }],
+      seniority: [{ name: 'senior', count: 2 }],
+      roleFamily: [{ name: 'data-science', count: 2 }],
+      clusters: [{ id: 0, size: 3, label: 'Theme 1' }],
+      projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
     };
 
     const result = await getPublishedJobMarketSnapshot({
@@ -29,6 +37,11 @@ describe('getPublishedJobMarketSnapshot', () => {
         ({
           documentCount: 1,
           publishedAt: '2026-07-01T00:00:00.000Z',
+          skills: [],
+          seniority: [],
+          roleFamily: [],
+          clusters: [],
+          projection: [],
           rawText: 'Acme Corp seeks a data scientist…',
           source: 'confidential-board',
           employer: 'Acme Corp',
@@ -40,7 +53,28 @@ describe('getPublishedJobMarketSnapshot', () => {
       snapshot: {
         documentCount: 1,
         publishedAt: '2026-07-01T00:00:00.000Z',
+        skills: [],
+        seniority: [],
+        roleFamily: [],
+        clusters: [],
+        projection: [],
       },
+    });
+  });
+});
+
+describe('startJobMarketRecompute', () => {
+  it('returns the orchestrator result through the lab facade', async () => {
+    const result = await startJobMarketRecompute({
+      startRecompute: async () => ({
+        status: 'rejected',
+        reason: 'An analysis run is already in progress',
+      }),
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
     });
   });
 });

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -13,6 +13,16 @@ export type GetPublishedJobMarketSnapshotDeps = {
   fetchPublished?: FetchPublishedJobMarketSnapshot;
 };
 
+export {
+  archiveJobDescription,
+  restoreJobDescription,
+  prepareActiveCorpusForAnalysis,
+  selectActiveCorpus,
+  DEFAULT_MAX_AGE_MONTHS,
+  type JobDescriptionCorpusRecord,
+  type JobDescriptionStatus,
+} from './job-market-corpus';
+
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
   // Guest publication query lands in a later slice; until then nothing is published.
   return null;

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -1,6 +1,33 @@
+export type SkillFrequency = {
+  name: string;
+  count: number;
+};
+
+export type TaxonomyBucket = {
+  name: string;
+  count: number;
+};
+
+export type ClusterSummary = {
+  id: number;
+  size: number;
+  label: string;
+};
+
+export type ProjectionPoint = {
+  x: number;
+  y: number;
+  clusterId: number;
+};
+
 export type JobMarketSnapshot = {
   documentCount: number;
   publishedAt: string;
+  skills: SkillFrequency[];
+  seniority: TaxonomyBucket[];
+  roleFamily: TaxonomyBucket[];
+  clusters: ClusterSummary[];
+  projection: ProjectionPoint[];
 };
 
 export type PublishedJobMarketResult =
@@ -13,6 +40,16 @@ export type GetPublishedJobMarketSnapshotDeps = {
   fetchPublished?: FetchPublishedJobMarketSnapshot;
 };
 
+export type StartJobMarketRecomputeResult =
+  | { status: 'started'; runId: string }
+  | { status: 'rejected'; reason: string };
+
+export type StartJobMarketRecompute = () => Promise<StartJobMarketRecomputeResult>;
+
+export type StartJobMarketRecomputeDeps = {
+  startRecompute?: StartJobMarketRecompute;
+};
+
 export {
   archiveJobDescription,
   restoreJobDescription,
@@ -23,9 +60,28 @@ export {
   type JobDescriptionStatus,
 } from './job-market-corpus';
 
+function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
+  return {
+    documentCount: snapshot.documentCount,
+    publishedAt: snapshot.publishedAt,
+    skills: snapshot.skills ?? [],
+    seniority: snapshot.seniority ?? [],
+    roleFamily: snapshot.roleFamily ?? [],
+    clusters: snapshot.clusters ?? [],
+    projection: snapshot.projection ?? [],
+  };
+}
+
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
-  // Guest publication query lands in a later slice; until then nothing is published.
+  // Wiring to Amplify getPublishedJobMarketSnapshot lands with sandbox/outputs.
   return null;
+}
+
+async function defaultStartRecompute(): Promise<StartJobMarketRecomputeResult> {
+  return {
+    status: 'rejected',
+    reason: 'Recompute client is not configured',
+  };
 }
 
 export async function getPublishedJobMarketSnapshot(
@@ -40,9 +96,13 @@ export async function getPublishedJobMarketSnapshot(
 
   return {
     status: 'published',
-    snapshot: {
-      documentCount: snapshot.documentCount,
-      publishedAt: snapshot.publishedAt,
-    },
+    snapshot: sanitizeSnapshot(snapshot),
   };
+}
+
+export async function startJobMarketRecompute(
+  deps: StartJobMarketRecomputeDeps = {},
+): Promise<StartJobMarketRecomputeResult> {
+  const start = deps.startRecompute ?? defaultStartRecompute;
+  return start();
 }


### PR DESCRIPTION
## Summary
- Disables Cognito self-sign-up (`allowAdminCreateUserOnly`) so only an invited owner can administer the lab.
- Adds `startJobMarketRecompute` orchestration: single-flight `AnalysisRun`, 150-doc active corpus cap, async invoke of the analyse worker.
- Analyse worker prepares the active corpus (archive/age hygiene), embeds with contentHash cache (Bedrock stubbed in tests), writes `CorpusSnapshot` + run metrics, and updates `LabPublication` only on success; failures leave the last good publication intact.
- Guests fetch aggregates via `getPublishedJobMarketSnapshot`; lab facade covers published/empty + start-recompute seams.
- Documents a minimal CloudWatch cost/alerting path in `docs/CI-AND-DEPLOYMENT.md`.

Closes #39

## Test plan
- [ ] `npm test` — orchestrator, analyse, run, wiring, and facade tests pass
- [ ] `npm run typecheck` and `npm run lint`
- [ ] Merge/stack after #38 (`feat/job-market-lab-archive-38` / PR #46)
- [ ] Sandbox: invite owner user, confirm self-sign-up rejected
- [ ] Sandbox: start recompute with a small active corpus; guest query returns snapshot
- [ ] Sandbox: second overlapping start is rejected; forced worker failure leaves prior publication
- [ ] Confirm CloudWatch alarm guidance in `docs/CI-AND-DEPLOYMENT.md`

## Stacking
Targets `feat/job-market-lab-archive-38` (issue #38). Retarget to `develop` after #38 merges, or merge the stack in order.

Made with [Cursor](https://cursor.com)