### PR TITLE
Wire live published snapshot on job market lab (#50)

### DIFF
--- a/src/lib/fetch-published-job-market-snapshot.test.ts
+++ b/src/lib/fetch-published-job-market-snapshot.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fetchPublishedSnapshotViaQuery,
+  publishedQueryFromClient,
+} from './fetch-published-job-market-snapshot';
+import { getPublishedJobMarketSnapshot } from './job-market-lab';
+
+describe('fetchPublishedSnapshotViaQuery', () => {
+  it('yields empty publication when the query returns null data', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery({
+          getPublishedJobMarketSnapshot: async () => ({ data: null }),
+        }),
+    });
+
+    expect(result).toEqual({ status: 'empty' });
+  });
+
+  it('yields empty publication when the query returns errors', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery({
+          getPublishedJobMarketSnapshot: async () => ({
+            data: { documentCount: 1 },
+            errors: [{ message: 'Unauthorised' }],
+          }),
+        }),
+    });
+
+    expect(result).toEqual({ status: 'empty' });
+  });
+
+  it('yields published and sanitised snapshot when the query returns a payload', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery({
+          getPublishedJobMarketSnapshot: async () => ({
+            data: {
+              documentCount: 2,
+              publishedAt: '2026-07-14T12:00:00.000Z',
+              skills: [{ name: 'python', count: 2 }],
+              seniority: [{ name: 'senior', count: 1 }],
+              roleFamily: [{ name: 'engineering', count: 2 }],
+              clusters: [{ id: 0, size: 2, label: 'Theme A' }],
+              projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
+              employer: 'must-not-leak',
+            },
+          }),
+        }),
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      snapshot: {
+        documentCount: 2,
+        publishedAt: '2026-07-14T12:00:00.000Z',
+        skills: [{ name: 'python', count: 2 }],
+        seniority: [{ name: 'senior', count: 1 }],
+        roleFamily: [{ name: 'engineering', count: 2 }],
+        clusters: [{ id: 0, size: 2, label: 'Theme A' }],
+        projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
+      },
+    });
+  });
+
+  it('only invokes the published query — never lists historical snapshots', async () => {
+    const client = {
+      queries: {
+        getPublishedJobMarketSnapshot: async () => ({
+          data: {
+            documentCount: 1,
+            publishedAt: '2026-07-14T12:00:00.000Z',
+            skills: [],
+            seniority: [],
+            roleFamily: [],
+            clusters: [],
+            projection: [],
+          },
+        }),
+      },
+      models: {
+        CorpusSnapshot: {
+          list: async () => {
+            throw new Error('guests must not list CorpusSnapshot');
+          },
+        },
+        LabPublication: {
+          list: async () => {
+            throw new Error('guests must not list LabPublication');
+          },
+        },
+      },
+    };
+
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery(publishedQueryFromClient(client)),
+    });
+
+    expect(result.status).toBe('published');
+  });
+});

--- a/src/lib/fetch-published-job-market-snapshot.ts
+++ b/src/lib/fetch-published-job-market-snapshot.ts
@@ -1,0 +1,55 @@
+import type { JobMarketSnapshot } from './job-market-lab';
+
+export type PublishedJobMarketQuery = {
+  getPublishedJobMarketSnapshot: () => Promise<{
+    data: unknown;
+    errors?: Array<{ message: string }>;
+  }>;
+};
+
+/** Amplify client shape limited to the guest-safe published query. */
+export type AmplifyPublishedSnapshotClient = {
+  queries: {
+    getPublishedJobMarketSnapshot: () => Promise<{
+      data: unknown;
+      errors?: Array<{ message: string }>;
+    }>;
+  };
+};
+
+/** Builds a query seam that only calls getPublishedJobMarketSnapshot — never model list APIs. */
+export function publishedQueryFromClient(
+  client: AmplifyPublishedSnapshotClient,
+): PublishedJobMarketQuery {
+  return {
+    getPublishedJobMarketSnapshot: () =>
+      client.queries.getPublishedJobMarketSnapshot(),
+  };
+}
+
+export async function fetchPublishedSnapshotViaQuery(
+  query: PublishedJobMarketQuery,
+): Promise<JobMarketSnapshot | null> {
+  const { data, errors } = await query.getPublishedJobMarketSnapshot();
+
+  if (errors?.length || data == null) {
+    return null;
+  }
+
+  if (typeof data === 'object' && !Array.isArray(data)) {
+    return data as JobMarketSnapshot;
+  }
+
+  if (typeof data === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(data);
+      if (typeof parsed === 'object' && parsed != null && !Array.isArray(parsed)) {
+        return parsed as JobMarketSnapshot;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -61,6 +61,12 @@ describe('getPublishedJobMarketSnapshot', () => {
       },
     });
   });
+
+  it('returns empty from the default Amplify path when outputs are absent', async () => {
+    const result = await getPublishedJobMarketSnapshot();
+
+    expect(result).toEqual({ status: 'empty' });
+  });
 });
 
 describe('startJobMarketRecompute', () => {

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -1,3 +1,13 @@
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { configureSiteAmplify } from './configure-site-amplify';
+import {
+  fetchPublishedSnapshotViaQuery,
+  publishedQueryFromClient,
+  type AmplifyPublishedSnapshotClient,
+} from './fetch-published-job-market-snapshot';
+import { readAmplifyOutputs } from './read-amplify-outputs';
+
 export type SkillFrequency = {
   name: string;
   count: number;
@@ -73,8 +83,25 @@ function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
 }
 
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
-  // Wiring to Amplify getPublishedJobMarketSnapshot lands with sandbox/outputs.
-  return null;
+  try {
+    const outputs = readAmplifyOutputs();
+    if (!outputs) {
+      return null;
+    }
+
+    configureSiteAmplify(outputs, (config, options) => {
+      Amplify.configure(config, options);
+    });
+
+    // Guest-safe auth: default data mode is userPool; allow.guest needs identityPool.
+    const client = generateClient({
+      authMode: 'identityPool',
+    }) as AmplifyPublishedSnapshotClient;
+
+    return fetchPublishedSnapshotViaQuery(publishedQueryFromClient(client));
+  } catch {
+    return null;
+  }
 }
 
 async function defaultStartRecompute(): Promise<StartJobMarketRecomputeResult> {


### PR DESCRIPTION
## Summary
- Wires the job market lab facade default fetch to Amplify `getPublishedJobMarketSnapshot` (guest `identityPool`), sanitising through the existing lab API seam.
- `/labs/job-market` shows published aggregates when a LabPublication pointer exists, or the intentional empty state when nothing is published / outputs are absent.
- Guests only use the published query path — no historical snapshot listing.

Closes #50

## Test plan
- [ ] `npm test` / typecheck / lint green in CI
- [ ] With `amplify_outputs.json` absent, page shows empty state (not an error)
- [ ] With sandbox + published snapshot, lab shows metrics from facade
- [ ] Confirm tests cover published vs empty and that list APIs are not invoked

Made with [Cursor](https://cursor.com)