### PR TITLE
Fix Amplify sandbox schema and stack circular dependencies

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -32,7 +32,6 @@ backend.storage.resources.bucket.addEventNotification(
   { prefix: 'raw/' },
 );
 
-const bucketName = backend.storage.resources.bucket.bucketName;
 const analyseFunctionName = backend.jobMarketAnalyse.resources.lambda.functionName;
 
 backend.jobMarketRecompute.addEnvironment(
@@ -40,16 +39,9 @@ backend.jobMarketRecompute.addEnvironment(
   analyseFunctionName,
 );
 backend.jobMarketRecompute.addEnvironment('MAX_ACTIVE_DOCS', '150');
-backend.jobMarketAnalyse.addEnvironment('JOB_MARKET_BUCKET_NAME', bucketName);
 
 backend.jobMarketAnalyse.resources.lambda.grantInvoke(
   backend.jobMarketRecompute.resources.lambda,
-);
-backend.storage.resources.bucket.grantRead(
-  backend.jobMarketAnalyse.resources.lambda,
-);
-backend.storage.resources.bucket.grantWrite(
-  backend.jobMarketAnalyse.resources.lambda,
 );
 
 backend.jobMarketAnalyse.resources.lambda.addToRolePolicy(

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -6,26 +6,27 @@ import { jobMarketPublication } from '../functions/job-market-publication/resour
 
 const schema = a
   .schema({
+    JobDescriptionStatus: a.enum(['active', 'archived']),
+    AnalysisRunStatus: a.enum(['queued', 'running', 'succeeded', 'failed']),
+
     JobDescription: a
       .model({
         s3Key: a.string().required(),
         contentHash: a.string().required(),
         collectedAt: a.datetime().required(),
-        status: a.enum(['active', 'archived']).required(),
+        status: a.ref('JobDescriptionStatus').required(),
         title: a.string(),
         seniority: a.string(),
         roleFamily: a.string(),
         source: a.string(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create', 'update', 'delete']),
+        allow.authenticated().to(['read', 'create', 'update', 'delete']),
       ]),
 
     AnalysisRun: a
       .model({
-        status: a
-          .enum(['queued', 'running', 'succeeded', 'failed'])
-          .required(),
+        status: a.ref('AnalysisRunStatus').required(),
         docsConsidered: a.integer(),
         docsEmbedded: a.integer(),
         docsCacheHit: a.integer(),
@@ -35,7 +36,7 @@ const schema = a
         errorMessage: a.string(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create', 'update']),
+        allow.authenticated().to(['read', 'create', 'update']),
       ]),
 
     CorpusSnapshot: a
@@ -44,7 +45,7 @@ const schema = a
         payload: a.json().required(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create']),
+        allow.authenticated().to(['read', 'create']),
       ]),
 
     LabPublication: a
@@ -52,7 +53,7 @@ const schema = a
         currentSnapshotId: a.id().required(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create', 'update']),
+        allow.authenticated().to(['read', 'create', 'update']),
       ]),
 
     startJobMarketRecompute: a

--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -61,7 +61,7 @@ async function saveJobDescription(
 async function loadMarkdown(s3Key: string): Promise<string> {
   const object = await s3.send(
     new GetObjectCommand({
-      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Bucket: env.JOB_MARKET_LAB_BUCKET_NAME,
       Key: s3Key,
     }),
   );
@@ -76,7 +76,7 @@ async function getCachedEmbedding(contentHash: string): Promise<number[] | null>
   try {
     const object = await s3.send(
       new GetObjectCommand({
-        Bucket: env.JOB_MARKET_BUCKET_NAME,
+        Bucket: env.JOB_MARKET_LAB_BUCKET_NAME,
         Key: `embeddings/${contentHash}.json`,
       }),
     );
@@ -97,7 +97,7 @@ async function putCachedEmbedding(
 ): Promise<void> {
   await s3.send(
     new PutObjectCommand({
-      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Bucket: env.JOB_MARKET_LAB_BUCKET_NAME,
       Key: `embeddings/${contentHash}.json`,
       Body: JSON.stringify({ vector }),
       ContentType: 'application/json',

--- a/amplify/functions/job-market-analyse/resource.ts
+++ b/amplify/functions/job-market-analyse/resource.ts
@@ -12,4 +12,6 @@ export const jobMarketAnalyse = defineFunction({
   environment: {
     BEDROCK_MODEL_ID: 'amazon.titan-embed-text-v2:0',
   },
+  // Uses the data API; storage bucket name is injected via defineStorage access (SSM).
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-ingest/resource.ts
+++ b/amplify/functions/job-market-ingest/resource.ts
@@ -7,4 +7,6 @@ import { defineFunction } from '@aws-amplify/backend';
 export const jobMarketIngest = defineFunction({
   name: 'job-market-ingest',
   entry: './handler.ts',
+  // Shares the data stack: ingest writes JobDescription rows via the data API.
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-publication/resource.ts
+++ b/amplify/functions/job-market-publication/resource.ts
@@ -6,4 +6,6 @@ import { defineFunction } from '@aws-amplify/backend';
 export const jobMarketPublication = defineFunction({
   name: 'job-market-publication',
   entry: './handler.ts',
+  // Custom query resolver — must live in the data stack.
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-recompute/resource.ts
+++ b/amplify/functions/job-market-recompute/resource.ts
@@ -8,4 +8,6 @@ export const jobMarketRecompute = defineFunction({
   name: 'job-market-recompute',
   entry: './handler.ts',
   timeoutSeconds: 60,
+  // Data mutation handler + Amplify Data client — must live in the data stack.
+  resourceGroupName: 'data',
 });


### PR DESCRIPTION
## Summary
- Fixes Gen 2 data schema TypeScript errors (`a.enum().required()` → top-level enums + `a.ref().required()`; `allow.authenticated().to(...)`).
- Assigns job-market Lambdas to `resourceGroupName: 'data'` to break storage/data/function circular nested-stack deps.
- Uses Amplify storage-injected `JOB_MARKET_LAB_BUCKET_NAME` instead of CDK bucket grants that recreated the cycle.

## Test plan
- [ ] CI quality green
- [ ] `npm run sandbox` synthesises/deploys without schema or circular-dependency errors
- [ ] Analyse worker can resolve bucket via `env.JOB_MARKET_LAB_BUCKET_NAME`
