### PR TITLE
Restore login page validate and types

### DIFF
--- a/src/components/sections/labs/job-market-lab-corpus-admin.test.tsx
+++ b/src/components/sections/labs/job-market-lab-corpus-admin.test.tsx
@@ -85,8 +85,8 @@ describe('JobMarketLabCorpusAdmin', () => {
     ]);
     renderAdmin(ownerAuth(), corpus);
 
-    expect(await screen.findByText(jobMarketLab.corpusAdmin.heading)).toBeInTheDocument();
-    expect(screen.getByText('Risk modeller')).toBeInTheDocument();
+    expect(await screen.findByText('Risk modeller')).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.corpusAdmin.heading)).toBeInTheDocument();
     expect(screen.getByText('jd-1')).toBeInTheDocument();
     expect(screen.getByText(jobMarketLab.corpusAdmin.statusActiveLabel)).toBeInTheDocument();
     expect(screen.queryByText(/secret JD body|markdown|# Role/i)).not.toBeInTheDocument();

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -179,6 +179,24 @@ export interface JobMarketLabPageData {
   corpusAdmin: JobMarketLabCorpusAdminData;
 }
 
+export interface LoginPageErrors {
+  generic: string;
+  notConfigured: string;
+  required: string;
+}
+
+export interface LoginPageData {
+  heading: string;
+  description: string;
+  emailLabel: string;
+  passwordLabel: string;
+  submitLabel: string;
+  signOutLabel: string;
+  signedInHeading: string;
+  signedInDescription: string;
+  errors: LoginPageErrors;
+}
+
 // Common/shared types
 export interface SocialLinks {
   github: string;

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -163,6 +163,22 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(corpusAdmin, 'errorLabel', 'jobMarketLab.corpusAdmin');
 }
 
+export function assertValidLoginPage(data: unknown): void {
+  const page = requireRecord(data, 'login');
+  requireString(page, 'heading', 'login');
+  requireString(page, 'description', 'login');
+  requireString(page, 'emailLabel', 'login');
+  requireString(page, 'passwordLabel', 'login');
+  requireString(page, 'submitLabel', 'login');
+  requireString(page, 'signOutLabel', 'login');
+  requireString(page, 'signedInHeading', 'login');
+  requireString(page, 'signedInDescription', 'login');
+  const errors = requireRecord(page.errors, 'login.errors');
+  requireString(errors, 'generic', 'login.errors');
+  requireString(errors, 'notConfigured', 'login.errors');
+  requireString(errors, 'required', 'login.errors');
+}
+
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');


### PR DESCRIPTION
## Summary
- Restores `LoginPageData` / `LoginPageErrors` and `assertValidLoginPage` removed when #58 merged after #57 and deleted the only remaining copies.
- Fixes the Turbopack/Next build error: export assertValidLoginPage doesn't exist in validate.ts.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test -- --run src/data` passes
- [ ] Dev server loads without the missing-export build error
