### PR TITLE
Add owner sign-in via site login page (#49)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { site } from "@/data";
 import { AmplifyProvider } from "@/components/amplify-provider";
+import { SiteAuthRoot } from "@/components/site-auth-root";
 import { StructuredData } from "@/components/seo/structured-data";
 import { ThemeScript } from "@/components/theme-script";
 import { readAmplifyOutputs } from "@/lib/read-amplify-outputs";
@@ -60,7 +61,9 @@ export default function RootLayout({
         <StructuredData />
       </head>
       <body className="antialiased">
-        <AmplifyProvider outputs={amplifyOutputs}>{children}</AmplifyProvider>
+        <AmplifyProvider outputs={amplifyOutputs}>
+          <SiteAuthRoot outputs={amplifyOutputs}>{children}</SiteAuthRoot>
+        </AmplifyProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { LoginSection } from '@/components/sections/login/login-section';
+import { getPageData, site } from '@/data';
+
+const login = getPageData('/login');
+
+export const metadata: Metadata = {
+  title: `${login.heading} - ${site.metadata.author}`,
+  description: login.description,
+  openGraph: {
+    title: `${login.heading} - ${site.metadata.author}`,
+    description: login.description,
+    url: `${site.metadata.siteUrl}/login`,
+    type: 'website',
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function LoginPage() {
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <LoginSection />
+    </SitePage>
+  );
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -57,6 +57,18 @@ describe('sitemap', () => {
     });
   });
 
+  it('includes the owner login route', () => {
+    const entries = sitemap();
+    const loginEntry = entries.find((entry) => entry.url === `${site.metadata.siteUrl}/login`);
+
+    expect(loginEntry).toEqual({
+      url: `${site.metadata.siteUrl}/login`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    });
+  });
+
   it('includes blog post URLs with lastModified dates from the reader module', () => {
     const posts = getAllBlogPosts(fixturesDir);
     const entries = buildSitemap(fixturesDir);

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -43,6 +43,9 @@ export function FooterSection() {
                     {email}
                   </a>
                 </Text>
+                <NavLink href={footer.contact.ownerSignIn.href}>
+                  {footer.contact.ownerSignIn.label}
+                </NavLink>
               </div>
             </FooterColumn>
 

--- a/src/components/sections/login/login-section.test.tsx
+++ b/src/components/sections/login/login-section.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { LoginSection } from '@/components/sections/login/login-section';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { login } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderLogin(auth = createMemorySiteAuth()) {
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <LoginSection />
+    </SiteAuthProvider>,
+  );
+}
+
+describe('LoginSection', () => {
+  it('shows the sign-in form without registration copy when unauthenticated', async () => {
+    renderLogin();
+
+    expect(await screen.findByRole('heading', { name: login.heading })).toBeInTheDocument();
+    expect(screen.getByLabelText(login.emailLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText(login.passwordLabel)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: login.submitLabel })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: login.signOutLabel })).not.toBeInTheDocument();
+    expect(screen.queryByText(/create account|register|sign up/i)).not.toBeInTheDocument();
+  });
+
+  it('shows signed-in state and sign-out after a successful sign-in', async () => {
+    const user = userEvent.setup();
+    const auth = createMemorySiteAuth();
+    renderLogin(auth);
+
+    await user.type(await screen.findByLabelText(login.emailLabel), 'owner@example.com');
+    await user.type(screen.getByLabelText(login.passwordLabel), 'secret');
+    await user.click(screen.getByRole('button', { name: login.submitLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: login.signedInHeading })).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(login.signedInDescription.replace('{email}', 'owner@example.com')),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: login.signOutLabel })).toBeInTheDocument();
+    expect(screen.queryByLabelText(login.passwordLabel)).not.toBeInTheDocument();
+  });
+
+  it('returns to the sign-in form after sign-out', async () => {
+    const user = userEvent.setup();
+    const auth = createMemorySiteAuth({
+      status: 'authenticated',
+      email: 'owner@example.com',
+    });
+    renderLogin(auth);
+
+    await user.click(await screen.findByRole('button', { name: login.signOutLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(login.passwordLabel)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: login.signOutLabel })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sections/login/login-section.tsx
+++ b/src/components/sections/login/login-section.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import {
+  Button,
+  Container,
+  Heading,
+  Section,
+  Text,
+} from '@/components/ui';
+import { login } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+
+const fieldClassName =
+  'mt-2 w-full border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]';
+
+export function LoginSection() {
+  const { session, isLoading, signIn, signOut } = useSiteAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    if (!email.trim() || !password) {
+      setError(login.errors.required);
+      return;
+    }
+
+    setIsSubmitting(true);
+    const result = await signIn(email.trim(), password);
+    setIsSubmitting(false);
+
+    if (result.status === 'failed') {
+      setError(result.reason);
+      return;
+    }
+
+    setPassword('');
+  }
+
+  async function handleSignOut() {
+    setError(null);
+    await signOut();
+  }
+
+  if (isLoading || session === null) {
+    return (
+      <Section className="py-20">
+        <Container>
+          <Text variant="muted">Checking session…</Text>
+        </Container>
+      </Section>
+    );
+  }
+
+  if (session.status === 'authenticated') {
+    return (
+      <Section className="py-20">
+        <Container>
+          <div className="mx-auto max-w-md space-y-6">
+            <Heading size="md" as="h1">
+              {login.signedInHeading}
+            </Heading>
+            <Text>
+              {login.signedInDescription.replace('{email}', session.email)}
+            </Text>
+            <Button type="button" variant="outline" onClick={() => void handleSignOut()}>
+              {login.signOutLabel}
+            </Button>
+          </div>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mx-auto max-w-md space-y-8">
+          <div className="space-y-4">
+            <Heading size="md" as="h1">
+              {login.heading}
+            </Heading>
+            <Text variant="muted">{login.description}</Text>
+          </div>
+
+          <form className="space-y-6" onSubmit={(event) => void handleSubmit(event)} noValidate>
+            <div>
+              <label htmlFor="login-email" className="font-body text-sm text-[var(--foreground)]">
+                {login.emailLabel}
+              </label>
+              <input
+                id="login-email"
+                name="email"
+                type="email"
+                autoComplete="username"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className={fieldClassName}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="login-password" className="font-body text-sm text-[var(--foreground)]">
+                {login.passwordLabel}
+              </label>
+              <input
+                id="login-password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className={fieldClassName}
+              />
+            </div>
+
+            {error ? (
+              <p
+                role="alert"
+                className="font-body text-base leading-relaxed text-[var(--destructive,var(--primary))]"
+              >
+                {error}
+              </p>
+            ) : null}
+
+            <Button type="submit" disabled={isSubmitting}>
+              {login.submitLabel}
+            </Button>
+          </form>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/site-auth-root.tsx
+++ b/src/components/site-auth-root.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useMemo, type ReactNode } from 'react';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import type { AmplifyOutputs } from '@/lib/configure-site-amplify';
+import { createSiteAuthFromOutputs } from '@/lib/site-auth';
+
+type SiteAuthRootProps = {
+  children: ReactNode;
+  outputs: AmplifyOutputs | null;
+};
+
+export function SiteAuthRoot({ children, outputs }: SiteAuthRootProps) {
+  const auth = useMemo(() => createSiteAuthFromOutputs(outputs), [outputs]);
+
+  return <SiteAuthProvider auth={auth}>{children}</SiteAuthProvider>;
+}

--- a/src/data/common/footer.json
+++ b/src/data/common/footer.json
@@ -9,7 +9,11 @@
       "github": "https://github.com/hashadar",
       "linkedin": "https://linkedin.com/in/hdar"
     },
-    "copyright": "© 2026 hasha dar. All rights reserved."
+    "copyright": "© 2026 hasha dar. All rights reserved.",
+    "ownerSignIn": {
+      "label": "Owner sign in",
+      "href": "/login"
+    }
   }
 }
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -4,6 +4,7 @@ import aboutData from './pages/about.json';
 import blogData from './pages/blog.json';
 import labsData from './pages/labs.json';
 import jobMarketLabData from './pages/job-market-lab.json';
+import loginData from './pages/login.json';
 import footerData from './common/footer.json';
 import navigationData from './common/navigation.json';
 import siteData from './common/site.json';
@@ -16,6 +17,7 @@ import type {
   BlogPageData,
   LabsPageData,
   JobMarketLabPageData,
+  LoginPageData,
   CareerProfile,
   FooterData,
   NavigationData,
@@ -29,6 +31,7 @@ import {
   assertValidHomePage,
   assertValidJobMarketLabPage,
   assertValidLabsPage,
+  assertValidLoginPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -41,6 +44,7 @@ validateDataFile('pages/about.json', aboutData, assertValidAboutPage);
 validateDataFile('pages/blog.json', blogData, assertValidBlogPage);
 validateDataFile('pages/labs.json', labsData, assertValidLabsPage);
 validateDataFile('pages/job-market-lab.json', jobMarketLabData, assertValidJobMarketLabPage);
+validateDataFile('pages/login.json', loginData, assertValidLoginPage);
 validateDataFile('common/footer.json', footerData, assertValidFooter);
 validateDataFile('common/navigation.json', navigationData, assertValidNavigation);
 validateDataFile('common/site.json', siteData, assertValidSite);
@@ -52,6 +56,7 @@ export const about = aboutData as AboutPageData;
 export const blog = blogData as BlogPageData;
 export const labs = labsData as LabsPageData;
 export const jobMarketLab = jobMarketLabData as JobMarketLabPageData;
+export const login = loginData as LoginPageData;
 export const careerProfile = careerProfileData as CareerProfile;
 
 export { getHomeExperienceView, getAboutExperienceView } from './profile/experience-slices';
@@ -71,6 +76,7 @@ export function getPageData(route: '/blog'): BlogPageData;
 export function getPageData(route: '/portfolio'): PortfolioPageData;
 export function getPageData(route: '/labs'): LabsPageData;
 export function getPageData(route: '/labs/job-market'): JobMarketLabPageData;
+export function getPageData(route: '/login'): LoginPageData;
 export function getPageData(
   route: string,
 ):
@@ -80,6 +86,7 @@ export function getPageData(
   | PortfolioPageData
   | LabsPageData
   | JobMarketLabPageData
+  | LoginPageData
   | null;
 export function getPageData(route: string) {
   switch (route) {
@@ -96,6 +103,8 @@ export function getPageData(route: string) {
       return labs;
     case '/labs/job-market':
       return jobMarketLab;
+    case '/login':
+      return login;
     default:
       return null;
   }

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -7,6 +7,7 @@ import {
   home,
   labs,
   jobMarketLab,
+  login,
   portfolio,
   footer,
   navigation,
@@ -22,6 +23,15 @@ describe('getPageData', () => {
     expect(getPageData('/portfolio')).toBe(portfolio);
     expect(getPageData('/labs')).toBe(labs);
     expect(getPageData('/labs/job-market')).toBe(jobMarketLab);
+    expect(getPageData('/login')).toBe(login);
+  });
+
+  it('returns British English owner sign-in copy without registration', () => {
+    const page = getPageData('/login');
+    expect(page?.heading).toBe('Owner sign in');
+    expect(page?.submitLabel).toBe('Sign in');
+    expect(page?.signOutLabel).toBe('Sign out');
+    expect(JSON.stringify(page)).not.toMatch(/create account|register|sign up/i);
   });
 
   it('returns null for unknown routes', () => {
@@ -37,5 +47,12 @@ describe('getCommonData', () => {
 
   it('includes a Labs navigation link to the Labs index', () => {
     expect(navigation.links).toContainEqual({ label: 'Labs', href: '/labs' });
+  });
+
+  it('includes a discreet owner sign-in link in the footer', () => {
+    expect(footer.contact.ownerSignIn).toEqual({
+      label: 'Owner sign in',
+      href: '/login',
+    });
   });
 });

--- a/src/data/pages/login.json
+++ b/src/data/pages/login.json
@@ -1,0 +1,15 @@
+{
+  "heading": "Owner sign in",
+  "description": "Sign in with the email and password for your invited owner account. Self-registration is not available.",
+  "emailLabel": "Email",
+  "passwordLabel": "Password",
+  "submitLabel": "Sign in",
+  "signOutLabel": "Sign out",
+  "signedInHeading": "Signed in",
+  "signedInDescription": "You are signed in as {email}.",
+  "errors": {
+    "generic": "Sign-in failed. Check your email and password, then try again.",
+    "notConfigured": "Sign-in is unavailable because authentication is not configured.",
+    "required": "Enter your email and password to continue."
+  }
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -155,6 +155,24 @@ export interface JobMarketLabPageData {
   clustersHeading: string;
 }
 
+export interface LoginPageErrors {
+  generic: string;
+  notConfigured: string;
+  required: string;
+}
+
+export interface LoginPageData {
+  heading: string;
+  description: string;
+  emailLabel: string;
+  passwordLabel: string;
+  submitLabel: string;
+  signOutLabel: string;
+  signedInHeading: string;
+  signedInDescription: string;
+  errors: LoginPageErrors;
+}
+
 // Common/shared types
 export interface SocialLinks {
   github: string;
@@ -169,6 +187,7 @@ export interface ContactInfo {
   email: string;
   social: SocialLinks;
   copyright: string;
+  ownerSignIn: NavLink;
 }
 
 export interface FooterData {

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -7,6 +7,7 @@ import {
   assertValidHomePage,
   assertValidJobMarketLabPage,
   assertValidLabsPage,
+  assertValidLoginPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -18,6 +19,7 @@ import blogData from '@/data/pages/blog.json';
 import portfolioData from '@/data/pages/portfolio.json';
 import labsData from '@/data/pages/labs.json';
 import jobMarketLabData from '@/data/pages/job-market-lab.json';
+import loginData from '@/data/pages/login.json';
 import footerData from '@/data/common/footer.json';
 import navigationData from '@/data/common/navigation.json';
 import siteData from '@/data/common/site.json';
@@ -55,6 +57,9 @@ describe('validateDataFile', () => {
         jobMarketLabData,
         assertValidJobMarketLabPage,
       ),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('pages/login.json', loginData, assertValidLoginPage),
     ).not.toThrow();
     expect(() =>
       validateDataFile('common/footer.json', footerData, assertValidFooter),

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -145,6 +145,22 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(page, 'clustersHeading', 'jobMarketLab');
 }
 
+export function assertValidLoginPage(data: unknown): void {
+  const page = requireRecord(data, 'login');
+  requireString(page, 'heading', 'login');
+  requireString(page, 'description', 'login');
+  requireString(page, 'emailLabel', 'login');
+  requireString(page, 'passwordLabel', 'login');
+  requireString(page, 'submitLabel', 'login');
+  requireString(page, 'signOutLabel', 'login');
+  requireString(page, 'signedInHeading', 'login');
+  requireString(page, 'signedInDescription', 'login');
+  const errors = requireRecord(page.errors, 'login.errors');
+  requireString(errors, 'generic', 'login.errors');
+  requireString(errors, 'notConfigured', 'login.errors');
+  requireString(errors, 'required', 'login.errors');
+}
+
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');
@@ -157,6 +173,9 @@ export function assertValidFooter(data: unknown): void {
   const social = requireRecord(contact.social, 'footer.contact.social');
   requireString(social, 'github', 'footer.contact.social');
   requireString(social, 'linkedin', 'footer.contact.social');
+  const ownerSignIn = requireRecord(contact.ownerSignIn, 'footer.contact.ownerSignIn');
+  requireString(ownerSignIn, 'label', 'footer.contact.ownerSignIn');
+  requireString(ownerSignIn, 'href', 'footer.contact.ownerSignIn');
 }
 
 export function assertValidNavigation(data: unknown): void {

--- a/src/hooks/use-site-auth.tsx
+++ b/src/hooks/use-site-auth.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type {
+  AuthSession,
+  SignInResult,
+  SiteAuthPort,
+} from '@/lib/site-auth';
+
+type SiteAuthContextValue = {
+  session: AuthSession | null;
+  isLoading: boolean;
+  signIn: (email: string, password: string) => Promise<SignInResult>;
+  signOut: () => Promise<void>;
+};
+
+const SiteAuthContext = createContext<SiteAuthContextValue | null>(null);
+
+export type SiteAuthProviderProps = {
+  children: ReactNode;
+  auth: SiteAuthPort;
+};
+
+export function SiteAuthProvider({ children, auth }: SiteAuthProviderProps) {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refreshSession = useCallback(async () => {
+    const next = await auth.getSession();
+    setSession(next);
+    setIsLoading(false);
+  }, [auth]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const next = await auth.getSession();
+      if (!cancelled) {
+        setSession(next);
+        setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [auth]);
+
+  const signIn = useCallback(
+    async (email: string, password: string) => {
+      const result = await auth.signIn(email, password);
+      if (result.status === 'signed_in') {
+        await refreshSession();
+      }
+      return result;
+    },
+    [auth, refreshSession],
+  );
+
+  const signOut = useCallback(async () => {
+    await auth.signOut();
+    await refreshSession();
+  }, [auth, refreshSession]);
+
+  return (
+    <SiteAuthContext.Provider value={{ session, isLoading, signIn, signOut }}>
+      {children}
+    </SiteAuthContext.Provider>
+  );
+}
+
+export function useSiteAuth(): SiteAuthContextValue {
+  const value = useContext(SiteAuthContext);
+  if (!value) {
+    throw new Error('useSiteAuth must be used within a SiteAuthProvider');
+  }
+  return value;
+}

--- a/src/lib/site-auth.test.ts
+++ b/src/lib/site-auth.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_NOT_CONFIGURED_REASON,
+  createAmplifySiteAuth,
+  createMemorySiteAuth,
+  createSiteAuthFromOutputs,
+  type AmplifyAuthClient,
+} from '@/lib/site-auth';
+
+function createFakeAmplifyClient(
+  overrides: Partial<AmplifyAuthClient> = {},
+): AmplifyAuthClient {
+  return {
+    getCurrentUser: vi.fn(async () => {
+      throw new Error('UserUnAuthenticatedException');
+    }),
+    fetchUserAttributes: vi.fn(async () => ({})),
+    signIn: vi.fn(async () => ({ isSignedIn: true })),
+    signOut: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('createMemorySiteAuth', () => {
+  it('getSession returns unauthenticated when starting signed out', async () => {
+    const auth = createMemorySiteAuth();
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+
+  it('after successful signIn, getSession is authenticated', async () => {
+    const auth = createMemorySiteAuth();
+
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'signed_in',
+    });
+    await expect(auth.getSession()).resolves.toEqual({
+      status: 'authenticated',
+      email: 'owner@example.com',
+    });
+  });
+
+  it('signOut clears the session to unauthenticated', async () => {
+    const auth = createMemorySiteAuth();
+    await auth.signIn('owner@example.com', 'secret');
+
+    await auth.signOut();
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+});
+
+describe('createAmplifySiteAuth', () => {
+  it('getSession returns unauthenticated when Amplify is not configured', async () => {
+    const auth = createAmplifySiteAuth({ isConfigured: false });
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+
+  it('signIn fails with a clear British English reason when Amplify is not configured', async () => {
+    const auth = createAmplifySiteAuth({ isConfigured: false });
+
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'failed',
+      reason: AUTH_NOT_CONFIGURED_REASON,
+    });
+  });
+
+  it('getSession returns authenticated email when Amplify reports a signed-in user', async () => {
+    const client = createFakeAmplifyClient({
+      getCurrentUser: vi.fn(async () => ({ username: 'owner', userId: '1' })),
+      fetchUserAttributes: vi.fn(async () => ({ email: 'owner@example.com' })),
+    });
+    const auth = createAmplifySiteAuth({ isConfigured: true, client });
+
+    await expect(auth.getSession()).resolves.toEqual({
+      status: 'authenticated',
+      email: 'owner@example.com',
+    });
+  });
+
+  it('getSession returns unauthenticated when Amplify reports no signed-in user', async () => {
+    const auth = createAmplifySiteAuth({
+      isConfigured: true,
+      client: createFakeAmplifyClient(),
+    });
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+
+  it('signIn succeeds when Amplify accepts credentials', async () => {
+    const client = createFakeAmplifyClient({
+      signIn: vi.fn(async () => ({ isSignedIn: true })),
+    });
+    const auth = createAmplifySiteAuth({ isConfigured: true, client });
+
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'signed_in',
+    });
+    expect(client.signIn).toHaveBeenCalledWith({
+      username: 'owner@example.com',
+      password: 'secret',
+    });
+  });
+
+  it('signOut clears the Amplify session', async () => {
+    const client = createFakeAmplifyClient();
+    const auth = createAmplifySiteAuth({ isConfigured: true, client });
+
+    await auth.signOut();
+
+    expect(client.signOut).toHaveBeenCalled();
+  });
+});
+
+describe('createSiteAuthFromOutputs', () => {
+  it('behaves as unconfigured when outputs are missing', async () => {
+    const auth = createSiteAuthFromOutputs(null);
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'failed',
+      reason: AUTH_NOT_CONFIGURED_REASON,
+    });
+  });
+});

--- a/src/lib/site-auth.ts
+++ b/src/lib/site-auth.ts
@@ -1,0 +1,134 @@
+import type { AmplifyOutputs } from './configure-site-amplify';
+
+export type AuthSession =
+  | { status: 'authenticated'; email: string }
+  | { status: 'unauthenticated' };
+
+export type SignInResult =
+  | { status: 'signed_in' }
+  | { status: 'failed'; reason: string };
+
+export type SiteAuthPort = {
+  getSession: () => Promise<AuthSession>;
+  signIn: (email: string, password: string) => Promise<SignInResult>;
+  signOut: () => Promise<void>;
+};
+
+export const AUTH_NOT_CONFIGURED_REASON =
+  'Sign-in is unavailable because authentication is not configured.';
+
+export function createMemorySiteAuth(
+  initial: AuthSession = { status: 'unauthenticated' },
+): SiteAuthPort {
+  let session = initial;
+
+  return {
+    async getSession() {
+      return session;
+    },
+    async signIn(email: string) {
+      session = { status: 'authenticated', email };
+      return { status: 'signed_in' };
+    },
+    async signOut() {
+      session = { status: 'unauthenticated' };
+    },
+  };
+}
+
+export type AmplifyAuthClient = {
+  getCurrentUser: () => Promise<{ username: string; userId: string }>;
+  fetchUserAttributes: () => Promise<Record<string, string | undefined>>;
+  signIn: (input: {
+    username: string;
+    password: string;
+  }) => Promise<{ isSignedIn: boolean }>;
+  signOut: () => Promise<void>;
+};
+
+export function createAmplifySiteAuth(options: {
+  isConfigured: boolean;
+  client?: AmplifyAuthClient;
+}): SiteAuthPort {
+  const { isConfigured, client } = options;
+
+  return {
+    async getSession() {
+      if (!isConfigured || !client) {
+        return { status: 'unauthenticated' };
+      }
+
+      try {
+        await client.getCurrentUser();
+        const attributes = await client.fetchUserAttributes();
+        const email = attributes.email;
+        if (!email) {
+          return { status: 'unauthenticated' };
+        }
+        return { status: 'authenticated', email };
+      } catch {
+        return { status: 'unauthenticated' };
+      }
+    },
+    async signIn(email: string, password: string) {
+      if (!isConfigured || !client) {
+        return { status: 'failed', reason: AUTH_NOT_CONFIGURED_REASON };
+      }
+
+      try {
+        const result = await client.signIn({ username: email, password });
+        if (!result.isSignedIn) {
+          return {
+            status: 'failed',
+            reason: 'Sign-in could not be completed. Please try again.',
+          };
+        }
+        return { status: 'signed_in' };
+      } catch {
+        return {
+          status: 'failed',
+          reason: 'Sign-in failed. Check your email and password, then try again.',
+        };
+      }
+    },
+    async signOut() {
+      if (!isConfigured || !client) {
+        return;
+      }
+      await client.signOut();
+    },
+  };
+}
+
+export function createDefaultAmplifyAuthClient(): AmplifyAuthClient {
+  return {
+    async getCurrentUser() {
+      const { getCurrentUser } = await import('aws-amplify/auth');
+      return getCurrentUser();
+    },
+    async fetchUserAttributes() {
+      const { fetchUserAttributes } = await import('aws-amplify/auth');
+      return fetchUserAttributes();
+    },
+    async signIn(input) {
+      const { signIn } = await import('aws-amplify/auth');
+      const result = await signIn(input);
+      return { isSignedIn: result.isSignedIn };
+    },
+    async signOut() {
+      const { signOut } = await import('aws-amplify/auth');
+      await signOut();
+    },
+  };
+}
+
+export function createSiteAuthFromOutputs(
+  outputs?: AmplifyOutputs | null,
+): SiteAuthPort {
+  const isConfigured = outputs != null && Object.keys(outputs).length > 0;
+  return createAmplifySiteAuth({
+    isConfigured,
+    client: isConfigured ? createDefaultAmplifyAuthClient() : undefined,
+  });
+}
+

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -47,6 +47,12 @@ export function buildSitemap(blogDirectory?: string): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/login`,
+      lastModified,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
     ...blogPosts.map((post) => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: new Date(post.frontmatter.date),


### PR DESCRIPTION
## Summary
- Adds public `/login` with Cognito email/password via an injectable auth session seam (no self-registration UI).
- Session is available to client surfaces through `SiteAuthProvider` / `useSiteAuth`; sign-out clears it.
- Login and sign-out copy live in the data layer (British English); footer link and sitemap entry make the route reachable.

Closes #49

## Test plan
- [ ] `npm test` / typecheck / lint green in CI
- [ ] Unauthenticated: form shown, no register/create-account copy
- [ ] Authenticated (fake port or real Cognito): signed-in state and sign-out
- [ ] Without Amplify outputs: getSession is unauthenticated; sign-in fails with clear reason