### PR TITLE
Fix duplicate login validate breaking typecheck

### DIFF
--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -183,24 +183,6 @@ export interface LoginPageData {
   errors: LoginPageErrors;
 }
 
-export interface LoginPageErrors {
-  generic: string;
-  notConfigured: string;
-  required: string;
-}
-
-export interface LoginPageData {
-  heading: string;
-  description: string;
-  emailLabel: string;
-  passwordLabel: string;
-  submitLabel: string;
-  signOutLabel: string;
-  signedInHeading: string;
-  signedInDescription: string;
-  errors: LoginPageErrors;
-}
-
 // Common/shared types
 export interface SocialLinks {
   github: string;

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -168,22 +168,6 @@ export function assertValidLoginPage(data: unknown): void {
   requireString(errors, 'required', 'login.errors');
 }
 
-export function assertValidLoginPage(data: unknown): void {
-  const page = requireRecord(data, 'login');
-  requireString(page, 'heading', 'login');
-  requireString(page, 'description', 'login');
-  requireString(page, 'emailLabel', 'login');
-  requireString(page, 'passwordLabel', 'login');
-  requireString(page, 'submitLabel', 'login');
-  requireString(page, 'signOutLabel', 'login');
-  requireString(page, 'signedInHeading', 'login');
-  requireString(page, 'signedInDescription', 'login');
-  const errors = requireRecord(page.errors, 'login.errors');
-  requireString(errors, 'generic', 'login.errors');
-  requireString(errors, 'notConfigured', 'login.errors');
-  requireString(errors, 'required', 'login.errors');
-}
-
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');


### PR DESCRIPTION
## Summary
- Removes the duplicated `assertValidLoginPage` and `LoginPage*` declarations that landed on `develop` via #56 and broke CI typecheck.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] CI quality green
