### PR TITLE
Ship job market signal lab (Amplify Gen 2) to production

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -1,9 +1,9 @@
+/**
+ * Soft-disable Cognito self-registration in defineAuth comments;
+ * enforce allowAdminCreateUserOnly via backend.ts CDK override (#39).
+ */
 import { defineAuth } from '@aws-amplify/backend';
 
-/**
- * Job market lab auth skeleton.
- * Later slices tighten this (self-sign-up disabled, invited admin only — #39).
- */
 export const auth = defineAuth({
   loginWith: {
     email: true,

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -32,7 +32,6 @@ backend.storage.resources.bucket.addEventNotification(
   { prefix: 'raw/' },
 );
 
-const bucketName = backend.storage.resources.bucket.bucketName;
 const analyseFunctionName = backend.jobMarketAnalyse.resources.lambda.functionName;
 
 backend.jobMarketRecompute.addEnvironment(
@@ -40,16 +39,9 @@ backend.jobMarketRecompute.addEnvironment(
   analyseFunctionName,
 );
 backend.jobMarketRecompute.addEnvironment('MAX_ACTIVE_DOCS', '150');
-backend.jobMarketAnalyse.addEnvironment('JOB_MARKET_BUCKET_NAME', bucketName);
 
 backend.jobMarketAnalyse.resources.lambda.grantInvoke(
   backend.jobMarketRecompute.resources.lambda,
-);
-backend.storage.resources.bucket.grantRead(
-  backend.jobMarketAnalyse.resources.lambda,
-);
-backend.storage.resources.bucket.grantWrite(
-  backend.jobMarketAnalyse.resources.lambda,
 );
 
 backend.jobMarketAnalyse.resources.lambda.addToRolePolicy(

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,12 +1,20 @@
 import { defineBackend } from '@aws-amplify/backend';
+import { EventType } from 'aws-cdk-lib/aws-s3';
+import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
 import { auth } from './auth/resource.js';
 import { data } from './data/resource.js';
 import { storage } from './storage/resource.js';
-import { labPlaceholder } from './functions/lab-placeholder/resource.js';
+import { jobMarketIngest } from './functions/job-market-ingest/resource.js';
 
-defineBackend({
+const backend = defineBackend({
   auth,
   data,
   storage,
-  labPlaceholder,
+  jobMarketIngest,
 });
+
+backend.storage.resources.bucket.addEventNotification(
+  EventType.OBJECT_CREATED,
+  new LambdaDestination(backend.jobMarketIngest.resources.lambda),
+  { prefix: 'raw/' },
+);

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,20 +1,61 @@
 import { defineBackend } from '@aws-amplify/backend';
 import { EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { auth } from './auth/resource.js';
 import { data } from './data/resource.js';
 import { storage } from './storage/resource.js';
 import { jobMarketIngest } from './functions/job-market-ingest/resource.js';
+import { jobMarketRecompute } from './functions/job-market-recompute/resource.js';
+import { jobMarketAnalyse } from './functions/job-market-analyse/resource.js';
+import { jobMarketPublication } from './functions/job-market-publication/resource.js';
 
 const backend = defineBackend({
   auth,
   data,
   storage,
   jobMarketIngest,
+  jobMarketRecompute,
+  jobMarketAnalyse,
+  jobMarketPublication,
 });
+
+// Owner-only Cognito: disable self-sign-up (admin invite / AdminCreateUser only).
+const { cfnUserPool } = backend.auth.resources.cfnResources;
+cfnUserPool.adminCreateUserConfig = {
+  allowAdminCreateUserOnly: true,
+};
 
 backend.storage.resources.bucket.addEventNotification(
   EventType.OBJECT_CREATED,
   new LambdaDestination(backend.jobMarketIngest.resources.lambda),
   { prefix: 'raw/' },
+);
+
+const bucketName = backend.storage.resources.bucket.bucketName;
+const analyseFunctionName = backend.jobMarketAnalyse.resources.lambda.functionName;
+
+backend.jobMarketRecompute.addEnvironment(
+  'JOB_MARKET_ANALYSE_FUNCTION_NAME',
+  analyseFunctionName,
+);
+backend.jobMarketRecompute.addEnvironment('MAX_ACTIVE_DOCS', '150');
+backend.jobMarketAnalyse.addEnvironment('JOB_MARKET_BUCKET_NAME', bucketName);
+
+backend.jobMarketAnalyse.resources.lambda.grantInvoke(
+  backend.jobMarketRecompute.resources.lambda,
+);
+backend.storage.resources.bucket.grantRead(
+  backend.jobMarketAnalyse.resources.lambda,
+);
+backend.storage.resources.bucket.grantWrite(
+  backend.jobMarketAnalyse.resources.lambda,
+);
+
+backend.jobMarketAnalyse.resources.lambda.addToRolePolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ['bedrock:InvokeModel'],
+    resources: ['*'],
+  }),
 );

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,5 +1,8 @@
 import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
 import { jobMarketIngest } from '../functions/job-market-ingest/resource';
+import { jobMarketRecompute } from '../functions/job-market-recompute/resource';
+import { jobMarketAnalyse } from '../functions/job-market-analyse/resource';
+import { jobMarketPublication } from '../functions/job-market-publication/resource';
 
 const schema = a
   .schema({
@@ -17,8 +20,65 @@ const schema = a
       .authorization((allow) => [
         allow.authenticated.to(['read', 'create', 'update', 'delete']),
       ]),
+
+    AnalysisRun: a
+      .model({
+        status: a
+          .enum(['queued', 'running', 'succeeded', 'failed'])
+          .required(),
+        docsConsidered: a.integer(),
+        docsEmbedded: a.integer(),
+        docsCacheHit: a.integer(),
+        clusterCount: a.integer(),
+        bedrockInputTokens: a.integer(),
+        estimatedCostUsd: a.float(),
+        errorMessage: a.string(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create', 'update']),
+      ]),
+
+    CorpusSnapshot: a
+      .model({
+        runId: a.id().required(),
+        payload: a.json().required(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create']),
+      ]),
+
+    LabPublication: a
+      .model({
+        currentSnapshotId: a.id().required(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create', 'update']),
+      ]),
+
+    startJobMarketRecompute: a
+      .mutation()
+      .returns(
+        a.customType({
+          status: a.string().required(),
+          runId: a.string(),
+          reason: a.string(),
+        }),
+      )
+      .authorization((allow) => [allow.authenticated()])
+      .handler(a.handler.function(jobMarketRecompute)),
+
+    getPublishedJobMarketSnapshot: a
+      .query()
+      .returns(a.json())
+      .authorization((allow) => [allow.guest(), allow.authenticated()])
+      .handler(a.handler.function(jobMarketPublication)),
   })
-  .authorization((allow) => [allow.resource(jobMarketIngest)]);
+  .authorization((allow) => [
+    allow.resource(jobMarketIngest),
+    allow.resource(jobMarketRecompute),
+    allow.resource(jobMarketAnalyse),
+    allow.resource(jobMarketPublication),
+  ]);
 
 export type Schema = ClientSchema<typeof schema>;
 

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -6,26 +6,27 @@ import { jobMarketPublication } from '../functions/job-market-publication/resour
 
 const schema = a
   .schema({
+    JobDescriptionStatus: a.enum(['active', 'archived']),
+    AnalysisRunStatus: a.enum(['queued', 'running', 'succeeded', 'failed']),
+
     JobDescription: a
       .model({
         s3Key: a.string().required(),
         contentHash: a.string().required(),
         collectedAt: a.datetime().required(),
-        status: a.enum(['active', 'archived']).required(),
+        status: a.ref('JobDescriptionStatus').required(),
         title: a.string(),
         seniority: a.string(),
         roleFamily: a.string(),
         source: a.string(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create', 'update', 'delete']),
+        allow.authenticated().to(['read', 'create', 'update', 'delete']),
       ]),
 
     AnalysisRun: a
       .model({
-        status: a
-          .enum(['queued', 'running', 'succeeded', 'failed'])
-          .required(),
+        status: a.ref('AnalysisRunStatus').required(),
         docsConsidered: a.integer(),
         docsEmbedded: a.integer(),
         docsCacheHit: a.integer(),
@@ -35,7 +36,7 @@ const schema = a
         errorMessage: a.string(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create', 'update']),
+        allow.authenticated().to(['read', 'create', 'update']),
       ]),
 
     CorpusSnapshot: a
@@ -44,7 +45,7 @@ const schema = a
         payload: a.json().required(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create']),
+        allow.authenticated().to(['read', 'create']),
       ]),
 
     LabPublication: a
@@ -52,7 +53,7 @@ const schema = a
         currentSnapshotId: a.id().required(),
       })
       .authorization((allow) => [
-        allow.authenticated.to(['read', 'create', 'update']),
+        allow.authenticated().to(['read', 'create', 'update']),
       ]),
 
     startJobMarketRecompute: a

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,16 +1,24 @@
 import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
+import { jobMarketIngest } from '../functions/job-market-ingest/resource';
 
-/**
- * Data schema placeholder for the job market lab.
- * Models (JobDescription, AnalysisRun, CorpusSnapshot, LabPublication) land in later slices.
- */
-const schema = a.schema({
-  LabScaffold: a
-    .model({
-      label: a.string(),
-    })
-    .authorization((allow) => [allow.authenticated()]),
-});
+const schema = a
+  .schema({
+    JobDescription: a
+      .model({
+        s3Key: a.string().required(),
+        contentHash: a.string().required(),
+        collectedAt: a.datetime().required(),
+        status: a.enum(['active', 'archived']).required(),
+        title: a.string(),
+        seniority: a.string(),
+        roleFamily: a.string(),
+        source: a.string(),
+      })
+      .authorization((allow) => [
+        allow.authenticated.to(['read', 'create', 'update', 'delete']),
+      ]),
+  })
+  .authorization((allow) => [allow.resource(jobMarketIngest)]);
 
 export type Schema = ClientSchema<typeof schema>;
 

--- a/amplify/functions/job-market-analyse/analyse.test.ts
+++ b/amplify/functions/job-market-analyse/analyse.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  analyseCorpus,
+  MAX_CLUSTER_K,
+  MAX_PROJECTION_POINTS,
+  MAX_SKILLS,
+  type AnalyzableDocument,
+} from './analyse';
+
+const docs: AnalyzableDocument[] = [
+  {
+    id: 'jd-1',
+    contentHash: 'hash-1',
+    markdown:
+      'We need Python, SQL, and teamwork. Senior data scientist role with modelling.',
+    seniority: 'senior',
+    roleFamily: 'data-science',
+  },
+  {
+    id: 'jd-2',
+    contentHash: 'hash-2',
+    markdown: 'Looking for Python, Tableau, and communication skills.',
+    seniority: 'mid',
+    roleFamily: 'analytics',
+  },
+  {
+    id: 'jd-3',
+    contentHash: 'hash-1',
+    markdown:
+      'We need Python, SQL, and teamwork. Senior data scientist role with modelling.',
+    seniority: 'senior',
+    roleFamily: 'data-science',
+  },
+];
+
+describe('analyseCorpus', () => {
+  it('publishes a snapshot within caps and accounts for embedding cache hits', async () => {
+    const embed = vi.fn(async (text: string) => ({
+      vector: Array.from({ length: 8 }, (_, index) => (text.length + index) / 100),
+      inputTokens: 12,
+      estimatedCostUsd: 0.0001,
+    }));
+    const cacheGet = vi.fn(async (contentHash: string) =>
+      contentHash === 'hash-1'
+        ? Array.from({ length: 8 }, (_, index) => index / 10)
+        : null,
+    );
+    const cachePut = vi.fn(async () => undefined);
+
+    const result = await analyseCorpus(docs, {
+      embed,
+      getCachedEmbedding: cacheGet,
+      putCachedEmbedding: cachePut,
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.snapshot.skills.length).toBeLessThanOrEqual(MAX_SKILLS);
+    expect(result.snapshot.projection.length).toBeLessThanOrEqual(
+      MAX_PROJECTION_POINTS,
+    );
+    expect(result.snapshot.clusters.length).toBeLessThanOrEqual(MAX_CLUSTER_K);
+    expect(result.snapshot.documentCount).toBe(3);
+    expect(result.snapshot.publishedAt).toBe('2026-07-14T12:00:00.000Z');
+    expect(result.snapshot).not.toHaveProperty('rawText');
+    expect(result.snapshot).not.toHaveProperty('source');
+    expect(result.snapshot.skills.every((skill) => typeof skill.name === 'string')).toBe(
+      true,
+    );
+    expect(result.metrics).toMatchObject({
+      docsConsidered: 3,
+      docsCacheHit: 2,
+      docsEmbedded: 1,
+    });
+    expect(result.metrics.bedrockInputTokens).toBeGreaterThan(0);
+    expect(result.metrics.estimatedCostUsd).toBeGreaterThan(0);
+    expect(embed).toHaveBeenCalledOnce();
+    expect(cachePut).toHaveBeenCalledOnce();
+  });
+});

--- a/amplify/functions/job-market-analyse/analyse.ts
+++ b/amplify/functions/job-market-analyse/analyse.ts
@@ -1,0 +1,297 @@
+export const MAX_SKILLS = 40;
+export const MAX_PROJECTION_POINTS = 200;
+export const MAX_CLUSTER_K = 12;
+
+export type AnalyzableDocument = {
+  id: string;
+  contentHash: string;
+  markdown: string;
+  seniority?: string;
+  roleFamily?: string;
+  title?: string;
+};
+
+export type SkillFrequency = {
+  name: string;
+  count: number;
+};
+
+export type TaxonomyBucket = {
+  name: string;
+  count: number;
+};
+
+export type ClusterSummary = {
+  id: number;
+  size: number;
+  label: string;
+};
+
+export type ProjectionPoint = {
+  x: number;
+  y: number;
+  clusterId: number;
+};
+
+export type CorpusSnapshotPayload = {
+  documentCount: number;
+  publishedAt: string;
+  skills: SkillFrequency[];
+  seniority: TaxonomyBucket[];
+  roleFamily: TaxonomyBucket[];
+  clusters: ClusterSummary[];
+  projection: ProjectionPoint[];
+};
+
+export type AnalysisMetrics = {
+  docsConsidered: number;
+  docsEmbedded: number;
+  docsCacheHit: number;
+  clusterCount: number;
+  bedrockInputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type EmbedResult = {
+  vector: number[];
+  inputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type AnalyseCorpusDeps = {
+  embed: (text: string) => Promise<EmbedResult>;
+  getCachedEmbedding: (contentHash: string) => Promise<number[] | null>;
+  putCachedEmbedding: (contentHash: string, vector: number[]) => Promise<void>;
+  now?: Date;
+  maxSkills?: number;
+  maxProjectionPoints?: number;
+  maxClusters?: number;
+  cluster?: (
+    vectors: number[][],
+    k: number,
+  ) => { assignments: number[]; centroids: number[][] };
+};
+
+export type AnalyseCorpusResult = {
+  snapshot: CorpusSnapshotPayload;
+  metrics: AnalysisMetrics;
+};
+
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'the',
+  'to',
+  'we',
+  'with',
+  'you',
+  'your',
+  'need',
+  'looking',
+  'role',
+  'skills',
+]);
+
+export function extractSkillFrequencies(
+  documents: AnalyzableDocument[],
+  maxSkills: number = MAX_SKILLS,
+): SkillFrequency[] {
+  const counts = new Map<string, number>();
+
+  for (const document of documents) {
+    const tokens = document.markdown
+      .toLowerCase()
+      .match(/[a-z][a-z0-9+.#-]{1,}/g) ?? [];
+    const seen = new Set<string>();
+    for (const token of tokens) {
+      if (STOPWORDS.has(token) || seen.has(token)) {
+        continue;
+      }
+      seen.add(token);
+      counts.set(token, (counts.get(token) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, maxSkills);
+}
+
+function taxonomyBreakdown(
+  documents: AnalyzableDocument[],
+  field: 'seniority' | 'roleFamily',
+): TaxonomyBucket[] {
+  const counts = new Map<string, number>();
+  for (const document of documents) {
+    const value = document[field];
+    if (!value) {
+      continue;
+    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function euclidean(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    const delta = (a[index] ?? 0) - (b[index] ?? 0);
+    sum += delta * delta;
+  }
+  return Math.sqrt(sum);
+}
+
+/** Swap-ready default clusterer (k-means). */
+export function kMeansCluster(
+  vectors: number[][],
+  k: number,
+  maxIterations: number = 25,
+): { assignments: number[]; centroids: number[][] } {
+  if (vectors.length === 0) {
+    return { assignments: [], centroids: [] };
+  }
+
+  const clusterCount = Math.max(1, Math.min(k, vectors.length, MAX_CLUSTER_K));
+  const dimensions = vectors[0]?.length ?? 0;
+  const centroids = vectors.slice(0, clusterCount).map((vector) => [...vector]);
+  const assignments = new Array<number>(vectors.length).fill(0);
+
+  for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+    let moved = false;
+    for (let index = 0; index < vectors.length; index += 1) {
+      let best = 0;
+      let bestDistance = Number.POSITIVE_INFINITY;
+      for (let centroidIndex = 0; centroidIndex < centroids.length; centroidIndex += 1) {
+        const distance = euclidean(vectors[index]!, centroids[centroidIndex]!);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          best = centroidIndex;
+        }
+      }
+      if (assignments[index] !== best) {
+        assignments[index] = best;
+        moved = true;
+      }
+    }
+
+    const sums = centroids.map(() => new Array<number>(dimensions).fill(0));
+    const counts = new Array<number>(centroids.length).fill(0);
+    for (let index = 0; index < vectors.length; index += 1) {
+      const clusterId = assignments[index]!;
+      counts[clusterId] += 1;
+      const vector = vectors[index]!;
+      for (let dim = 0; dim < dimensions; dim += 1) {
+        sums[clusterId]![dim] += vector[dim] ?? 0;
+      }
+    }
+    for (let centroidIndex = 0; centroidIndex < centroids.length; centroidIndex += 1) {
+      if (counts[centroidIndex] === 0) {
+        continue;
+      }
+      centroids[centroidIndex] = sums[centroidIndex]!.map(
+        (value) => value / counts[centroidIndex]!,
+      );
+    }
+
+    if (!moved) {
+      break;
+    }
+  }
+
+  return { assignments, centroids };
+}
+
+export async function analyseCorpus(
+  documents: AnalyzableDocument[],
+  deps: AnalyseCorpusDeps,
+): Promise<AnalyseCorpusResult> {
+  const maxSkills = deps.maxSkills ?? MAX_SKILLS;
+  const maxProjectionPoints = deps.maxProjectionPoints ?? MAX_PROJECTION_POINTS;
+  const maxClusters = deps.maxClusters ?? MAX_CLUSTER_K;
+  const cluster = deps.cluster ?? kMeansCluster;
+  const now = deps.now ?? new Date();
+
+  const vectors: number[][] = [];
+  let docsCacheHit = 0;
+  let docsEmbedded = 0;
+  let bedrockInputTokens = 0;
+  let estimatedCostUsd = 0;
+
+  for (const document of documents) {
+    const cached = await deps.getCachedEmbedding(document.contentHash);
+    if (cached) {
+      docsCacheHit += 1;
+      vectors.push(cached);
+      continue;
+    }
+
+    const embedded = await deps.embed(document.markdown);
+    docsEmbedded += 1;
+    bedrockInputTokens += embedded.inputTokens;
+    estimatedCostUsd += embedded.estimatedCostUsd;
+    await deps.putCachedEmbedding(document.contentHash, embedded.vector);
+    vectors.push(embedded.vector);
+  }
+
+  const k = Math.min(
+    maxClusters,
+    Math.max(1, Math.round(Math.sqrt(documents.length || 1))),
+  );
+  const { assignments } = cluster(vectors, k);
+
+  const clusterSizes = new Map<number, number>();
+  for (const assignment of assignments) {
+    clusterSizes.set(assignment, (clusterSizes.get(assignment) ?? 0) + 1);
+  }
+
+  const clusters = [...clusterSizes.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([id, size]) => ({
+      id,
+      size,
+      label: `Theme ${id + 1}`,
+    }));
+
+  const projection = documents.slice(0, maxProjectionPoints).map((document, index) => ({
+    x: vectors[index]?.[0] ?? 0,
+    y: vectors[index]?.[1] ?? 0,
+    clusterId: assignments[index] ?? 0,
+  }));
+
+  return {
+    snapshot: {
+      documentCount: documents.length,
+      publishedAt: now.toISOString(),
+      skills: extractSkillFrequencies(documents, maxSkills),
+      seniority: taxonomyBreakdown(documents, 'seniority'),
+      roleFamily: taxonomyBreakdown(documents, 'roleFamily'),
+      clusters,
+      projection,
+    },
+    metrics: {
+      docsConsidered: documents.length,
+      docsEmbedded,
+      docsCacheHit,
+      clusterCount: clusters.length,
+      bedrockInputTokens,
+      estimatedCostUsd,
+    },
+  };
+}

--- a/amplify/functions/job-market-analyse/corpus.ts
+++ b/amplify/functions/job-market-analyse/corpus.ts
@@ -1,0 +1,122 @@
+/** Lambda-local copy of corpus hygiene (facade source of truth: src/lib/job-market-corpus.ts). */
+
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionCorpusRecord = {
+  id: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+  s3Key?: string;
+  contentHash?: string;
+};
+
+export const DEFAULT_MAX_AGE_MONTHS = 18;
+
+export type ArchiveJobDescriptionDeps = {
+  getJobDescription: (id: string) => Promise<JobDescriptionCorpusRecord | null>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+};
+
+export type ArchiveJobDescriptionResult =
+  | { status: 'archived'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_archived'; record: JobDescriptionCorpusRecord };
+
+export type PrepareActiveCorpusDeps = {
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export function selectActiveCorpus(
+  records: JobDescriptionCorpusRecord[],
+): JobDescriptionCorpusRecord[] {
+  return records.filter((record) => record.status === 'active');
+}
+
+export function isOlderThanAgeWindow(
+  collectedAt: string,
+  now: Date,
+  maxAgeMonths: number = DEFAULT_MAX_AGE_MONTHS,
+): boolean {
+  const collected = new Date(collectedAt);
+  if (Number.isNaN(collected.getTime())) {
+    return false;
+  }
+
+  const cutoff = new Date(now);
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - maxAgeMonths);
+  return collected.getTime() < cutoff.getTime();
+}
+
+export type RestoreJobDescriptionResult =
+  | { status: 'restored'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_active'; record: JobDescriptionCorpusRecord };
+
+export async function archiveJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<ArchiveJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'archived') {
+    return { status: 'already_archived', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'archived',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'archived', record };
+}
+
+export async function restoreJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<RestoreJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'active') {
+    return { status: 'already_active', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'active',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'restored', record };
+}
+
+export async function prepareActiveCorpusForAnalysis(
+  deps: PrepareActiveCorpusDeps,
+): Promise<JobDescriptionCorpusRecord[]> {
+  const now = deps.now ?? new Date();
+  const maxAgeMonths = deps.maxAgeMonths ?? DEFAULT_MAX_AGE_MONTHS;
+  const records = await deps.listJobDescriptions();
+
+  for (const record of records) {
+    if (
+      record.status === 'active' &&
+      isOlderThanAgeWindow(record.collectedAt, now, maxAgeMonths)
+    ) {
+      await deps.saveJobDescription({ ...record, status: 'archived' });
+    }
+  }
+
+  const refreshed = await deps.listJobDescriptions();
+  return selectActiveCorpus(refreshed);
+}

--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -61,7 +61,7 @@ async function saveJobDescription(
 async function loadMarkdown(s3Key: string): Promise<string> {
   const object = await s3.send(
     new GetObjectCommand({
-      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Bucket: env.JOB_MARKET_LAB_BUCKET_NAME,
       Key: s3Key,
     }),
   );
@@ -76,7 +76,7 @@ async function getCachedEmbedding(contentHash: string): Promise<number[] | null>
   try {
     const object = await s3.send(
       new GetObjectCommand({
-        Bucket: env.JOB_MARKET_BUCKET_NAME,
+        Bucket: env.JOB_MARKET_LAB_BUCKET_NAME,
         Key: `embeddings/${contentHash}.json`,
       }),
     );
@@ -97,7 +97,7 @@ async function putCachedEmbedding(
 ): Promise<void> {
   await s3.send(
     new PutObjectCommand({
-      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Bucket: env.JOB_MARKET_LAB_BUCKET_NAME,
       Key: `embeddings/${contentHash}.json`,
       Body: JSON.stringify({ vector }),
       ContentType: 'application/json',

--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -1,0 +1,231 @@
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import type { Handler } from 'aws-lambda';
+import { env } from '$amplify/env/job-market-analyse';
+import type { Schema } from '../../data/resource';
+import { executeAnalysisRun } from './run';
+import type { AnalysisRunRecord } from '../job-market-recompute/orchestrator';
+import type { StoredCorpusSnapshot } from './run';
+import type { JobDescriptionCorpusRecord } from './corpus';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const s3 = new S3Client({});
+const bedrock = new BedrockRuntimeClient({});
+
+const PUBLICATION_ID = 'current';
+
+type AnalyseEvent = {
+  runId: string;
+};
+
+async function listJobDescriptions(): Promise<JobDescriptionCorpusRecord[]> {
+  const { data, errors } = await client.models.JobDescription.list();
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return (data ?? []).map((record) => ({
+    id: record.id,
+    collectedAt: record.collectedAt,
+    status: record.status as JobDescriptionCorpusRecord['status'],
+    s3Key: record.s3Key,
+    contentHash: record.contentHash,
+    title: record.title ?? undefined,
+    seniority: record.seniority ?? undefined,
+    roleFamily: record.roleFamily ?? undefined,
+    source: record.source ?? undefined,
+  }));
+}
+
+async function saveJobDescription(
+  record: JobDescriptionCorpusRecord,
+): Promise<void> {
+  const { errors } = await client.models.JobDescription.update({
+    id: record.id,
+    status: record.status,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+async function loadMarkdown(s3Key: string): Promise<string> {
+  const object = await s3.send(
+    new GetObjectCommand({
+      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Key: s3Key,
+    }),
+  );
+  const body = await object.Body?.transformToString('utf-8');
+  if (!body) {
+    throw new Error(`Empty object body for ${s3Key}`);
+  }
+  return body;
+}
+
+async function getCachedEmbedding(contentHash: string): Promise<number[] | null> {
+  try {
+    const object = await s3.send(
+      new GetObjectCommand({
+        Bucket: env.JOB_MARKET_BUCKET_NAME,
+        Key: `embeddings/${contentHash}.json`,
+      }),
+    );
+    const body = await object.Body?.transformToString('utf-8');
+    if (!body) {
+      return null;
+    }
+    const parsed = JSON.parse(body) as { vector?: number[] };
+    return Array.isArray(parsed.vector) ? parsed.vector : null;
+  } catch {
+    return null;
+  }
+}
+
+async function putCachedEmbedding(
+  contentHash: string,
+  vector: number[],
+): Promise<void> {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: env.JOB_MARKET_BUCKET_NAME,
+      Key: `embeddings/${contentHash}.json`,
+      Body: JSON.stringify({ vector }),
+      ContentType: 'application/json',
+    }),
+  );
+}
+
+async function embed(text: string) {
+  const modelId = env.BEDROCK_MODEL_ID;
+  const response = await bedrock.send(
+    new InvokeModelCommand({
+      modelId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        inputText: text.slice(0, 8000),
+        dimensions: 256,
+        normalize: true,
+      }),
+    }),
+  );
+  const payload = JSON.parse(new TextDecoder().decode(response.body)) as {
+    embedding?: number[];
+    inputTextTokenCount?: number;
+  };
+  if (!payload.embedding) {
+    throw new Error('Bedrock embedding response did not include a vector');
+  }
+  const inputTokens = payload.inputTextTokenCount ?? Math.ceil(text.length / 4);
+  // Titan embed rough cost placeholder for metrics (USD per 1k input tokens).
+  const estimatedCostUsd = (inputTokens / 1000) * 0.0001;
+  return {
+    vector: payload.embedding,
+    inputTokens,
+    estimatedCostUsd,
+  };
+}
+
+async function saveSnapshot(
+  snapshot: StoredCorpusSnapshot,
+): Promise<StoredCorpusSnapshot> {
+  const { errors } = await client.models.CorpusSnapshot.create({
+    id: snapshot.id,
+    runId: snapshot.runId,
+    payload: snapshot.payload,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return snapshot;
+}
+
+async function updateRun(run: AnalysisRunRecord): Promise<AnalysisRunRecord> {
+  const { errors } = await client.models.AnalysisRun.update({
+    id: run.id,
+    status: run.status,
+    docsConsidered: run.docsConsidered,
+    docsEmbedded: run.docsEmbedded,
+    docsCacheHit: run.docsCacheHit,
+    clusterCount: run.clusterCount,
+    bedrockInputTokens: run.bedrockInputTokens,
+    estimatedCostUsd: run.estimatedCostUsd,
+    errorMessage: run.errorMessage,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return run;
+}
+
+async function updatePublication(publication: {
+  currentSnapshotId: string;
+}): Promise<void> {
+  const existing = await client.models.LabPublication.get({ id: PUBLICATION_ID });
+  if (existing.data) {
+    const { errors } = await client.models.LabPublication.update({
+      id: PUBLICATION_ID,
+      currentSnapshotId: publication.currentSnapshotId,
+    });
+    if (errors?.length) {
+      throw new Error(errors.map((error) => error.message).join('; '));
+    }
+    return;
+  }
+  const { errors } = await client.models.LabPublication.create({
+    id: PUBLICATION_ID,
+    currentSnapshotId: publication.currentSnapshotId,
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+async function getPublication() {
+  const { data } = await client.models.LabPublication.get({ id: PUBLICATION_ID });
+  if (!data) {
+    return null;
+  }
+  return { currentSnapshotId: data.currentSnapshotId };
+}
+
+export const handler: Handler<AnalyseEvent> = async (event) => {
+  const runId = event.runId;
+  if (!runId) {
+    throw new Error('runId is required');
+  }
+
+  const result = await executeAnalysisRun({
+    runId,
+    listJobDescriptions,
+    saveJobDescription,
+    loadMarkdown,
+    embed,
+    getCachedEmbedding,
+    putCachedEmbedding,
+    saveSnapshot,
+    updateRun,
+    updatePublication,
+    getPublication,
+  });
+
+  if (result.status === 'failed') {
+    console.error(`[job-market-analyse] Run ${runId} failed: ${result.reason}`);
+  } else {
+    console.log(
+      `[job-market-analyse] Run ${runId} succeeded snapshot=${result.snapshot.id}`,
+    );
+  }
+
+  return result;
+};

--- a/amplify/functions/job-market-analyse/resource.ts
+++ b/amplify/functions/job-market-analyse/resource.ts
@@ -12,4 +12,6 @@ export const jobMarketAnalyse = defineFunction({
   environment: {
     BEDROCK_MODEL_ID: 'amazon.titan-embed-text-v2:0',
   },
+  // Uses the data API; storage bucket name is injected via defineStorage access (SSM).
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-analyse/resource.ts
+++ b/amplify/functions/job-market-analyse/resource.ts
@@ -1,0 +1,15 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Analysis worker: Bedrock embeddings (contentHash cache), descriptive stats, k-means.
+ * Invoked asynchronously by the recompute orchestrator — not guest-callable.
+ */
+export const jobMarketAnalyse = defineFunction({
+  name: 'job-market-analyse',
+  entry: './handler.ts',
+  timeoutSeconds: 300,
+  memoryMB: 1024,
+  environment: {
+    BEDROCK_MODEL_ID: 'amazon.titan-embed-text-v2:0',
+  },
+});

--- a/amplify/functions/job-market-analyse/run.test.ts
+++ b/amplify/functions/job-market-analyse/run.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JobDescriptionCorpusRecord } from './corpus';
+import { executeAnalysisRun } from './run';
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    s3Key: `raw/${overrides.id}.md`,
+    contentHash: `hash-${overrides.id}`,
+    ...overrides,
+  };
+}
+
+describe('executeAnalysisRun', () => {
+  it('excludes archived documents from analysis and publishes on success', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['active', doc({ id: 'active', title: 'Active role', seniority: 'senior' })],
+      ['archived', doc({ id: 'archived', status: 'archived', title: 'Old role' })],
+    ]);
+    const publication = { currentSnapshotId: 'snap-old' };
+    const snapshots = new Map<string, unknown>();
+    const runs = new Map<string, { id: string; status: string }>([
+      ['run-1', { id: 'run-1', status: 'queued' }],
+    ]);
+
+    const result = await executeAnalysisRun({
+      runId: 'run-1',
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      loadMarkdown: async (s3Key) =>
+        s3Key.includes('archived')
+          ? 'ARCHIVED SHOULD NOT APPEAR python'
+          : 'Python SQL modelling experience required',
+      embed: async () => ({
+        vector: [0.1, 0.2, 0.3, 0.4],
+        inputTokens: 8,
+        estimatedCostUsd: 0.0002,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      saveSnapshot: async (snapshot) => {
+        snapshots.set(snapshot.id, snapshot);
+        return snapshot;
+      },
+      updateRun: async (run) => {
+        runs.set(run.id, run);
+        return run;
+      },
+      updatePublication: async (next) => {
+        publication.currentSnapshotId = next.currentSnapshotId;
+      },
+      getPublication: async () => publication,
+      createSnapshotId: () => 'snap-new',
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(publication.currentSnapshotId).toBe('snap-new');
+    expect(snapshots.get('snap-new')).toMatchObject({
+      id: 'snap-new',
+      payload: expect.objectContaining({
+        documentCount: 1,
+      }),
+    });
+    expect(JSON.stringify(snapshots.get('snap-new'))).not.toMatch(/ARCHIVED SHOULD NOT APPEAR/i);
+    expect(runs.get('run-1')).toMatchObject({
+      status: 'succeeded',
+      docsConsidered: 1,
+    });
+  });
+
+  it('keeps the last good publication when a run fails', async () => {
+    const publication = { currentSnapshotId: 'snap-good' };
+    const updatePublication = vi.fn();
+
+    const result = await executeAnalysisRun({
+      runId: 'run-fail',
+      listJobDescriptions: async () => [doc({ id: 'active' })],
+      saveJobDescription: async () => undefined,
+      loadMarkdown: async () => {
+        throw new Error('S3 unavailable');
+      },
+      embed: async () => ({
+        vector: [0.1, 0.2],
+        inputTokens: 1,
+        estimatedCostUsd: 0.0001,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      saveSnapshot: async (snapshot) => snapshot,
+      updateRun: async (run) => run,
+      updatePublication,
+      getPublication: async () => publication,
+      createSnapshotId: () => 'snap-should-not-publish',
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      reason: 'S3 unavailable',
+    });
+    expect(publication.currentSnapshotId).toBe('snap-good');
+    expect(updatePublication).not.toHaveBeenCalled();
+  });
+});

--- a/amplify/functions/job-market-analyse/run.ts
+++ b/amplify/functions/job-market-analyse/run.ts
@@ -1,0 +1,120 @@
+import {
+  prepareActiveCorpusForAnalysis,
+  type JobDescriptionCorpusRecord,
+} from './corpus';
+import {
+  analyseCorpus,
+  type AnalyseCorpusDeps,
+  type CorpusSnapshotPayload,
+} from './analyse';
+import type { AnalysisRunRecord } from '../job-market-recompute/orchestrator';
+
+export type StoredCorpusSnapshot = {
+  id: string;
+  runId: string;
+  payload: CorpusSnapshotPayload;
+  createdAt: string;
+};
+
+export type LabPublicationPointer = {
+  currentSnapshotId: string;
+};
+
+export type ExecuteAnalysisRunDeps = {
+  runId: string;
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  loadMarkdown: (s3Key: string) => Promise<string>;
+  embed: AnalyseCorpusDeps['embed'];
+  getCachedEmbedding: AnalyseCorpusDeps['getCachedEmbedding'];
+  putCachedEmbedding: AnalyseCorpusDeps['putCachedEmbedding'];
+  saveSnapshot: (snapshot: StoredCorpusSnapshot) => Promise<StoredCorpusSnapshot>;
+  updateRun: (run: AnalysisRunRecord) => Promise<AnalysisRunRecord>;
+  updatePublication: (publication: LabPublicationPointer) => Promise<void>;
+  getPublication: () => Promise<LabPublicationPointer | null>;
+  createSnapshotId?: () => string;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export type ExecuteAnalysisRunResult =
+  | { status: 'succeeded'; snapshot: StoredCorpusSnapshot; run: AnalysisRunRecord }
+  | { status: 'failed'; reason: string };
+
+export async function executeAnalysisRun(
+  deps: ExecuteAnalysisRunDeps,
+): Promise<ExecuteAnalysisRunResult> {
+  const now = deps.now ?? new Date();
+
+  try {
+    await deps.updateRun({
+      id: deps.runId,
+      status: 'running',
+      createdAt: now.toISOString(),
+    });
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: deps.listJobDescriptions,
+      saveJobDescription: deps.saveJobDescription,
+      now,
+      maxAgeMonths: deps.maxAgeMonths,
+    });
+
+    const analyzable: Array<{
+      id: string;
+      contentHash: string;
+      markdown: string;
+      seniority?: string;
+      roleFamily?: string;
+      title?: string;
+    }> = [];
+    for (const record of active) {
+      const s3Key = record.s3Key ?? record.id;
+      const markdown = await deps.loadMarkdown(s3Key);
+      analyzable.push({
+        id: record.id,
+        contentHash: record.contentHash ?? record.id,
+        markdown,
+        seniority: record.seniority,
+        roleFamily: record.roleFamily,
+        title: record.title,
+      });
+    }
+
+    const analysis = await analyseCorpus(analyzable, {
+      embed: deps.embed,
+      getCachedEmbedding: deps.getCachedEmbedding,
+      putCachedEmbedding: deps.putCachedEmbedding,
+      now,
+    });
+
+    const snapshot: StoredCorpusSnapshot = {
+      id: deps.createSnapshotId?.() ?? `snap-${now.toISOString()}`,
+      runId: deps.runId,
+      payload: analysis.snapshot,
+      createdAt: now.toISOString(),
+    };
+
+    await deps.saveSnapshot(snapshot);
+    await deps.updatePublication({ currentSnapshotId: snapshot.id });
+
+    const run: AnalysisRunRecord = {
+      id: deps.runId,
+      status: 'succeeded',
+      createdAt: now.toISOString(),
+      ...analysis.metrics,
+    };
+    await deps.updateRun(run);
+
+    return { status: 'succeeded', snapshot, run };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'Analysis failed';
+    await deps.updateRun({
+      id: deps.runId,
+      status: 'failed',
+      createdAt: now.toISOString(),
+      errorMessage: reason,
+    });
+    return { status: 'failed', reason };
+  }
+}

--- a/amplify/functions/job-market-ingest/fixtures/invalid-yaml.md
+++ b/amplify/functions/job-market-ingest/fixtures/invalid-yaml.md
@@ -1,0 +1,6 @@
+---
+collectedAt: [this is: not: valid
+title: Broken
+---
+
+Body with invalid YAML frontmatter.

--- a/amplify/functions/job-market-ingest/fixtures/missing-collected-at.md
+++ b/amplify/functions/job-market-ingest/fixtures/missing-collected-at.md
@@ -1,0 +1,6 @@
+---
+title: Missing collectedAt
+seniority: junior
+---
+
+Body without a required collectedAt field.

--- a/amplify/functions/job-market-ingest/fixtures/missing-frontmatter.md
+++ b/amplify/functions/job-market-ingest/fixtures/missing-frontmatter.md
@@ -1,0 +1,3 @@
+# No frontmatter
+
+Just a markdown body with no YAML block.

--- a/amplify/functions/job-market-ingest/fixtures/valid-jd.md
+++ b/amplify/functions/job-market-ingest/fixtures/valid-jd.md
@@ -1,0 +1,9 @@
+---
+collectedAt: 2026-06-15T10:00:00.000Z
+title: Senior Data Scientist
+seniority: senior
+roleFamily: data-science
+source: confidential-board
+---
+
+We are looking for a senior data scientist to lead modelling work across credit risk portfolios.

--- a/amplify/functions/job-market-ingest/handler.ts
+++ b/amplify/functions/job-market-ingest/handler.ts
@@ -1,0 +1,87 @@
+import type { S3Handler } from 'aws-lambda';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { env } from '$amplify/env/job-market-ingest';
+import type { Schema } from '../../data/resource';
+import {
+  ingestJobDescription,
+  type JobDescriptionRecord,
+} from './ingest';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const s3 = new S3Client();
+
+async function upsertJobDescription(
+  record: JobDescriptionRecord,
+): Promise<void> {
+  const payload = {
+    id: record.id,
+    s3Key: record.s3Key,
+    contentHash: record.contentHash,
+    collectedAt: record.collectedAt,
+    status: record.status,
+    ...(record.title !== undefined ? { title: record.title } : {}),
+    ...(record.seniority !== undefined ? { seniority: record.seniority } : {}),
+    ...(record.roleFamily !== undefined ? { roleFamily: record.roleFamily } : {}),
+    ...(record.source !== undefined ? { source: record.source } : {}),
+  };
+
+  const existing = await client.models.JobDescription.get({ id: record.id });
+  if (existing.data) {
+    const { errors } = await client.models.JobDescription.update(payload);
+    if (errors?.length) {
+      throw new Error(errors.map((error) => error.message).join('; '));
+    }
+    return;
+  }
+
+  const { errors } = await client.models.JobDescription.create(payload);
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+function decodeS3Key(key: string): string {
+  return decodeURIComponent(key.replace(/\+/g, ' '));
+}
+
+export const handler: S3Handler = async (event) => {
+  for (const record of event.Records) {
+    const s3Key = decodeS3Key(record.s3.object.key);
+    if (!s3Key.startsWith('raw/')) {
+      continue;
+    }
+
+    const bucket = record.s3.bucket.name;
+    const object = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: s3Key }),
+    );
+    const body = await object.Body?.transformToString('utf-8');
+    if (!body) {
+      const message = `[job-market-ingest] Empty object body for ${s3Key}`;
+      console.error(message);
+      throw new Error(message);
+    }
+
+    const result = await ingestJobDescription(
+      { s3Key, body },
+      { upsertJobDescription },
+    );
+
+    if (result.status === 'rejected') {
+      const message = `[job-market-ingest] Rejected ${s3Key}: ${result.reason}`;
+      console.error(message);
+      throw new Error(message);
+    }
+
+    console.log(
+      `[job-market-ingest] Ingested ${s3Key} hash=${result.record.contentHash}`,
+    );
+  }
+};

--- a/amplify/functions/job-market-ingest/ingest.test.ts
+++ b/amplify/functions/job-market-ingest/ingest.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { ingestJobDescription } from './ingest';
+
+const fixturesDir = path.join(import.meta.dirname, 'fixtures');
+
+function readFixture(name: string): string {
+  return readFileSync(path.join(fixturesDir, name), 'utf8');
+}
+
+describe('ingestJobDescription', () => {
+  it('upserts an active JobDescription from valid frontmatter markdown', async () => {
+    const body = readFixture('valid-jd.md');
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/valid-jd.md', body },
+      { upsertJobDescription },
+    );
+
+    expect(result).toMatchObject({
+      status: 'ingested',
+      record: {
+        id: 'raw/valid-jd.md',
+        s3Key: 'raw/valid-jd.md',
+        collectedAt: '2026-06-15T10:00:00.000Z',
+        status: 'active',
+        title: 'Senior Data Scientist',
+        seniority: 'senior',
+        roleFamily: 'data-science',
+        source: 'confidential-board',
+      },
+    });
+    expect(result.status).toBe('ingested');
+    if (result.status === 'ingested') {
+      expect(result.record.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+    expect(upsertJobDescription).toHaveBeenCalledOnce();
+    expect(upsertJobDescription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'raw/valid-jd.md',
+        s3Key: 'raw/valid-jd.md',
+        status: 'active',
+        collectedAt: '2026-06-15T10:00:00.000Z',
+      }),
+    );
+  });
+
+  it('rejects missing frontmatter without upserting', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/missing-frontmatter.md', body: readFixture('missing-frontmatter.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Missing YAML frontmatter',
+    });
+    expect(upsertJobDescription).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing collectedAt without upserting', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/missing-collected-at.md', body: readFixture('missing-collected-at.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Frontmatter requires a valid collectedAt',
+    });
+    expect(upsertJobDescription).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid YAML frontmatter without upserting', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/invalid-yaml.md', body: readFixture('invalid-yaml.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result.status).toBe('rejected');
+    if (result.status === 'rejected') {
+      expect(result.reason.length).toBeGreaterThan(0);
+    }
+    expect(upsertJobDescription).not.toHaveBeenCalled();
+  });
+
+  it('changes contentHash when file contents change', async () => {
+    const s3Key = 'raw/valid-jd.md';
+    const original = readFixture('valid-jd.md');
+    const updated = `${original}\n\nUpdated requirement: PyTorch experience.\n`;
+    const upsertJobDescription = vi.fn(async () => undefined);
+
+    const first = await ingestJobDescription(
+      { s3Key, body: original },
+      { upsertJobDescription },
+    );
+    const second = await ingestJobDescription(
+      { s3Key, body: updated },
+      { upsertJobDescription },
+    );
+
+    expect(first.status).toBe('ingested');
+    expect(second.status).toBe('ingested');
+    if (first.status === 'ingested' && second.status === 'ingested') {
+      expect(second.record.contentHash).not.toBe(first.record.contentHash);
+      expect(second.record.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it('does not start corpus recompute on ingest', async () => {
+    const upsertJobDescription = vi.fn(async () => undefined);
+    const startRecompute = vi.fn(async () => undefined);
+
+    const result = await ingestJobDescription(
+      { s3Key: 'raw/valid-jd.md', body: readFixture('valid-jd.md') },
+      { upsertJobDescription },
+    );
+
+    expect(result.status).toBe('ingested');
+    expect(upsertJobDescription).toHaveBeenCalledOnce();
+    expect(startRecompute).not.toHaveBeenCalled();
+  });
+});

--- a/amplify/functions/job-market-ingest/ingest.ts
+++ b/amplify/functions/job-market-ingest/ingest.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto';
+import matter from 'gray-matter';
+
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionRecord = {
+  id: string;
+  s3Key: string;
+  contentHash: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+};
+
+export type IngestResult =
+  | { status: 'ingested'; record: JobDescriptionRecord }
+  | { status: 'rejected'; reason: string };
+
+export type UpsertJobDescription = (
+  record: JobDescriptionRecord,
+) => Promise<void>;
+
+export type IngestJobDescriptionDeps = {
+  upsertJobDescription: UpsertJobDescription;
+};
+
+function optionalString(
+  value: unknown,
+): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function formatCollectedAt(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return undefined;
+    }
+    return parsed.toISOString();
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+
+  return undefined;
+}
+
+export async function ingestJobDescription(
+  input: { s3Key: string; body: string },
+  deps: IngestJobDescriptionDeps,
+): Promise<IngestResult> {
+  if (!input.body.startsWith('---')) {
+    return {
+      status: 'rejected',
+      reason: 'Missing YAML frontmatter',
+    };
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    ({ data } = matter(input.body) as { data: Record<string, unknown> });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid frontmatter';
+    return { status: 'rejected', reason: message };
+  }
+
+  const collectedAt = formatCollectedAt(data.collectedAt);
+  if (!collectedAt) {
+    return {
+      status: 'rejected',
+      reason: 'Frontmatter requires a valid collectedAt',
+    };
+  }
+
+  const record: JobDescriptionRecord = {
+    id: input.s3Key,
+    s3Key: input.s3Key,
+    contentHash: createHash('sha256').update(input.body, 'utf8').digest('hex'),
+    collectedAt,
+    status: 'active',
+    title: optionalString(data.title),
+    seniority: optionalString(data.seniority),
+    roleFamily: optionalString(data.roleFamily),
+    source: optionalString(data.source),
+  };
+
+  await deps.upsertJobDescription(record);
+
+  return { status: 'ingested', record };
+}

--- a/amplify/functions/job-market-ingest/resource.ts
+++ b/amplify/functions/job-market-ingest/resource.ts
@@ -7,4 +7,6 @@ import { defineFunction } from '@aws-amplify/backend';
 export const jobMarketIngest = defineFunction({
   name: 'job-market-ingest',
   entry: './handler.ts',
+  // Shares the data stack: ingest writes JobDescription rows via the data API.
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-ingest/resource.ts
+++ b/amplify/functions/job-market-ingest/resource.ts
@@ -1,0 +1,10 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * S3 ObjectCreated ingest for job-description markdown under raw/*.
+ * Does not start corpus recompute — that stays an admin on-demand action.
+ */
+export const jobMarketIngest = defineFunction({
+  name: 'job-market-ingest',
+  entry: './handler.ts',
+});

--- a/amplify/functions/job-market-ingest/wiring.test.ts
+++ b/amplify/functions/job-market-ingest/wiring.test.ts
@@ -14,8 +14,14 @@ describe('job market lab ingest wiring', () => {
     expect(backendTs).toMatch(/prefix:\s*'raw\/'/);
   });
 
-  it('does not wire corpus recompute into the ingest path', () => {
-    expect(backendTs).not.toMatch(/recompute/i);
-    expect(backendTs).not.toMatch(/AnalysisRun/);
+  it('does not start recompute from the S3 ObjectCreated ingest notification', () => {
+    const notificationBlock =
+      backendTs.match(
+        /addEventNotification\([\s\S]*?\);\s*/,
+      )?.[0] ?? '';
+
+    expect(notificationBlock).toMatch(/jobMarketIngest\.resources\.lambda/);
+    expect(notificationBlock).not.toMatch(/jobMarketRecompute/);
+    expect(notificationBlock).not.toMatch(/AnalysisRun/);
   });
 });

--- a/amplify/functions/job-market-ingest/wiring.test.ts
+++ b/amplify/functions/job-market-ingest/wiring.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('job market lab ingest wiring', () => {
+  const backendTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'backend.ts'),
+    'utf8',
+  );
+
+  it('registers the ingest function and raw/ ObjectCreated notification', () => {
+    expect(backendTs).toMatch(/jobMarketIngest/);
+    expect(backendTs).toMatch(/EventType\.OBJECT_CREATED/);
+    expect(backendTs).toMatch(/prefix:\s*'raw\/'/);
+  });
+
+  it('does not wire corpus recompute into the ingest path', () => {
+    expect(backendTs).not.toMatch(/recompute/i);
+    expect(backendTs).not.toMatch(/AnalysisRun/);
+  });
+});

--- a/amplify/functions/job-market-publication/handler.ts
+++ b/amplify/functions/job-market-publication/handler.ts
@@ -1,0 +1,31 @@
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { env } from '$amplify/env/job-market-publication';
+import type { Schema } from '../../data/resource';
+import type { CorpusSnapshotPayload } from '../job-market-analyse/analyse';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const PUBLICATION_ID = 'current';
+
+export const handler: Schema['getPublishedJobMarketSnapshot']['functionHandler'] =
+  async () => {
+    const publication = await client.models.LabPublication.get({
+      id: PUBLICATION_ID,
+    });
+    const snapshotId = publication.data?.currentSnapshotId;
+    if (!snapshotId) {
+      return null;
+    }
+
+    const snapshot = await client.models.CorpusSnapshot.get({ id: snapshotId });
+    if (!snapshot.data?.payload) {
+      return null;
+    }
+
+    return snapshot.data.payload as CorpusSnapshotPayload;
+  };

--- a/amplify/functions/job-market-publication/resource.ts
+++ b/amplify/functions/job-market-publication/resource.ts
@@ -1,0 +1,9 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Guest-readable publication query: LabPublication pointer → CorpusSnapshot payload.
+ */
+export const jobMarketPublication = defineFunction({
+  name: 'job-market-publication',
+  entry: './handler.ts',
+});

--- a/amplify/functions/job-market-publication/resource.ts
+++ b/amplify/functions/job-market-publication/resource.ts
@@ -6,4 +6,6 @@ import { defineFunction } from '@aws-amplify/backend';
 export const jobMarketPublication = defineFunction({
   name: 'job-market-publication',
   entry: './handler.ts',
+  // Custom query resolver — must live in the data stack.
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-recompute/handler.ts
+++ b/amplify/functions/job-market-recompute/handler.ts
@@ -1,0 +1,93 @@
+import type { Schema } from '../../data/resource';
+import { getAmplifyDataClientConfig } from '@aws-amplify/backend/function/runtime';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+import { env } from '$amplify/env/job-market-recompute';
+import {
+  DEFAULT_MAX_ACTIVE_DOCS,
+  startRecompute,
+  type AnalysisRunRecord,
+} from './orchestrator';
+
+const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
+
+Amplify.configure(resourceConfig, libraryOptions);
+
+const client = generateClient<Schema>();
+const lambda = new LambdaClient({});
+
+async function listInFlightRuns(): Promise<AnalysisRunRecord[]> {
+  const { data, errors } = await client.models.AnalysisRun.list({
+    filter: {
+      or: [
+        { status: { eq: 'queued' } },
+        { status: { eq: 'running' } },
+      ],
+    },
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return (data ?? []).map((run) => ({
+    id: run.id,
+    status: run.status as AnalysisRunRecord['status'],
+    createdAt: run.createdAt,
+  }));
+}
+
+async function countActiveDocuments(): Promise<number> {
+  const { data, errors } = await client.models.JobDescription.list({
+    filter: { status: { eq: 'active' } },
+  });
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+  return data?.length ?? 0;
+}
+
+async function createRun(run: AnalysisRunRecord): Promise<AnalysisRunRecord> {
+  const { data, errors } = await client.models.AnalysisRun.create({
+    id: run.id,
+    status: run.status,
+  });
+  if (errors?.length || !data) {
+    throw new Error(errors?.map((error) => error.message).join('; ') ?? 'Failed to create run');
+  }
+  return {
+    id: data.id,
+    status: data.status as AnalysisRunRecord['status'],
+    createdAt: data.createdAt,
+  };
+}
+
+async function invokeWorker(runId: string): Promise<void> {
+  const functionName = env.JOB_MARKET_ANALYSE_FUNCTION_NAME;
+  if (!functionName) {
+    throw new Error('JOB_MARKET_ANALYSE_FUNCTION_NAME is not configured');
+  }
+
+  await lambda.send(
+    new InvokeCommand({
+      FunctionName: functionName,
+      InvocationType: 'Event',
+      Payload: Buffer.from(JSON.stringify({ runId })),
+    }),
+  );
+}
+
+export const handler: Schema['startJobMarketRecompute']['functionHandler'] = async () => {
+  const result = await startRecompute({
+    listInFlightRuns,
+    countActiveDocuments,
+    createRun,
+    invokeWorker,
+    maxActiveDocs: Number(env.MAX_ACTIVE_DOCS ?? DEFAULT_MAX_ACTIVE_DOCS),
+  });
+
+  if (result.status === 'rejected') {
+    return { status: 'rejected', reason: result.reason };
+  }
+
+  return { status: 'started', runId: result.run.id };
+};

--- a/amplify/functions/job-market-recompute/orchestrator.test.ts
+++ b/amplify/functions/job-market-recompute/orchestrator.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MAX_ACTIVE_DOCS,
+  startRecompute,
+  type AnalysisRunRecord,
+} from './orchestrator';
+
+describe('startRecompute', () => {
+  it('rejects a second start while a run is queued or running (single-flight)', async () => {
+    const runs: AnalysisRunRecord[] = [
+      {
+        id: 'run-1',
+        status: 'running',
+        createdAt: '2026-07-14T10:00:00.000Z',
+      },
+    ];
+
+    const result = await startRecompute({
+      listInFlightRuns: async () =>
+        runs.filter((run) => run.status === 'queued' || run.status === 'running'),
+      countActiveDocuments: async () => 3,
+      createRun: vi.fn(),
+      invokeWorker: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
+    });
+  });
+
+  it('refuses recompute when the active corpus exceeds the document cap', async () => {
+    const result = await startRecompute({
+      listInFlightRuns: async () => [],
+      countActiveDocuments: async () => DEFAULT_MAX_ACTIVE_DOCS + 1,
+      createRun: vi.fn(),
+      invokeWorker: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: `Active corpus exceeds the ${DEFAULT_MAX_ACTIVE_DOCS}-document cap (${DEFAULT_MAX_ACTIVE_DOCS + 1} active)`,
+    });
+  });
+
+  it('starts a queued run and invokes the worker when the corpus is within caps', async () => {
+    const createRun = vi.fn(async (run: AnalysisRunRecord) => run);
+    const invokeWorker = vi.fn(async () => undefined);
+
+    const result = await startRecompute({
+      listInFlightRuns: async () => [],
+      countActiveDocuments: async () => 2,
+      createRun,
+      invokeWorker,
+      now: new Date('2026-07-14T12:00:00.000Z'),
+      createId: () => 'run-new',
+    });
+
+    expect(result).toEqual({
+      status: 'started',
+      run: {
+        id: 'run-new',
+        status: 'queued',
+        createdAt: '2026-07-14T12:00:00.000Z',
+      },
+    });
+    expect(createRun).toHaveBeenCalledOnce();
+    expect(invokeWorker).toHaveBeenCalledWith('run-new');
+  });
+});

--- a/amplify/functions/job-market-recompute/orchestrator.ts
+++ b/amplify/functions/job-market-recompute/orchestrator.ts
@@ -1,0 +1,67 @@
+export type AnalysisRunStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed';
+
+export type AnalysisRunRecord = {
+  id: string;
+  status: AnalysisRunStatus;
+  createdAt: string;
+  docsConsidered?: number;
+  docsEmbedded?: number;
+  docsCacheHit?: number;
+  clusterCount?: number;
+  bedrockInputTokens?: number;
+  estimatedCostUsd?: number;
+  errorMessage?: string;
+};
+
+export const DEFAULT_MAX_ACTIVE_DOCS = 150;
+
+export type StartRecomputeResult =
+  | { status: 'started'; run: AnalysisRunRecord }
+  | { status: 'rejected'; reason: string };
+
+export type StartRecomputeDeps = {
+  listInFlightRuns: () => Promise<AnalysisRunRecord[]>;
+  countActiveDocuments: () => Promise<number>;
+  createRun: (run: AnalysisRunRecord) => Promise<AnalysisRunRecord>;
+  invokeWorker: (runId: string) => Promise<void>;
+  now?: Date;
+  maxActiveDocs?: number;
+  createId?: () => string;
+};
+
+export async function startRecompute(
+  deps: StartRecomputeDeps,
+): Promise<StartRecomputeResult> {
+  const inFlight = await deps.listInFlightRuns();
+  if (inFlight.length > 0) {
+    return {
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
+    };
+  }
+
+  const maxActiveDocs = deps.maxActiveDocs ?? DEFAULT_MAX_ACTIVE_DOCS;
+  const activeCount = await deps.countActiveDocuments();
+  if (activeCount > maxActiveDocs) {
+    return {
+      status: 'rejected',
+      reason: `Active corpus exceeds the ${maxActiveDocs}-document cap (${activeCount} active)`,
+    };
+  }
+
+  const now = deps.now ?? new Date();
+  const run: AnalysisRunRecord = {
+    id: deps.createId?.() ?? `run-${now.toISOString()}`,
+    status: 'queued',
+    createdAt: now.toISOString(),
+  };
+
+  const created = await deps.createRun(run);
+  await deps.invokeWorker(created.id);
+
+  return { status: 'started', run: created };
+}

--- a/amplify/functions/job-market-recompute/resource.ts
+++ b/amplify/functions/job-market-recompute/resource.ts
@@ -8,4 +8,6 @@ export const jobMarketRecompute = defineFunction({
   name: 'job-market-recompute',
   entry: './handler.ts',
   timeoutSeconds: 60,
+  // Data mutation handler + Amplify Data client — must live in the data stack.
+  resourceGroupName: 'data',
 });

--- a/amplify/functions/job-market-recompute/resource.ts
+++ b/amplify/functions/job-market-recompute/resource.ts
@@ -1,0 +1,11 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Owner-only on-demand recompute orchestrator.
+ * Creates an AnalysisRun (single-flight + active-doc caps) and invokes the analyse worker.
+ */
+export const jobMarketRecompute = defineFunction({
+  name: 'job-market-recompute',
+  entry: './handler.ts',
+  timeoutSeconds: 60,
+});

--- a/amplify/functions/job-market-recompute/wiring.test.ts
+++ b/amplify/functions/job-market-recompute/wiring.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('job market recompute wiring', () => {
+  const backendTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'backend.ts'),
+    'utf8',
+  );
+  const authTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'auth', 'resource.ts'),
+    'utf8',
+  );
+  const dataTs = readFileSync(
+    path.join(process.cwd(), 'amplify', 'data', 'resource.ts'),
+    'utf8',
+  );
+
+  it('disables Cognito self-sign-up (admin create only)', () => {
+    expect(backendTs).toMatch(/allowAdminCreateUserOnly:\s*true/);
+    expect(authTs).toMatch(/loginWith:\s*\{[\s\S]*email:\s*true/);
+  });
+
+  it('wires recompute orchestration to the analyse worker', () => {
+    expect(backendTs).toMatch(/jobMarketRecompute/);
+    expect(backendTs).toMatch(/jobMarketAnalyse/);
+    expect(backendTs).toMatch(/JOB_MARKET_ANALYSE_FUNCTION_NAME/);
+    expect(backendTs).toMatch(/grantInvoke/);
+  });
+
+  it('exposes guest publication query and authenticated recompute mutation', () => {
+    expect(dataTs).toMatch(/getPublishedJobMarketSnapshot/);
+    expect(dataTs).toMatch(/startJobMarketRecompute/);
+    expect(dataTs).toMatch(/allow\.guest\(\)/);
+    expect(dataTs).toMatch(/AnalysisRun/);
+    expect(dataTs).toMatch(/CorpusSnapshot/);
+    expect(dataTs).toMatch(/LabPublication/);
+  });
+});

--- a/amplify/functions/lab-placeholder/handler.ts
+++ b/amplify/functions/lab-placeholder/handler.ts
@@ -1,4 +1,0 @@
-export const handler = async () => ({
-  statusCode: 200,
-  body: 'job-market-lab-placeholder',
-});

--- a/amplify/functions/lab-placeholder/resource.ts
+++ b/amplify/functions/lab-placeholder/resource.ts
@@ -1,9 +1,0 @@
-import { defineFunction } from '@aws-amplify/backend';
-
-/**
- * Placeholder function so the Gen 2 functions directory is wired.
- * Ingest / recompute handlers replace this in later slices.
- */
-export const labPlaceholder = defineFunction({
-  name: 'job-market-lab-placeholder',
-});

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -1,9 +1,11 @@
 import { defineStorage } from '@aws-amplify/backend';
 import { jobMarketIngest } from '../functions/job-market-ingest/resource';
+import { jobMarketAnalyse } from '../functions/job-market-analyse/resource';
 
 /**
  * Job market lab corpus storage.
  * raw/* — markdown JDs (ingest trigger wired in backend.ts for this prefix only).
+ * embeddings/* — contentHash embedding cache for the analyse worker.
  */
 export const storage = defineStorage({
   name: 'jobMarketLab',
@@ -11,8 +13,12 @@ export const storage = defineStorage({
     'raw/*': [
       allow.authenticated.to(['read', 'write', 'delete']),
       allow.resource(jobMarketIngest).to(['read']),
+      allow.resource(jobMarketAnalyse).to(['read']),
     ],
-    'embeddings/*': [allow.authenticated.to(['read', 'write', 'delete'])],
+    'embeddings/*': [
+      allow.authenticated.to(['read', 'write', 'delete']),
+      allow.resource(jobMarketAnalyse).to(['read', 'write']),
+    ],
     'artefacts/*': [allow.authenticated.to(['read', 'write', 'delete'])],
   }),
 });

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -1,13 +1,17 @@
 import { defineStorage } from '@aws-amplify/backend';
+import { jobMarketIngest } from '../functions/job-market-ingest/resource';
 
 /**
- * Job market lab storage skeleton.
- * Prefix layout (raw / embeddings / artefacts) is refined in ingest and recompute slices.
+ * Job market lab corpus storage.
+ * raw/* — markdown JDs (ingest trigger wired in backend.ts for this prefix only).
  */
 export const storage = defineStorage({
   name: 'jobMarketLab',
   access: (allow) => ({
-    'raw/*': [allow.authenticated.to(['read', 'write', 'delete'])],
+    'raw/*': [
+      allow.authenticated.to(['read', 'write', 'delete']),
+      allow.resource(jobMarketIngest).to(['read']),
+    ],
     'embeddings/*': [allow.authenticated.to(['read', 'write', 'delete'])],
     'artefacts/*': [allow.authenticated.to(['read', 'write', 'delete'])],
   }),

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -15,6 +15,21 @@ Backend definitions live in `amplify/` (auth, data, storage, and the job-market 
 
 Script-first JD ingest: with sandbox/Hosting outputs present, `npm run ingest:jd -- path/to/file.md` uploads markdown to the `raw/` prefix; the ingest Lambda upserts `JobDescription` metadata and does not start recompute.
 
+Owner recompute (Cognito email/password, self-sign-up disabled via `allowAdminCreateUserOnly`): authenticated `startJobMarketRecompute` creates a single-flight `AnalysisRun` (refuses above 150 active docs), then asynchronously invokes the analyse worker. The worker reads active markdown from S3, uses Bedrock embeddings with a `embeddings/{contentHash}.json` cache, writes `CorpusSnapshot` + run metrics, and updates `LabPublication` only on success. Guests read aggregates only via `getPublishedJobMarketSnapshot`.
+
+### Minimal CloudWatch cost / alerting path
+
+After the Gen 2 backend is deployed, configure these in the AWS console (names only; no committed secrets):
+
+| Alarm / metric | Where | Suggested use |
+|----------------|--------|----------------|
+| `AWS/Lambda` `Errors` on `job-market-analyse` | CloudWatch alarm | Page on repeated worker failures |
+| `AWS/Lambda` `Duration` / `Throttles` on analyse + recompute | CloudWatch alarm | Catch runaway or concurrency issues |
+| `AWS/Bedrock` `Invocations` / model invocation latency | CloudWatch metrics (region of Bedrock) | Spot unexpected embed volume |
+| Estimated cost from `AnalysisRun.estimatedCostUsd` | App metric / log filter on analyse success logs | Spot spend anomalies before the next recompute |
+
+V1 does not ship a dedicated billing budget in CDK; create a Billing → Budgets alert for Bedrock + Lambda in the account that hosts the Amplify app if spend sensitivity is high. Run-level token/cost fields on `AnalysisRun` are the product-side source of truth for per-recompute cost.
+
 | Environment | Outputs file |
 |-------------|----------------|
 | **GitHub Actions / marketing-only local** | `amplify_outputs.json` is absent (gitignored). `readAmplifyOutputs()` returns null; `configureSiteAmplify` no-ops so public pages stay up. |

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -11,7 +11,9 @@ There is **no accidental double-deploy** from GitHub Actions: Actions do not pus
 
 ## Amplify Gen 2 backend
 
-Backend definitions live in `amplify/` (auth, data, storage, functions placeholders for the job market lab). Hosting deploys them via `npx ampx pipeline-deploy` in the `backend` phase of `amplify.yml`, then runs the existing frontend `preBuild` (blog sync) and `build`.
+Backend definitions live in `amplify/` (auth, data, storage, and the job-market ingest function for the lab). Hosting deploys them via `npx ampx pipeline-deploy` in the `backend` phase of `amplify.yml`, then runs the existing frontend `preBuild` (blog sync) and `build`.
+
+Script-first JD ingest: with sandbox/Hosting outputs present, `npm run ingest:jd -- path/to/file.md` uploads markdown to the `raw/` prefix; the ingest Lambda upserts `JobDescription` metadata and does not start recompute.
 
 | Environment | Outputs file |
 |-------------|----------------|

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Amplify sandbox / pipeline-deploy artefacts (gitignored)
+    ".amplify/**",
     // Legacy scripts (tracked separately as tech debt)
     "scripts/**",
   ]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "hashadar_website",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
+        "@aws-sdk/client-lambda": "^3.1086.0",
         "@aws-sdk/client-s3": "^3.1086.0",
         "@fontsource/zalando-sans-expanded": "^5.2.1",
         "aws-amplify": "^6.18.0",
@@ -8998,6 +9000,46 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1086.0.tgz",
+      "integrity": "sha512-IuzaMjeJ3P7UnVamYnKlNoR/DAZqybRX4zYEqH7giwm31DuluB2qplydyjSxF07H3/5iuc6lCUbMI7pD/m0yng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.67",
+        "@aws-sdk/eventstream-handler-node": "^3.972.26",
+        "@aws-sdk/middleware-eventstream": "^3.972.22",
+        "@aws-sdk/middleware-websocket": "^3.972.39",
+        "@aws-sdk/token-providers": "3.1086.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1086.0.tgz",
+      "integrity": "sha512-/d1uB//QrUnIuHmYsB+VByGvezOwiICHZU1JFxLxCcDrmR/zZlfV5sjh91SPvRiK04ckL3GhPeO6L2qG33TKeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cloudcontrol": {
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudcontrol/-/client-cloudcontrol-3.1086.0.tgz",
@@ -9241,7 +9283,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1086.0.tgz",
       "integrity": "sha512-IxsHC4BM1nrSBhJJvZe9ELpPmEl8ZeSZLKoc7sACU2icKqMMF1X06Q78s7NSSoafuTI8xRnFKh7BRHfaGNLvGA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -9650,6 +9691,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
+      "integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/lib-storage": {
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1086.0.tgz",
@@ -9669,6 +9725,21 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3.1086.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
+      "integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
@@ -9737,6 +9808,24 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
+      "integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hashadar_website",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1086.0",
         "@fontsource/zalando-sans-expanded": "^5.2.1",
         "aws-amplify": "^6.18.0",
         "clsx": "^2.1.1",
@@ -38,6 +39,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/aws-lambda": "^8.10.162",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -8904,7 +8906,6 @@
       "version": "3.1000.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
       "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -9321,7 +9322,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1086.0.tgz",
       "integrity": "sha512-6+7mVMPKetZmmF2L1yRJ+rN9b1OwVgc5sju2mj8ixdxuGjtVZ0ekFlcWGBFMQT9gpFk55PPLBng/XRYO3qah5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.16",
@@ -9726,7 +9726,6 @@
       "version": "3.972.62",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
       "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "node": ">=22"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
+    "@aws-sdk/client-lambda": "^3.1086.0",
     "@aws-sdk/client-s3": "^3.1086.0",
     "@fontsource/zalando-sans-expanded": "^5.2.1",
     "aws-amplify": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "sandbox": "npx ampx sandbox"
+    "sandbox": "npx ampx sandbox",
+    "ingest:jd": "node scripts/ingest-job-description.mjs"
   },
   "engines": {
     "node": ">=22"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1086.0",
     "@fontsource/zalando-sans-expanded": "^5.2.1",
     "aws-amplify": "^6.18.0",
     "clsx": "^2.1.1",
@@ -46,6 +48,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/aws-lambda": "^8.10.162",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/scripts/ingest-job-description.mjs
+++ b/scripts/ingest-job-description.mjs
@@ -1,0 +1,77 @@
+/**
+ * Upload a job-description markdown file to the lab raw/ corpus prefix.
+ *
+ * Requires amplify_outputs.json (from `npm run sandbox` or Hosting) and AWS
+ * credentials that can PutObject to the storage bucket. The S3 ObjectCreated
+ * trigger upserts JobDescription metadata; recompute is not started.
+ *
+ * Usage: node scripts/ingest-job-description.mjs <path-to.md> [optional-object-name.md]
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outputsPath = path.join(root, 'amplify_outputs.json');
+
+const filePath = process.argv[2];
+const objectName = process.argv[3];
+
+if (!filePath) {
+  console.error(
+    'Usage: node scripts/ingest-job-description.mjs <path-to.md> [optional-object-name.md]',
+  );
+  process.exit(1);
+}
+
+if (!existsSync(outputsPath)) {
+  console.error(
+    'amplify_outputs.json not found. Run `npm run sandbox` (or deploy) first.',
+  );
+  process.exit(1);
+}
+
+const outputs = JSON.parse(readFileSync(outputsPath, 'utf8'));
+const bucketName = outputs.storage?.bucket_name;
+const region = outputs.storage?.aws_region;
+
+if (!bucketName || !region) {
+  console.error(
+    'amplify_outputs.json is missing storage.bucket_name / storage.aws_region.',
+  );
+  process.exit(1);
+}
+
+const absolutePath = path.resolve(filePath);
+if (!existsSync(absolutePath)) {
+  console.error(`File not found: ${absolutePath}`);
+  process.exit(1);
+}
+
+const body = readFileSync(absolutePath);
+const keyName = objectName ?? path.basename(absolutePath);
+if (!keyName.toLowerCase().endsWith('.md')) {
+  console.error('Object name must end with .md');
+  process.exit(1);
+}
+
+const key = `raw/${keyName}`;
+const client = new S3Client({ region });
+
+await client.send(
+  new PutObjectCommand({
+    Bucket: bucketName,
+    Key: key,
+    Body: body,
+    ContentType: 'text/markdown; charset=utf-8',
+  }),
+);
+
+console.log(`Uploaded s3://${bucketName}/${key}`);
+console.log(
+  'Ingest Lambda will upsert JobDescription metadata if frontmatter is valid.',
+);

--- a/src/app/labs/job-market/page.test.ts
+++ b/src/app/labs/job-market/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { metadata } from '@/app/labs/job-market/page';
+import { jobMarketLab, site } from '@/data';
+
+describe('Job market lab page metadata', () => {
+  it('derives title and description from job market lab page data', () => {
+    expect(metadata).toMatchObject({
+      title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+      description: jobMarketLab.description,
+      openGraph: {
+        title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+        description: jobMarketLab.description,
+        url: `${site.metadata.siteUrl}/labs/job-market`,
+        type: 'website',
+      },
+    });
+  });
+});

--- a/src/app/labs/job-market/page.tsx
+++ b/src/app/labs/job-market/page.tsx
@@ -1,0 +1,28 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { JobMarketLabSection } from '@/components/sections/labs/job-market-lab-section';
+import { getPageData, site } from '@/data';
+import { getPublishedJobMarketSnapshot } from '@/lib/job-market-lab';
+
+const jobMarketLab = getPageData('/labs/job-market');
+
+export const metadata: Metadata = {
+  title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+  description: jobMarketLab.description,
+  openGraph: {
+    title: `${jobMarketLab.heading} - ${site.metadata.author}`,
+    description: jobMarketLab.description,
+    url: `${site.metadata.siteUrl}/labs/job-market`,
+    type: 'website',
+  },
+};
+
+export default async function JobMarketLabPage() {
+  const publication = await getPublishedJobMarketSnapshot();
+
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <JobMarketLabSection publication={publication} />
+    </SitePage>
+  );
+}

--- a/src/app/labs/page.test.ts
+++ b/src/app/labs/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { metadata } from '@/app/labs/page';
+import { labs, site } from '@/data';
+
+describe('Labs page metadata', () => {
+  it('derives title and description from labs page data', () => {
+    expect(metadata).toMatchObject({
+      title: `${labs.heading} - ${site.metadata.author}`,
+      description: labs.description,
+      openGraph: {
+        title: `${labs.heading} - ${site.metadata.author}`,
+        description: labs.description,
+        url: `${site.metadata.siteUrl}/labs`,
+        type: 'website',
+      },
+    });
+  });
+});

--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { LabsIndexSection } from '@/components/sections/labs/labs-index-section';
+import { getPageData, site } from '@/data';
+
+const labs = getPageData('/labs');
+
+export const metadata: Metadata = {
+  title: `${labs.heading} - ${site.metadata.author}`,
+  description: labs.description,
+  openGraph: {
+    title: `${labs.heading} - ${site.metadata.author}`,
+    description: labs.description,
+    url: `${site.metadata.siteUrl}/labs`,
+    type: 'website',
+  },
+};
+
+export default function LabsPage() {
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <LabsIndexSection />
+    </SitePage>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { site } from "@/data";
 import { AmplifyProvider } from "@/components/amplify-provider";
+import { SiteAuthRoot } from "@/components/site-auth-root";
 import { StructuredData } from "@/components/seo/structured-data";
 import { ThemeScript } from "@/components/theme-script";
 import { readAmplifyOutputs } from "@/lib/read-amplify-outputs";
@@ -60,7 +61,9 @@ export default function RootLayout({
         <StructuredData />
       </head>
       <body className="antialiased">
-        <AmplifyProvider outputs={amplifyOutputs}>{children}</AmplifyProvider>
+        <AmplifyProvider outputs={amplifyOutputs}>
+          <SiteAuthRoot outputs={amplifyOutputs}>{children}</SiteAuthRoot>
+        </AmplifyProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { LoginSection } from '@/components/sections/login/login-section';
+import { getPageData, site } from '@/data';
+
+const login = getPageData('/login');
+
+export const metadata: Metadata = {
+  title: `${login.heading} - ${site.metadata.author}`,
+  description: login.description,
+  openGraph: {
+    title: `${login.heading} - ${site.metadata.author}`,
+    description: login.description,
+    url: `${site.metadata.siteUrl}/login`,
+    type: 'website',
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function LoginPage() {
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <LoginSection />
+    </SitePage>
+  );
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -36,6 +36,27 @@ describe('sitemap', () => {
     });
   });
 
+  it('includes Labs index and job-market lab routes', () => {
+    const entries = sitemap();
+    const labsEntry = entries.find((entry) => entry.url === `${site.metadata.siteUrl}/labs`);
+    const jobMarketEntry = entries.find(
+      (entry) => entry.url === `${site.metadata.siteUrl}/labs/job-market`,
+    );
+
+    expect(labsEntry).toEqual({
+      url: `${site.metadata.siteUrl}/labs`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    });
+    expect(jobMarketEntry).toEqual({
+      url: `${site.metadata.siteUrl}/labs/job-market`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    });
+  });
+
   it('includes blog post URLs with lastModified dates from the reader module', () => {
     const posts = getAllBlogPosts(fixturesDir);
     const entries = buildSitemap(fixturesDir);

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -57,6 +57,18 @@ describe('sitemap', () => {
     });
   });
 
+  it('includes the owner login route', () => {
+    const entries = sitemap();
+    const loginEntry = entries.find((entry) => entry.url === `${site.metadata.siteUrl}/login`);
+
+    expect(loginEntry).toEqual({
+      url: `${site.metadata.siteUrl}/login`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    });
+  });
+
   it('includes blog post URLs with lastModified dates from the reader module', () => {
     const posts = getAllBlogPosts(fixturesDir);
     const entries = buildSitemap(fixturesDir);

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -43,6 +43,9 @@ export function FooterSection() {
                     {email}
                   </a>
                 </Text>
+                <NavLink href={footer.contact.ownerSignIn.href}>
+                  {footer.contact.ownerSignIn.label}
+                </NavLink>
               </div>
             </FooterColumn>
 

--- a/src/components/sections/labs/job-market-lab-admin-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-admin-section.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+import type { StartJobMarketRecompute } from '@/lib/job-market-lab';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderAdmin(options?: {
+  auth?: ReturnType<typeof createMemorySiteAuth>;
+  startRecompute?: StartJobMarketRecompute;
+}) {
+  const auth = options?.auth ?? createMemorySiteAuth();
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <JobMarketLabAdminSection startRecompute={options?.startRecompute} />
+    </SiteAuthProvider>,
+  );
+}
+
+describe('JobMarketLabAdminSection', () => {
+  it('does not show admin controls when the visitor is unauthenticated', async () => {
+    renderAdmin();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking session/i)).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: jobMarketLab.admin.startButtonLabel }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows controls when authenticated and surfaces a started result', async () => {
+    const user = userEvent.setup();
+    const startRecompute = vi.fn<StartJobMarketRecompute>().mockResolvedValue({
+      status: 'started',
+      runId: 'run-42',
+    });
+
+    renderAdmin({
+      auth: createMemorySiteAuth({
+        status: 'authenticated',
+        email: 'owner@example.com',
+      }),
+      startRecompute,
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: jobMarketLab.admin.startButtonLabel }),
+    );
+
+    expect(startRecompute).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText(
+        jobMarketLab.admin.startedMessage.replace('{runId}', 'run-42'),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a rejected single-flight reason to the owner', async () => {
+    const user = userEvent.setup();
+    const startRecompute = vi.fn<StartJobMarketRecompute>().mockResolvedValue({
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
+    });
+
+    renderAdmin({
+      auth: createMemorySiteAuth({
+        status: 'authenticated',
+        email: 'owner@example.com',
+      }),
+      startRecompute,
+    });
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: jobMarketLab.admin.startButtonLabel,
+      }),
+    );
+
+    expect(
+      await screen.findByText(jobMarketLab.admin.rejectedHeading),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('An analysis run is already in progress'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-admin-section.tsx
+++ b/src/components/sections/labs/job-market-lab-admin-section.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Button,
+  Heading,
+  SectionHeader,
+  Text,
+} from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import type {
+  StartJobMarketRecompute,
+  StartJobMarketRecomputeResult,
+} from '@/lib/job-market-lab';
+import { defaultStartJobMarketRecompute } from '@/lib/start-job-market-recompute-client';
+
+export type JobMarketLabAdminSectionProps = {
+  startRecompute?: StartJobMarketRecompute;
+};
+
+export function JobMarketLabAdminSection({
+  startRecompute = defaultStartJobMarketRecompute,
+}: JobMarketLabAdminSectionProps) {
+  const { session, isLoading } = useSiteAuth();
+  const [isStarting, setIsStarting] = useState(false);
+  const [result, setResult] = useState<StartJobMarketRecomputeResult | null>(null);
+
+  if (isLoading || session === null || session.status !== 'authenticated') {
+    return null;
+  }
+
+  async function handleStart() {
+    setIsStarting(true);
+    setResult(null);
+    const next = await startRecompute();
+    setResult(next);
+    setIsStarting(false);
+  }
+
+  return (
+    <div className="mt-16 max-w-2xl space-y-6 border-t border-[var(--border)] pt-12">
+      <div className="space-y-3">
+        <SectionHeader as="h2" size="md" animated={false} showLeftAccent={false}>
+          {jobMarketLab.admin.heading}
+        </SectionHeader>
+        <Text variant="muted">{jobMarketLab.admin.description}</Text>
+      </div>
+
+      <Button
+        type="button"
+        onClick={() => void handleStart()}
+        disabled={isStarting}
+      >
+        {isStarting
+          ? jobMarketLab.admin.startingLabel
+          : jobMarketLab.admin.startButtonLabel}
+      </Button>
+
+      {result?.status === 'started' ? (
+        <p role="status" className="font-body text-base leading-relaxed text-[var(--foreground)]">
+          {jobMarketLab.admin.startedMessage.replace('{runId}', result.runId)}
+        </p>
+      ) : null}
+
+      {result?.status === 'rejected' ? (
+        <div role="alert" className="space-y-2">
+          <Heading as="h3" size="sm">
+            {jobMarketLab.admin.rejectedHeading}
+          </Heading>
+          <Text>{result.reason}</Text>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-corpus-admin.test.tsx
+++ b/src/components/sections/labs/job-market-lab-corpus-admin.test.tsx
@@ -85,8 +85,8 @@ describe('JobMarketLabCorpusAdmin', () => {
     ]);
     renderAdmin(ownerAuth(), corpus);
 
-    expect(await screen.findByText(jobMarketLab.corpusAdmin.heading)).toBeInTheDocument();
-    expect(screen.getByText('Risk modeller')).toBeInTheDocument();
+    expect(await screen.findByText('Risk modeller')).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.corpusAdmin.heading)).toBeInTheDocument();
     expect(screen.getByText('jd-1')).toBeInTheDocument();
     expect(screen.getByText(jobMarketLab.corpusAdmin.statusActiveLabel)).toBeInTheDocument();
     expect(screen.queryByText(/secret JD body|markdown|# Role/i)).not.toBeInTheDocument();

--- a/src/components/sections/labs/job-market-lab-corpus-admin.test.tsx
+++ b/src/components/sections/labs/job-market-lab-corpus-admin.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-lab-corpus-admin';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import type { JobDescriptionCorpusRecord } from '@/lib/job-market-corpus';
+
+afterEach(() => {
+  cleanup();
+});
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    title: 'Sample role',
+    s3Key: `keys/${overrides.id}.md`,
+    contentHash: 'hash',
+    ...overrides,
+  };
+}
+
+function createMemoryCorpus(
+  initial: JobDescriptionCorpusRecord[],
+): AmplifyCorpusDeps & {
+  store: Map<string, JobDescriptionCorpusRecord>;
+  deleteS3: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map(initial.map((item) => [item.id, { ...item }]));
+  const deleteS3 = vi.fn(async () => {
+    throw new Error('S3 delete must never be called for soft-archive');
+  });
+  return {
+    store,
+    deleteS3,
+    async getJobDescription(id) {
+      return store.get(id) ?? null;
+    },
+    async listJobDescriptions() {
+      return [...store.values()];
+    },
+    async saveJobDescription(record) {
+      store.set(record.id, record);
+    },
+  };
+}
+
+function renderAdmin(
+  auth = createMemorySiteAuth(),
+  corpus = createMemoryCorpus([doc({ id: 'jd-1' })]),
+) {
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <JobMarketLabCorpusAdmin corpus={corpus} />
+    </SiteAuthProvider>,
+  );
+}
+
+const ownerAuth = () =>
+  createMemorySiteAuth({ status: 'authenticated', email: 'owner@example.com' });
+
+describe('JobMarketLabCorpusAdmin', () => {
+  it('shows no corpus management controls to guests', async () => {
+    renderAdmin(createMemorySiteAuth({ status: 'unauthenticated' }));
+
+    expect(screen.queryByText(jobMarketLab.corpusAdmin.heading)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: jobMarketLab.corpusAdmin.archiveLabel }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: jobMarketLab.corpusAdmin.restoreLabel }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('jd-1')).not.toBeInTheDocument();
+  });
+
+  it('lets the signed-in owner soft-archive an active job description without deleting storage', async () => {
+    const user = userEvent.setup();
+    const corpus = createMemoryCorpus([
+      doc({ id: 'jd-1', title: 'Risk modeller', status: 'active' }),
+    ]);
+    renderAdmin(ownerAuth(), corpus);
+
+    expect(await screen.findByText(jobMarketLab.corpusAdmin.heading)).toBeInTheDocument();
+    expect(screen.getByText('Risk modeller')).toBeInTheDocument();
+    expect(screen.getByText('jd-1')).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.corpusAdmin.statusActiveLabel)).toBeInTheDocument();
+    expect(screen.queryByText(/secret JD body|markdown|# Role/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: jobMarketLab.corpusAdmin.archiveLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByText(jobMarketLab.corpusAdmin.statusArchivedLabel)).toBeInTheDocument();
+    });
+    expect(corpus.store.get('jd-1')?.status).toBe('archived');
+    expect(corpus.store.has('jd-1')).toBe(true);
+    expect(corpus.deleteS3).not.toHaveBeenCalled();
+  });
+
+  it('lets the signed-in owner restore an archived job description to active', async () => {
+    const user = userEvent.setup();
+    const corpus = createMemoryCorpus([
+      doc({ id: 'jd-2', title: 'Quant analyst', status: 'archived' }),
+    ]);
+    renderAdmin(ownerAuth(), corpus);
+
+    expect(await screen.findByText(jobMarketLab.corpusAdmin.statusArchivedLabel)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: jobMarketLab.corpusAdmin.restoreLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByText(jobMarketLab.corpusAdmin.statusActiveLabel)).toBeInTheDocument();
+    });
+    expect(corpus.store.get('jd-2')?.status).toBe('active');
+    expect(corpus.deleteS3).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-corpus-admin.tsx
+++ b/src/components/sections/labs/job-market-lab-corpus-admin.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import {
+  archiveJobDescription,
+  restoreJobDescription,
+  type JobDescriptionCorpusRecord,
+} from '@/lib/job-market-corpus';
+import {
+  createDefaultAmplifyCorpusDeps,
+  type AmplifyCorpusDeps,
+} from '@/lib/job-market-corpus-amplify';
+
+export type JobMarketLabCorpusAdminProps = {
+  corpus?: AmplifyCorpusDeps;
+};
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; records: JobDescriptionCorpusRecord[] }
+  | { status: 'error' };
+
+function statusLabel(status: JobDescriptionCorpusRecord['status']): string {
+  return status === 'active'
+    ? jobMarketLab.corpusAdmin.statusActiveLabel
+    : jobMarketLab.corpusAdmin.statusArchivedLabel;
+}
+
+export function JobMarketLabCorpusAdmin({ corpus }: JobMarketLabCorpusAdminProps) {
+  const { session, isLoading } = useSiteAuth();
+  const [deps] = useState(
+    () => corpus ?? createDefaultAmplifyCorpusDeps(),
+  );
+  const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const loadRecords = useCallback(async () => {
+    const records = await deps.listJobDescriptions();
+    return records;
+  }, [deps]);
+
+  useEffect(() => {
+    if (isLoading || session?.status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const records = await loadRecords();
+        if (!cancelled) {
+          setLoadState({ status: 'ready', records });
+        }
+      } catch {
+        if (!cancelled) {
+          setLoadState({ status: 'error' });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, session, loadRecords]);
+
+  if (isLoading || session?.status !== 'authenticated') {
+    return null;
+  }
+
+  async function refresh() {
+    setLoadState({ status: 'loading' });
+    try {
+      const records = await loadRecords();
+      setLoadState({ status: 'ready', records });
+    } catch {
+      setLoadState({ status: 'error' });
+    }
+  }
+
+  async function handleArchive(id: string) {
+    setPendingId(id);
+    try {
+      await archiveJobDescription(id, deps);
+      await refresh();
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  async function handleRestore(id: string) {
+    setPendingId(id);
+    try {
+      await restoreJobDescription(id, deps);
+      await refresh();
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <section className="mt-16 space-y-6" aria-labelledby="job-market-corpus-admin-heading">
+      <div className="max-w-2xl space-y-4">
+        <SectionHeader
+          id="job-market-corpus-admin-heading"
+          as="h2"
+          size="md"
+          animated={false}
+          showLeftAccent={false}
+        >
+          {jobMarketLab.corpusAdmin.heading}
+        </SectionHeader>
+        <Text variant="muted">{jobMarketLab.corpusAdmin.description}</Text>
+      </div>
+
+      {loadState.status === 'loading' || loadState.status === 'idle' ? (
+        <Text variant="muted">{jobMarketLab.corpusAdmin.loadingLabel}</Text>
+      ) : null}
+
+      {loadState.status === 'error' ? (
+        <p
+          role="alert"
+          className="font-body text-lg leading-relaxed text-[var(--foreground)]"
+        >
+          {jobMarketLab.corpusAdmin.errorLabel}
+        </p>
+      ) : null}
+
+      {loadState.status === 'ready' && loadState.records.length === 0 ? (
+        <Text variant="muted">{jobMarketLab.corpusAdmin.emptyList}</Text>
+      ) : null}
+
+      {loadState.status === 'ready' && loadState.records.length > 0 ? (
+        <ul className="space-y-4">
+          {loadState.records.map((record) => (
+            <li
+              key={record.id}
+              className="flex flex-col gap-3 border-b border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] py-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0 space-y-1">
+                <Text className="font-medium">
+                  {record.title?.trim() || jobMarketLab.corpusAdmin.untitledLabel}
+                </Text>
+                <Text size="sm" variant="muted" className="font-mono">
+                  {record.id}
+                </Text>
+                <Text size="sm">{statusLabel(record.status)}</Text>
+              </div>
+              <div>
+                {record.status === 'active' ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={pendingId === record.id}
+                    onClick={() => void handleArchive(record.id)}
+                  >
+                    {jobMarketLab.corpusAdmin.archiveLabel}
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={pendingId === record.id}
+                    onClick={() => void handleRestore(record.id)}
+                  >
+                    {jobMarketLab.corpusAdmin.restoreLabel}
+                  </Button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -74,6 +74,7 @@ describe('JobMarketLabSection', () => {
     expect(
       screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(jobMarketLab.corpusAdmin.heading)).not.toBeInTheDocument();
   });
 
   it('still shows the empty state when nothing is published', () => {

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -1,12 +1,25 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { JobMarketLabSection } from '@/components/sections/labs/job-market-lab-section';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
 import { jobMarketLab } from '@/data';
 import type { PublishedJobMarketResult } from '@/lib/job-market-lab';
+import { createMemorySiteAuth } from '@/lib/site-auth';
 
 afterEach(() => {
   cleanup();
 });
+
+function renderLab(
+  publication: PublishedJobMarketResult,
+  auth = createMemorySiteAuth(),
+) {
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <JobMarketLabSection publication={publication} />
+    </SiteAuthProvider>,
+  );
+}
 
 const published: PublishedJobMarketResult = {
   status: 'published',
@@ -38,7 +51,7 @@ const published: PublishedJobMarketResult = {
 
 describe('JobMarketLabSection', () => {
   it('renders corpus freshness and aggregate visuals from a published snapshot', () => {
-    render(<JobMarketLabSection publication={published} />);
+    renderLab(published);
 
     expect(screen.queryByText(jobMarketLab.emptyState)).not.toBeInTheDocument();
     expect(screen.getByText(jobMarketLab.metricsHeading)).toBeInTheDocument();
@@ -58,10 +71,13 @@ describe('JobMarketLabSection', () => {
     expect(screen.getByText('Theme 2')).toBeInTheDocument();
 
     expect(screen.getByText(jobMarketLab.corpusNote)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).not.toBeInTheDocument();
   });
 
   it('still shows the empty state when nothing is published', () => {
-    render(<JobMarketLabSection publication={{ status: 'empty' }} />);
+    renderLab({ status: 'empty' });
 
     expect(screen.getByText(jobMarketLab.emptyState)).toBeInTheDocument();
     expect(screen.queryByText(jobMarketLab.skillsHeading)).not.toBeInTheDocument();

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobMarketLabSection } from '@/components/sections/labs/job-market-lab-section';
+import { jobMarketLab } from '@/data';
+import type { PublishedJobMarketResult } from '@/lib/job-market-lab';
+
+afterEach(() => {
+  cleanup();
+});
+
+const published: PublishedJobMarketResult = {
+  status: 'published',
+  snapshot: {
+    documentCount: 12,
+    publishedAt: '2026-07-14T12:00:00.000Z',
+    skills: [
+      { name: 'python', count: 9 },
+      { name: 'sql', count: 7 },
+    ],
+    seniority: [
+      { name: 'senior', count: 8 },
+      { name: 'mid', count: 4 },
+    ],
+    roleFamily: [
+      { name: 'data-science', count: 7 },
+      { name: 'analytics', count: 5 },
+    ],
+    clusters: [
+      { id: 0, size: 7, label: 'Theme 1' },
+      { id: 1, size: 5, label: 'Theme 2' },
+    ],
+    projection: [
+      { x: 0.1, y: 0.2, clusterId: 0 },
+      { x: 0.4, y: 0.6, clusterId: 1 },
+    ],
+  },
+};
+
+describe('JobMarketLabSection', () => {
+  it('renders corpus freshness and aggregate visuals from a published snapshot', () => {
+    render(<JobMarketLabSection publication={published} />);
+
+    expect(screen.queryByText(jobMarketLab.emptyState)).not.toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.metricsHeading)).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText(/14 Jul 2026/i)).toBeInTheDocument();
+
+    expect(screen.getByText(jobMarketLab.skillsHeading)).toBeInTheDocument();
+    expect(screen.getByText('python')).toBeInTheDocument();
+    expect(screen.getByText('sql')).toBeInTheDocument();
+
+    expect(screen.getByText(jobMarketLab.taxonomyHeading)).toBeInTheDocument();
+    expect(screen.getByText('senior')).toBeInTheDocument();
+    expect(screen.getByText('data-science')).toBeInTheDocument();
+
+    expect(screen.getByText(jobMarketLab.clustersHeading)).toBeInTheDocument();
+    expect(screen.getByText('Theme 1')).toBeInTheDocument();
+    expect(screen.getByText('Theme 2')).toBeInTheDocument();
+
+    expect(screen.getByText(jobMarketLab.corpusNote)).toBeInTheDocument();
+  });
+
+  it('still shows the empty state when nothing is published', () => {
+    render(<JobMarketLabSection publication={{ status: 'empty' }} />);
+
+    expect(screen.getByText(jobMarketLab.emptyState)).toBeInTheDocument();
+    expect(screen.queryByText(jobMarketLab.skillsHeading)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -1,0 +1,29 @@
+import { Container, Section, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import type { PublishedJobMarketResult } from '@/lib/job-market-lab';
+
+interface JobMarketLabSectionProps {
+  publication: PublishedJobMarketResult;
+}
+
+export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mb-12 max-w-2xl space-y-4">
+          <SectionHeader animated={false}>{jobMarketLab.heading}</SectionHeader>
+          <Text variant="muted">{jobMarketLab.description}</Text>
+          <Text size="sm" variant="muted">
+            {jobMarketLab.corpusNote}
+          </Text>
+        </div>
+
+        {publication.status === 'empty' ? (
+          <div className="max-w-2xl space-y-2" role="status">
+            <Text>{jobMarketLab.emptyState}</Text>
+          </div>
+        ) : null}
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
+import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
 import { jobMarketLab } from '@/data';
 import type {
   JobMarketSnapshot,
@@ -217,6 +218,8 @@ export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
         ) : (
           <PublishedDashboard snapshot={publication.snapshot} />
         )}
+
+        <JobMarketLabAdminSection />
       </Container>
     </Section>
   );

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -2,6 +2,7 @@
 
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
 import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
+import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-lab-corpus-admin';
 import { jobMarketLab } from '@/data';
 import type {
   JobMarketSnapshot,
@@ -9,11 +10,13 @@ import type {
   SkillFrequency,
   TaxonomyBucket,
 } from '@/lib/job-market-lab';
+import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
 import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 import { cn } from '@/lib/utils';
 
 interface JobMarketLabSectionProps {
   publication: PublishedJobMarketResult;
+  corpus?: AmplifyCorpusDeps;
 }
 
 function formatPublishedAt(iso: string): string {
@@ -199,7 +202,7 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
   );
 }
 
-export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
+export function JobMarketLabSection({ publication, corpus }: JobMarketLabSectionProps) {
   return (
     <Section className="py-20">
       <Container>
@@ -220,6 +223,7 @@ export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
         )}
 
         <JobMarketLabAdminSection />
+        <JobMarketLabCorpusAdmin corpus={corpus} />
       </Container>
     </Section>
   );

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -1,9 +1,201 @@
+'use client';
+
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
 import { jobMarketLab } from '@/data';
-import type { PublishedJobMarketResult } from '@/lib/job-market-lab';
+import type {
+  JobMarketSnapshot,
+  PublishedJobMarketResult,
+  SkillFrequency,
+  TaxonomyBucket,
+} from '@/lib/job-market-lab';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
+import { cn } from '@/lib/utils';
 
 interface JobMarketLabSectionProps {
   publication: PublishedJobMarketResult;
+}
+
+function formatPublishedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+  return new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+function FrequencyBars({
+  items,
+  labelledBy,
+}: {
+  items: Array<SkillFrequency | TaxonomyBucket>;
+  labelledBy: string;
+}) {
+  const max = Math.max(...items.map((item) => item.count), 1);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  return (
+    <ul className="space-y-3" aria-labelledby={labelledBy}>
+      {items.map((item) => (
+        <li key={item.name} className="grid grid-cols-[minmax(0,7rem)_1fr_auto] items-center gap-3">
+          <Text size="sm" className="truncate">
+            {item.name}
+          </Text>
+          <div
+            className="h-2 overflow-hidden rounded-sm bg-[color-mix(in_oklab,var(--foreground)_12%,transparent)]"
+            role="presentation"
+          >
+            <div
+              className={cn(
+                'h-full rounded-sm bg-[var(--foreground)]',
+                !prefersReducedMotion && 'transition-[width] duration-500 ease-out',
+              )}
+              style={{ width: `${(item.count / max) * 100}%` }}
+            />
+          </div>
+          <Text size="sm" variant="muted" className="tabular-nums">
+            {item.count}
+          </Text>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ClusterProjection({ snapshot }: { snapshot: JobMarketSnapshot }) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const points = snapshot.projection.slice(0, 200);
+
+  if (points.length === 0) {
+    return null;
+  }
+
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const spanX = maxX - minX || 1;
+  const spanY = maxY - minY || 1;
+
+  return (
+    <div className="space-y-4">
+      <ul className="flex flex-wrap gap-x-4 gap-y-2" aria-label="Cluster sizes">
+        {snapshot.clusters.map((cluster) => (
+          <li key={cluster.id}>
+            <Text size="sm">
+              {cluster.label}
+              <span className="text-[var(--muted-foreground)]"> · {cluster.size}</span>
+            </Text>
+          </li>
+        ))}
+      </ul>
+      <svg
+        viewBox="0 0 320 180"
+        role="img"
+        aria-label="Two-dimensional projection of requirement clusters"
+        className="h-auto w-full max-w-xl border border-[color-mix(in_oklab,var(--foreground)_14%,transparent)] bg-[color-mix(in_oklab,var(--foreground)_4%,transparent)]"
+      >
+        {points.map((point, index) => {
+          const cx = ((point.x - minX) / spanX) * 300 + 10;
+          const cy = 170 - ((point.y - minY) / spanY) * 160;
+          return (
+            <circle
+              key={`${point.clusterId}-${index}`}
+              cx={cx}
+              cy={cy}
+              r={4}
+              className={cn(
+                point.clusterId % 2 === 0
+                  ? 'fill-[var(--foreground)]'
+                  : 'fill-[color-mix(in_oklab,var(--foreground)_55%,transparent)]',
+                !prefersReducedMotion && 'transition-opacity duration-300',
+              )}
+              opacity={0.85}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
+  const skillsId = 'job-market-skills-heading';
+  const taxonomyId = 'job-market-taxonomy-heading';
+  const clustersId = 'job-market-clusters-heading';
+
+  return (
+    <div className="space-y-14">
+      <section className="space-y-4" aria-labelledby="job-market-metrics-heading">
+        <SectionHeader id="job-market-metrics-heading" as="h2" size="md" animated={false} showLeftAccent={false}>
+          {jobMarketLab.metricsHeading}
+        </SectionHeader>
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Text size="sm" variant="muted">
+              {jobMarketLab.documentCountLabel}
+            </Text>
+            <Text className="text-3xl font-semibold tabular-nums tracking-tight">
+              {snapshot.documentCount}
+            </Text>
+          </div>
+          <div className="space-y-1">
+            <Text size="sm" variant="muted">
+              {jobMarketLab.publishedAtLabel}
+            </Text>
+            <Text className="text-xl font-medium tracking-tight">
+              {formatPublishedAt(snapshot.publishedAt)}
+            </Text>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4" aria-labelledby={skillsId}>
+        <SectionHeader id={skillsId} as="h2" size="md" animated={false} showLeftAccent={false}>
+          {jobMarketLab.skillsHeading}
+        </SectionHeader>
+        <FrequencyBars items={snapshot.skills.slice(0, 40)} labelledBy={skillsId} />
+      </section>
+
+      <section className="space-y-6" aria-labelledby={taxonomyId}>
+        <SectionHeader id={taxonomyId} as="h2" size="md" animated={false} showLeftAccent={false}>
+          {jobMarketLab.taxonomyHeading}
+        </SectionHeader>
+        <div className="grid gap-10 md:grid-cols-2">
+          <div className="space-y-3">
+            <Text size="sm" variant="muted">
+              {jobMarketLab.seniorityLabel}
+            </Text>
+            <FrequencyBars
+              items={snapshot.seniority}
+              labelledBy={taxonomyId}
+            />
+          </div>
+          <div className="space-y-3">
+            <Text size="sm" variant="muted">
+              {jobMarketLab.roleFamilyLabel}
+            </Text>
+            <FrequencyBars
+              items={snapshot.roleFamily}
+              labelledBy={taxonomyId}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4" aria-labelledby={clustersId}>
+        <SectionHeader id={clustersId} as="h2" size="md" animated={false} showLeftAccent={false}>
+          {jobMarketLab.clustersHeading}
+        </SectionHeader>
+        <ClusterProjection snapshot={snapshot} />
+      </section>
+    </div>
+  );
 }
 
 export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
@@ -22,7 +214,9 @@ export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
           <div className="max-w-2xl space-y-2" role="status">
             <Text>{jobMarketLab.emptyState}</Text>
           </div>
-        ) : null}
+        ) : (
+          <PublishedDashboard snapshot={publication.snapshot} />
+        )}
       </Container>
     </Section>
   );

--- a/src/components/sections/labs/labs-index-section.tsx
+++ b/src/components/sections/labs/labs-index-section.tsx
@@ -1,0 +1,40 @@
+import {
+  Button,
+  Container,
+  MotionReveal,
+  Section,
+  SectionHeader,
+  Text,
+} from '@/components/ui';
+import { labs } from '@/data';
+
+export function LabsIndexSection() {
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mb-16 max-w-2xl space-y-4">
+          <SectionHeader animated={false}>{labs.heading}</SectionHeader>
+          <Text variant="muted">{labs.description}</Text>
+        </div>
+
+        <ul className="space-y-10">
+          {labs.labs.map((lab, index) => (
+            <MotionReveal key={lab.href} variant="fade-up" distance="sm" delay={index * 0.05}>
+              <li className="max-w-2xl space-y-4">
+                <SectionHeader size="md" animated={false} showLeftAccent={false}>
+                  {lab.title}
+                </SectionHeader>
+                <Text size="sm" variant="muted">
+                  {lab.description}
+                </Text>
+                <Button href={lab.href} variant="outline" size="sm">
+                  Open lab
+                </Button>
+              </li>
+            </MotionReveal>
+          ))}
+        </ul>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/login/login-section.test.tsx
+++ b/src/components/sections/login/login-section.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { LoginSection } from '@/components/sections/login/login-section';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { login } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderLogin(auth = createMemorySiteAuth()) {
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <LoginSection />
+    </SiteAuthProvider>,
+  );
+}
+
+describe('LoginSection', () => {
+  it('shows the sign-in form without registration copy when unauthenticated', async () => {
+    renderLogin();
+
+    expect(await screen.findByRole('heading', { name: login.heading })).toBeInTheDocument();
+    expect(screen.getByLabelText(login.emailLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText(login.passwordLabel)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: login.submitLabel })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: login.signOutLabel })).not.toBeInTheDocument();
+    expect(screen.queryByText(/create account|register|sign up/i)).not.toBeInTheDocument();
+  });
+
+  it('shows signed-in state and sign-out after a successful sign-in', async () => {
+    const user = userEvent.setup();
+    const auth = createMemorySiteAuth();
+    renderLogin(auth);
+
+    await user.type(await screen.findByLabelText(login.emailLabel), 'owner@example.com');
+    await user.type(screen.getByLabelText(login.passwordLabel), 'secret');
+    await user.click(screen.getByRole('button', { name: login.submitLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: login.signedInHeading })).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(login.signedInDescription.replace('{email}', 'owner@example.com')),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: login.signOutLabel })).toBeInTheDocument();
+    expect(screen.queryByLabelText(login.passwordLabel)).not.toBeInTheDocument();
+  });
+
+  it('returns to the sign-in form after sign-out', async () => {
+    const user = userEvent.setup();
+    const auth = createMemorySiteAuth({
+      status: 'authenticated',
+      email: 'owner@example.com',
+    });
+    renderLogin(auth);
+
+    await user.click(await screen.findByRole('button', { name: login.signOutLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(login.passwordLabel)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: login.signOutLabel })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sections/login/login-section.tsx
+++ b/src/components/sections/login/login-section.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import {
+  Button,
+  Container,
+  Heading,
+  Section,
+  Text,
+} from '@/components/ui';
+import { login } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+
+const fieldClassName =
+  'mt-2 w-full border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]';
+
+export function LoginSection() {
+  const { session, isLoading, signIn, signOut } = useSiteAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    if (!email.trim() || !password) {
+      setError(login.errors.required);
+      return;
+    }
+
+    setIsSubmitting(true);
+    const result = await signIn(email.trim(), password);
+    setIsSubmitting(false);
+
+    if (result.status === 'failed') {
+      setError(result.reason);
+      return;
+    }
+
+    setPassword('');
+  }
+
+  async function handleSignOut() {
+    setError(null);
+    await signOut();
+  }
+
+  if (isLoading || session === null) {
+    return (
+      <Section className="py-20">
+        <Container>
+          <Text variant="muted">Checking session…</Text>
+        </Container>
+      </Section>
+    );
+  }
+
+  if (session.status === 'authenticated') {
+    return (
+      <Section className="py-20">
+        <Container>
+          <div className="mx-auto max-w-md space-y-6">
+            <Heading size="md" as="h1">
+              {login.signedInHeading}
+            </Heading>
+            <Text>
+              {login.signedInDescription.replace('{email}', session.email)}
+            </Text>
+            <Button type="button" variant="outline" onClick={() => void handleSignOut()}>
+              {login.signOutLabel}
+            </Button>
+          </div>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mx-auto max-w-md space-y-8">
+          <div className="space-y-4">
+            <Heading size="md" as="h1">
+              {login.heading}
+            </Heading>
+            <Text variant="muted">{login.description}</Text>
+          </div>
+
+          <form className="space-y-6" onSubmit={(event) => void handleSubmit(event)} noValidate>
+            <div>
+              <label htmlFor="login-email" className="font-body text-sm text-[var(--foreground)]">
+                {login.emailLabel}
+              </label>
+              <input
+                id="login-email"
+                name="email"
+                type="email"
+                autoComplete="username"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className={fieldClassName}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="login-password" className="font-body text-sm text-[var(--foreground)]">
+                {login.passwordLabel}
+              </label>
+              <input
+                id="login-password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className={fieldClassName}
+              />
+            </div>
+
+            {error ? (
+              <p
+                role="alert"
+                className="font-body text-base leading-relaxed text-[var(--destructive,var(--primary))]"
+              >
+                {error}
+              </p>
+            ) : null}
+
+            <Button type="submit" disabled={isSubmitting}>
+              {login.submitLabel}
+            </Button>
+          </form>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/site-auth-root.tsx
+++ b/src/components/site-auth-root.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useMemo, type ReactNode } from 'react';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import type { AmplifyOutputs } from '@/lib/configure-site-amplify';
+import { createSiteAuthFromOutputs } from '@/lib/site-auth';
+
+type SiteAuthRootProps = {
+  children: ReactNode;
+  outputs: AmplifyOutputs | null;
+};
+
+export function SiteAuthRoot({ children, outputs }: SiteAuthRootProps) {
+  const auth = useMemo(() => createSiteAuthFromOutputs(outputs), [outputs]);
+
+  return <SiteAuthProvider auth={auth}>{children}</SiteAuthProvider>;
+}

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -14,6 +14,8 @@ interface SectionHeaderProps {
   showBottomAccent?: boolean;
   animated?: boolean;
   delay?: number;
+  id?: string;
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 }
 
 export function SectionHeader({
@@ -26,6 +28,8 @@ export function SectionHeader({
   showBottomAccent = false,
   animated = true,
   delay = 0,
+  id,
+  as,
 }: SectionHeaderProps) {
   const alignmentClasses = {
     left: "",
@@ -43,7 +47,7 @@ export function SectionHeader({
         <div className="absolute -right-4 bottom-0 w-16 h-px bg-[var(--primary)] transform skew-x-12 opacity-30 hidden sm:block" />
       )}
 
-      <Heading size={size} className={`relative w-full ${className}`}>
+      <Heading id={id} as={as} size={size} className={`relative w-full ${className}`}>
         {children}
         {showBottomAccent && (
           <div className="absolute -bottom-2 -right-2 w-8 h-8 bg-[var(--primary)] opacity-10 transform rotate-45 hidden sm:block" />

--- a/src/components/ui/typography/heading.tsx
+++ b/src/components/ui/typography/heading.tsx
@@ -7,6 +7,7 @@ interface HeadingProps {
   as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   className?: string;
   style?: CSSProperties;
+  id?: string;
 }
 
 // Fluid typography that scales based on viewport width with proper min/max constraints
@@ -26,23 +27,25 @@ const sizeClasses = {
   sm: "",
 };
 
-export function Heading({ 
-  children, 
-  size = "lg", 
-  as: Component = "h1", 
+export function Heading({
+  children,
+  size = 'lg',
+  as: Component = 'h1',
   className,
-  style
+  style,
+  id,
 }: HeadingProps) {
   return (
-    <Component 
+    <Component
+      id={id}
       className={cn(
-        "font-body font-bold text-[var(--foreground)] break-words",
+        'font-body font-bold text-[var(--foreground)] break-words',
         sizeClasses[size],
-        className
+        className,
       )}
       style={{
         ...sizeStyles[size],
-        ...style
+        ...style,
       }}
     >
       {children}

--- a/src/data/common/footer.json
+++ b/src/data/common/footer.json
@@ -9,7 +9,11 @@
       "github": "https://github.com/hashadar",
       "linkedin": "https://linkedin.com/in/hdar"
     },
-    "copyright": "© 2026 hasha dar. All rights reserved."
+    "copyright": "© 2026 hasha dar. All rights reserved.",
+    "ownerSignIn": {
+      "label": "Owner sign in",
+      "href": "/login"
+    }
   }
 }
 

--- a/src/data/common/navigation.json
+++ b/src/data/common/navigation.json
@@ -13,6 +13,10 @@
       "href": "/portfolio"
     },
     {
+      "label": "Labs",
+      "href": "/labs"
+    },
+    {
       "label": "Blog",
       "href": "/blog"
     }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -4,6 +4,7 @@ import aboutData from './pages/about.json';
 import blogData from './pages/blog.json';
 import labsData from './pages/labs.json';
 import jobMarketLabData from './pages/job-market-lab.json';
+import loginData from './pages/login.json';
 import footerData from './common/footer.json';
 import navigationData from './common/navigation.json';
 import siteData from './common/site.json';
@@ -16,6 +17,7 @@ import type {
   BlogPageData,
   LabsPageData,
   JobMarketLabPageData,
+  LoginPageData,
   CareerProfile,
   FooterData,
   NavigationData,
@@ -29,6 +31,7 @@ import {
   assertValidHomePage,
   assertValidJobMarketLabPage,
   assertValidLabsPage,
+  assertValidLoginPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -41,6 +44,7 @@ validateDataFile('pages/about.json', aboutData, assertValidAboutPage);
 validateDataFile('pages/blog.json', blogData, assertValidBlogPage);
 validateDataFile('pages/labs.json', labsData, assertValidLabsPage);
 validateDataFile('pages/job-market-lab.json', jobMarketLabData, assertValidJobMarketLabPage);
+validateDataFile('pages/login.json', loginData, assertValidLoginPage);
 validateDataFile('common/footer.json', footerData, assertValidFooter);
 validateDataFile('common/navigation.json', navigationData, assertValidNavigation);
 validateDataFile('common/site.json', siteData, assertValidSite);
@@ -52,6 +56,7 @@ export const about = aboutData as AboutPageData;
 export const blog = blogData as BlogPageData;
 export const labs = labsData as LabsPageData;
 export const jobMarketLab = jobMarketLabData as JobMarketLabPageData;
+export const login = loginData as LoginPageData;
 export const careerProfile = careerProfileData as CareerProfile;
 
 export { getHomeExperienceView, getAboutExperienceView } from './profile/experience-slices';
@@ -71,6 +76,7 @@ export function getPageData(route: '/blog'): BlogPageData;
 export function getPageData(route: '/portfolio'): PortfolioPageData;
 export function getPageData(route: '/labs'): LabsPageData;
 export function getPageData(route: '/labs/job-market'): JobMarketLabPageData;
+export function getPageData(route: '/login'): LoginPageData;
 export function getPageData(
   route: string,
 ):
@@ -80,6 +86,7 @@ export function getPageData(
   | PortfolioPageData
   | LabsPageData
   | JobMarketLabPageData
+  | LoginPageData
   | null;
 export function getPageData(route: string) {
   switch (route) {
@@ -96,6 +103,8 @@ export function getPageData(route: string) {
       return labs;
     case '/labs/job-market':
       return jobMarketLab;
+    case '/login':
+      return login;
     default:
       return null;
   }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2,6 +2,8 @@ import homeData from './pages/home.json';
 import portfolioData from './pages/portfolio.json';
 import aboutData from './pages/about.json';
 import blogData from './pages/blog.json';
+import labsData from './pages/labs.json';
+import jobMarketLabData from './pages/job-market-lab.json';
 import footerData from './common/footer.json';
 import navigationData from './common/navigation.json';
 import siteData from './common/site.json';
@@ -12,6 +14,8 @@ import type {
   PortfolioPageData,
   AboutPageData,
   BlogPageData,
+  LabsPageData,
+  JobMarketLabPageData,
   CareerProfile,
   FooterData,
   NavigationData,
@@ -23,6 +27,8 @@ import {
   assertValidCareerProfile,
   assertValidFooter,
   assertValidHomePage,
+  assertValidJobMarketLabPage,
+  assertValidLabsPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -33,6 +39,8 @@ validateDataFile('pages/home.json', homeData, assertValidHomePage);
 validateDataFile('pages/portfolio.json', portfolioData, assertValidPortfolioPage);
 validateDataFile('pages/about.json', aboutData, assertValidAboutPage);
 validateDataFile('pages/blog.json', blogData, assertValidBlogPage);
+validateDataFile('pages/labs.json', labsData, assertValidLabsPage);
+validateDataFile('pages/job-market-lab.json', jobMarketLabData, assertValidJobMarketLabPage);
 validateDataFile('common/footer.json', footerData, assertValidFooter);
 validateDataFile('common/navigation.json', navigationData, assertValidNavigation);
 validateDataFile('common/site.json', siteData, assertValidSite);
@@ -42,6 +50,8 @@ export const home = homeData as HomePageData;
 export const portfolio = portfolioData as PortfolioPageData;
 export const about = aboutData as AboutPageData;
 export const blog = blogData as BlogPageData;
+export const labs = labsData as LabsPageData;
+export const jobMarketLab = jobMarketLabData as JobMarketLabPageData;
 export const careerProfile = careerProfileData as CareerProfile;
 
 export { getHomeExperienceView, getAboutExperienceView } from './profile/experience-slices';
@@ -59,7 +69,18 @@ export function getPageData(route: '/home'): HomePageData;
 export function getPageData(route: '/about'): AboutPageData;
 export function getPageData(route: '/blog'): BlogPageData;
 export function getPageData(route: '/portfolio'): PortfolioPageData;
-export function getPageData(route: string): HomePageData | AboutPageData | BlogPageData | PortfolioPageData | null;
+export function getPageData(route: '/labs'): LabsPageData;
+export function getPageData(route: '/labs/job-market'): JobMarketLabPageData;
+export function getPageData(
+  route: string,
+):
+  | HomePageData
+  | AboutPageData
+  | BlogPageData
+  | PortfolioPageData
+  | LabsPageData
+  | JobMarketLabPageData
+  | null;
 export function getPageData(route: string) {
   switch (route) {
     case '/':
@@ -71,6 +92,10 @@ export function getPageData(route: string) {
       return portfolio;
     case '/about':
       return about;
+    case '/labs':
+      return labs;
+    case '/labs/job-market':
+      return jobMarketLab;
     default:
       return null;
   }

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -5,6 +5,8 @@ import {
   getCommonData,
   getPageData,
   home,
+  labs,
+  jobMarketLab,
   portfolio,
   footer,
   navigation,
@@ -18,6 +20,8 @@ describe('getPageData', () => {
     expect(getPageData('/about')).toBe(about);
     expect(getPageData('/blog')).toBe(blog);
     expect(getPageData('/portfolio')).toBe(portfolio);
+    expect(getPageData('/labs')).toBe(labs);
+    expect(getPageData('/labs/job-market')).toBe(jobMarketLab);
   });
 
   it('returns null for unknown routes', () => {
@@ -29,5 +33,9 @@ describe('getPageData', () => {
 describe('getCommonData', () => {
   it('returns footer, navigation, and site together', () => {
     expect(getCommonData()).toEqual({ footer, navigation, site });
+  });
+
+  it('includes a Labs navigation link to the Labs index', () => {
+    expect(navigation.links).toContainEqual({ label: 'Labs', href: '/labs' });
   });
 });

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -7,6 +7,7 @@ import {
   home,
   labs,
   jobMarketLab,
+  login,
   portfolio,
   footer,
   navigation,
@@ -22,6 +23,15 @@ describe('getPageData', () => {
     expect(getPageData('/portfolio')).toBe(portfolio);
     expect(getPageData('/labs')).toBe(labs);
     expect(getPageData('/labs/job-market')).toBe(jobMarketLab);
+    expect(getPageData('/login')).toBe(login);
+  });
+
+  it('returns British English owner sign-in copy without registration', () => {
+    const page = getPageData('/login');
+    expect(page?.heading).toBe('Owner sign in');
+    expect(page?.submitLabel).toBe('Sign in');
+    expect(page?.signOutLabel).toBe('Sign out');
+    expect(JSON.stringify(page)).not.toMatch(/create account|register|sign up/i);
   });
 
   it('returns null for unknown routes', () => {
@@ -37,5 +47,12 @@ describe('getCommonData', () => {
 
   it('includes a Labs navigation link to the Labs index', () => {
     expect(navigation.links).toContainEqual({ label: 'Labs', href: '/labs' });
+  });
+
+  it('includes a discreet owner sign-in link in the footer', () => {
+    expect(footer.contact.ownerSignIn).toEqual({
+      label: 'Owner sign in',
+      href: '/login',
+    });
   });
 });

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -10,5 +10,13 @@
   "taxonomyHeading": "Seniority and role family",
   "seniorityLabel": "Seniority",
   "roleFamilyLabel": "Role family",
-  "clustersHeading": "Requirement themes"
+  "clustersHeading": "Requirement themes",
+  "admin": {
+    "heading": "Corpus recompute",
+    "description": "Start an analysis run against the active corpus. Only one run may be queued or in progress at a time.",
+    "startButtonLabel": "Start recompute",
+    "startingLabel": "Starting…",
+    "startedMessage": "Recompute started. Run id: {runId}. Status: queued.",
+    "rejectedHeading": "Could not start recompute"
+  }
 }

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -1,0 +1,6 @@
+{
+  "heading": "Job market signal lab",
+  "description": "High-level aggregates from a private financial-services job-description corpus. This is a portfolio demonstration, not live job-board coverage or career advice.",
+  "emptyState": "No published snapshot is available yet. Check back after the next corpus recompute.",
+  "corpusNote": "Figures shown here are aggregates only. Raw job descriptions and employer identity are never published."
+}

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -2,5 +2,13 @@
   "heading": "Job market signal lab",
   "description": "High-level aggregates from a private financial-services job-description corpus. This is a portfolio demonstration, not live job-board coverage or career advice.",
   "emptyState": "No published snapshot is available yet. Check back after the next corpus recompute.",
-  "corpusNote": "Figures shown here are aggregates only. Raw job descriptions and employer identity are never published."
+  "corpusNote": "Figures shown here are aggregates only. Raw job descriptions and employer identity are never published.",
+  "metricsHeading": "Corpus freshness",
+  "documentCountLabel": "Active documents in latest snapshot",
+  "publishedAtLabel": "Last published",
+  "skillsHeading": "Skill and tool frequencies",
+  "taxonomyHeading": "Seniority and role family",
+  "seniorityLabel": "Seniority",
+  "roleFamilyLabel": "Role family",
+  "clustersHeading": "Requirement themes"
 }

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -18,5 +18,17 @@
     "startingLabel": "Starting…",
     "startedMessage": "Recompute started. Run id: {runId}. Status: queued.",
     "rejectedHeading": "Could not start recompute"
+  },
+  "corpusAdmin": {
+    "heading": "Corpus management",
+    "description": "Soft-archive active job descriptions to exclude them from the next recompute, or restore archived ones. Objects in storage are not deleted.",
+    "archiveLabel": "Archive",
+    "restoreLabel": "Restore",
+    "statusActiveLabel": "Active",
+    "statusArchivedLabel": "Archived",
+    "emptyList": "No job descriptions found.",
+    "loadingLabel": "Loading corpus…",
+    "untitledLabel": "Untitled document",
+    "errorLabel": "Corpus management is temporarily unavailable."
   }
 }

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Labs",
+  "description": "Interactive technical demos that show how I approach AI, data science, machine learning, and AWS full-stack work.",
+  "labs": [
+    {
+      "title": "Job market signal lab",
+      "description": "Aggregate labour-market signals from a private job-description corpus.",
+      "href": "/labs/job-market"
+    }
+  ]
+}

--- a/src/data/pages/login.json
+++ b/src/data/pages/login.json
@@ -1,0 +1,15 @@
+{
+  "heading": "Owner sign in",
+  "description": "Sign in with the email and password for your invited owner account. Self-registration is not available.",
+  "emailLabel": "Email",
+  "passwordLabel": "Password",
+  "submitLabel": "Sign in",
+  "signOutLabel": "Sign out",
+  "signedInHeading": "Signed in",
+  "signedInDescription": "You are signed in as {email}.",
+  "errors": {
+    "generic": "Sign-in failed. Check your email and password, then try again.",
+    "notConfigured": "Sign-in is unavailable because authentication is not configured.",
+    "required": "Enter your email and password to continue."
+  }
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -128,6 +128,25 @@ export interface BlogPageData {
   allCategories: string;
 }
 
+export interface LabIndexItem {
+  title: string;
+  description: string;
+  href: string;
+}
+
+export interface LabsPageData {
+  heading: string;
+  description: string;
+  labs: LabIndexItem[];
+}
+
+export interface JobMarketLabPageData {
+  heading: string;
+  description: string;
+  emptyState: string;
+  corpusNote: string;
+}
+
 // Common/shared types
 export interface SocialLinks {
   github: string;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -179,24 +179,6 @@ export interface JobMarketLabPageData {
   corpusAdmin: JobMarketLabCorpusAdminData;
 }
 
-export interface LoginPageErrors {
-  generic: string;
-  notConfigured: string;
-  required: string;
-}
-
-export interface LoginPageData {
-  heading: string;
-  description: string;
-  emailLabel: string;
-  passwordLabel: string;
-  submitLabel: string;
-  signOutLabel: string;
-  signedInHeading: string;
-  signedInDescription: string;
-  errors: LoginPageErrors;
-}
-
 // Common/shared types
 export interface SocialLinks {
   github: string;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -155,6 +155,24 @@ export interface JobMarketLabPageData {
   clustersHeading: string;
 }
 
+export interface LoginPageErrors {
+  generic: string;
+  notConfigured: string;
+  required: string;
+}
+
+export interface LoginPageData {
+  heading: string;
+  description: string;
+  emailLabel: string;
+  passwordLabel: string;
+  submitLabel: string;
+  signOutLabel: string;
+  signedInHeading: string;
+  signedInDescription: string;
+  errors: LoginPageErrors;
+}
+
 // Common/shared types
 export interface SocialLinks {
   github: string;
@@ -169,6 +187,7 @@ export interface ContactInfo {
   email: string;
   social: SocialLinks;
   copyright: string;
+  ownerSignIn: NavLink;
 }
 
 export interface FooterData {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -149,6 +149,19 @@ export interface JobMarketLabAdminCopy {
   rejectedHeading: string;
 }
 
+export interface JobMarketLabCorpusAdminData {
+  heading: string;
+  description: string;
+  archiveLabel: string;
+  restoreLabel: string;
+  statusActiveLabel: string;
+  statusArchivedLabel: string;
+  emptyList: string;
+  loadingLabel: string;
+  untitledLabel: string;
+  errorLabel: string;
+}
+
 export interface JobMarketLabPageData {
   heading: string;
   description: string;
@@ -163,24 +176,7 @@ export interface JobMarketLabPageData {
   roleFamilyLabel: string;
   clustersHeading: string;
   admin: JobMarketLabAdminCopy;
-}
-
-export interface LoginPageErrors {
-  generic: string;
-  notConfigured: string;
-  required: string;
-}
-
-export interface LoginPageData {
-  heading: string;
-  description: string;
-  emailLabel: string;
-  passwordLabel: string;
-  submitLabel: string;
-  signOutLabel: string;
-  signedInHeading: string;
-  signedInDescription: string;
-  errors: LoginPageErrors;
+  corpusAdmin: JobMarketLabCorpusAdminData;
 }
 
 export interface LoginPageErrors {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -179,6 +179,24 @@ export interface JobMarketLabPageData {
   corpusAdmin: JobMarketLabCorpusAdminData;
 }
 
+export interface LoginPageErrors {
+  generic: string;
+  notConfigured: string;
+  required: string;
+}
+
+export interface LoginPageData {
+  heading: string;
+  description: string;
+  emailLabel: string;
+  passwordLabel: string;
+  submitLabel: string;
+  signOutLabel: string;
+  signedInHeading: string;
+  signedInDescription: string;
+  errors: LoginPageErrors;
+}
+
 // Common/shared types
 export interface SocialLinks {
   github: string;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -145,6 +145,14 @@ export interface JobMarketLabPageData {
   description: string;
   emptyState: string;
   corpusNote: string;
+  metricsHeading: string;
+  documentCountLabel: string;
+  publishedAtLabel: string;
+  skillsHeading: string;
+  taxonomyHeading: string;
+  seniorityLabel: string;
+  roleFamilyLabel: string;
+  clustersHeading: string;
 }
 
 // Common/shared types

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -140,6 +140,15 @@ export interface LabsPageData {
   labs: LabIndexItem[];
 }
 
+export interface JobMarketLabAdminCopy {
+  heading: string;
+  description: string;
+  startButtonLabel: string;
+  startingLabel: string;
+  startedMessage: string;
+  rejectedHeading: string;
+}
+
 export interface JobMarketLabPageData {
   heading: string;
   description: string;
@@ -153,6 +162,25 @@ export interface JobMarketLabPageData {
   seniorityLabel: string;
   roleFamilyLabel: string;
   clustersHeading: string;
+  admin: JobMarketLabAdminCopy;
+}
+
+export interface LoginPageErrors {
+  generic: string;
+  notConfigured: string;
+  required: string;
+}
+
+export interface LoginPageData {
+  heading: string;
+  description: string;
+  emailLabel: string;
+  passwordLabel: string;
+  submitLabel: string;
+  signOutLabel: string;
+  signedInHeading: string;
+  signedInDescription: string;
+  errors: LoginPageErrors;
 }
 
 export interface LoginPageErrors {

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -7,6 +7,7 @@ import {
   assertValidHomePage,
   assertValidJobMarketLabPage,
   assertValidLabsPage,
+  assertValidLoginPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -18,6 +19,7 @@ import blogData from '@/data/pages/blog.json';
 import portfolioData from '@/data/pages/portfolio.json';
 import labsData from '@/data/pages/labs.json';
 import jobMarketLabData from '@/data/pages/job-market-lab.json';
+import loginData from '@/data/pages/login.json';
 import footerData from '@/data/common/footer.json';
 import navigationData from '@/data/common/navigation.json';
 import siteData from '@/data/common/site.json';
@@ -55,6 +57,9 @@ describe('validateDataFile', () => {
         jobMarketLabData,
         assertValidJobMarketLabPage,
       ),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('pages/login.json', loginData, assertValidLoginPage),
     ).not.toThrow();
     expect(() =>
       validateDataFile('common/footer.json', footerData, assertValidFooter),

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -5,6 +5,8 @@ import {
   assertValidCareerProfile,
   assertValidFooter,
   assertValidHomePage,
+  assertValidJobMarketLabPage,
+  assertValidLabsPage,
   assertValidNavigation,
   assertValidPortfolioPage,
   assertValidSite,
@@ -14,6 +16,8 @@ import homeData from '@/data/pages/home.json';
 import aboutData from '@/data/pages/about.json';
 import blogData from '@/data/pages/blog.json';
 import portfolioData from '@/data/pages/portfolio.json';
+import labsData from '@/data/pages/labs.json';
+import jobMarketLabData from '@/data/pages/job-market-lab.json';
 import footerData from '@/data/common/footer.json';
 import navigationData from '@/data/common/navigation.json';
 import siteData from '@/data/common/site.json';
@@ -41,6 +45,16 @@ describe('validateDataFile', () => {
     ).not.toThrow();
     expect(() =>
       validateDataFile('pages/portfolio.json', portfolioData, assertValidPortfolioPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile('pages/labs.json', labsData, assertValidLabsPage),
+    ).not.toThrow();
+    expect(() =>
+      validateDataFile(
+        'pages/job-market-lab.json',
+        jobMarketLabData,
+        assertValidJobMarketLabPage,
+      ),
     ).not.toThrow();
     expect(() =>
       validateDataFile('common/footer.json', footerData, assertValidFooter),

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -150,22 +150,17 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(admin, 'startingLabel', 'jobMarketLab.admin');
   requireString(admin, 'startedMessage', 'jobMarketLab.admin');
   requireString(admin, 'rejectedHeading', 'jobMarketLab.admin');
-}
-
-export function assertValidLoginPage(data: unknown): void {
-  const page = requireRecord(data, 'login');
-  requireString(page, 'heading', 'login');
-  requireString(page, 'description', 'login');
-  requireString(page, 'emailLabel', 'login');
-  requireString(page, 'passwordLabel', 'login');
-  requireString(page, 'submitLabel', 'login');
-  requireString(page, 'signOutLabel', 'login');
-  requireString(page, 'signedInHeading', 'login');
-  requireString(page, 'signedInDescription', 'login');
-  const errors = requireRecord(page.errors, 'login.errors');
-  requireString(errors, 'generic', 'login.errors');
-  requireString(errors, 'notConfigured', 'login.errors');
-  requireString(errors, 'required', 'login.errors');
+  const corpusAdmin = requireRecord(page.corpusAdmin, 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'heading', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'description', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'archiveLabel', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'restoreLabel', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'statusActiveLabel', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'statusArchivedLabel', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'emptyList', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'loadingLabel', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'untitledLabel', 'jobMarketLab.corpusAdmin');
+  requireString(corpusAdmin, 'errorLabel', 'jobMarketLab.corpusAdmin');
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -163,6 +163,22 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(corpusAdmin, 'errorLabel', 'jobMarketLab.corpusAdmin');
 }
 
+export function assertValidLoginPage(data: unknown): void {
+  const page = requireRecord(data, 'login');
+  requireString(page, 'heading', 'login');
+  requireString(page, 'description', 'login');
+  requireString(page, 'emailLabel', 'login');
+  requireString(page, 'passwordLabel', 'login');
+  requireString(page, 'submitLabel', 'login');
+  requireString(page, 'signOutLabel', 'login');
+  requireString(page, 'signedInHeading', 'login');
+  requireString(page, 'signedInDescription', 'login');
+  const errors = requireRecord(page.errors, 'login.errors');
+  requireString(errors, 'generic', 'login.errors');
+  requireString(errors, 'notConfigured', 'login.errors');
+  requireString(errors, 'required', 'login.errors');
+}
+
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -135,6 +135,14 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(page, 'description', 'jobMarketLab');
   requireString(page, 'emptyState', 'jobMarketLab');
   requireString(page, 'corpusNote', 'jobMarketLab');
+  requireString(page, 'metricsHeading', 'jobMarketLab');
+  requireString(page, 'documentCountLabel', 'jobMarketLab');
+  requireString(page, 'publishedAtLabel', 'jobMarketLab');
+  requireString(page, 'skillsHeading', 'jobMarketLab');
+  requireString(page, 'taxonomyHeading', 'jobMarketLab');
+  requireString(page, 'seniorityLabel', 'jobMarketLab');
+  requireString(page, 'roleFamilyLabel', 'jobMarketLab');
+  requireString(page, 'clustersHeading', 'jobMarketLab');
 }
 
 export function assertValidFooter(data: unknown): void {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -145,6 +145,22 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(page, 'clustersHeading', 'jobMarketLab');
 }
 
+export function assertValidLoginPage(data: unknown): void {
+  const page = requireRecord(data, 'login');
+  requireString(page, 'heading', 'login');
+  requireString(page, 'description', 'login');
+  requireString(page, 'emailLabel', 'login');
+  requireString(page, 'passwordLabel', 'login');
+  requireString(page, 'submitLabel', 'login');
+  requireString(page, 'signOutLabel', 'login');
+  requireString(page, 'signedInHeading', 'login');
+  requireString(page, 'signedInDescription', 'login');
+  const errors = requireRecord(page.errors, 'login.errors');
+  requireString(errors, 'generic', 'login.errors');
+  requireString(errors, 'notConfigured', 'login.errors');
+  requireString(errors, 'required', 'login.errors');
+}
+
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');
@@ -157,6 +173,9 @@ export function assertValidFooter(data: unknown): void {
   const social = requireRecord(contact.social, 'footer.contact.social');
   requireString(social, 'github', 'footer.contact.social');
   requireString(social, 'linkedin', 'footer.contact.social');
+  const ownerSignIn = requireRecord(contact.ownerSignIn, 'footer.contact.ownerSignIn');
+  requireString(ownerSignIn, 'label', 'footer.contact.ownerSignIn');
+  requireString(ownerSignIn, 'href', 'footer.contact.ownerSignIn');
 }
 
 export function assertValidNavigation(data: unknown): void {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -163,22 +163,6 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(corpusAdmin, 'errorLabel', 'jobMarketLab.corpusAdmin');
 }
 
-export function assertValidLoginPage(data: unknown): void {
-  const page = requireRecord(data, 'login');
-  requireString(page, 'heading', 'login');
-  requireString(page, 'description', 'login');
-  requireString(page, 'emailLabel', 'login');
-  requireString(page, 'passwordLabel', 'login');
-  requireString(page, 'submitLabel', 'login');
-  requireString(page, 'signOutLabel', 'login');
-  requireString(page, 'signedInHeading', 'login');
-  requireString(page, 'signedInDescription', 'login');
-  const errors = requireRecord(page.errors, 'login.errors');
-  requireString(errors, 'generic', 'login.errors');
-  requireString(errors, 'notConfigured', 'login.errors');
-  requireString(errors, 'required', 'login.errors');
-}
-
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -117,6 +117,26 @@ export function assertValidPortfolioPage(data: unknown): void {
   );
 }
 
+export function assertValidLabsPage(data: unknown): void {
+  const page = requireRecord(data, 'labs');
+  requireString(page, 'heading', 'labs');
+  requireString(page, 'description', 'labs');
+  requireArray(page.labs, 'labs.labs').forEach((lab, index) => {
+    const item = requireRecord(lab, `labs.labs[${index}]`);
+    requireString(item, 'title', `labs.labs[${index}]`);
+    requireString(item, 'description', `labs.labs[${index}]`);
+    requireString(item, 'href', `labs.labs[${index}]`);
+  });
+}
+
+export function assertValidJobMarketLabPage(data: unknown): void {
+  const page = requireRecord(data, 'jobMarketLab');
+  requireString(page, 'heading', 'jobMarketLab');
+  requireString(page, 'description', 'jobMarketLab');
+  requireString(page, 'emptyState', 'jobMarketLab');
+  requireString(page, 'corpusNote', 'jobMarketLab');
+}
+
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -143,6 +143,29 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(page, 'seniorityLabel', 'jobMarketLab');
   requireString(page, 'roleFamilyLabel', 'jobMarketLab');
   requireString(page, 'clustersHeading', 'jobMarketLab');
+  const admin = requireRecord(page.admin, 'jobMarketLab.admin');
+  requireString(admin, 'heading', 'jobMarketLab.admin');
+  requireString(admin, 'description', 'jobMarketLab.admin');
+  requireString(admin, 'startButtonLabel', 'jobMarketLab.admin');
+  requireString(admin, 'startingLabel', 'jobMarketLab.admin');
+  requireString(admin, 'startedMessage', 'jobMarketLab.admin');
+  requireString(admin, 'rejectedHeading', 'jobMarketLab.admin');
+}
+
+export function assertValidLoginPage(data: unknown): void {
+  const page = requireRecord(data, 'login');
+  requireString(page, 'heading', 'login');
+  requireString(page, 'description', 'login');
+  requireString(page, 'emailLabel', 'login');
+  requireString(page, 'passwordLabel', 'login');
+  requireString(page, 'submitLabel', 'login');
+  requireString(page, 'signOutLabel', 'login');
+  requireString(page, 'signedInHeading', 'login');
+  requireString(page, 'signedInDescription', 'login');
+  const errors = requireRecord(page.errors, 'login.errors');
+  requireString(errors, 'generic', 'login.errors');
+  requireString(errors, 'notConfigured', 'login.errors');
+  requireString(errors, 'required', 'login.errors');
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/hooks/use-site-auth.tsx
+++ b/src/hooks/use-site-auth.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type {
+  AuthSession,
+  SignInResult,
+  SiteAuthPort,
+} from '@/lib/site-auth';
+
+type SiteAuthContextValue = {
+  session: AuthSession | null;
+  isLoading: boolean;
+  signIn: (email: string, password: string) => Promise<SignInResult>;
+  signOut: () => Promise<void>;
+};
+
+const SiteAuthContext = createContext<SiteAuthContextValue | null>(null);
+
+export type SiteAuthProviderProps = {
+  children: ReactNode;
+  auth: SiteAuthPort;
+};
+
+export function SiteAuthProvider({ children, auth }: SiteAuthProviderProps) {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refreshSession = useCallback(async () => {
+    const next = await auth.getSession();
+    setSession(next);
+    setIsLoading(false);
+  }, [auth]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const next = await auth.getSession();
+      if (!cancelled) {
+        setSession(next);
+        setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [auth]);
+
+  const signIn = useCallback(
+    async (email: string, password: string) => {
+      const result = await auth.signIn(email, password);
+      if (result.status === 'signed_in') {
+        await refreshSession();
+      }
+      return result;
+    },
+    [auth, refreshSession],
+  );
+
+  const signOut = useCallback(async () => {
+    await auth.signOut();
+    await refreshSession();
+  }, [auth, refreshSession]);
+
+  return (
+    <SiteAuthContext.Provider value={{ session, isLoading, signIn, signOut }}>
+      {children}
+    </SiteAuthContext.Provider>
+  );
+}
+
+export function useSiteAuth(): SiteAuthContextValue {
+  const value = useContext(SiteAuthContext);
+  if (!value) {
+    throw new Error('useSiteAuth must be used within a SiteAuthProvider');
+  }
+  return value;
+}

--- a/src/lib/fetch-published-job-market-snapshot.test.ts
+++ b/src/lib/fetch-published-job-market-snapshot.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fetchPublishedSnapshotViaQuery,
+  publishedQueryFromClient,
+} from './fetch-published-job-market-snapshot';
+import { getPublishedJobMarketSnapshot } from './job-market-lab';
+
+describe('fetchPublishedSnapshotViaQuery', () => {
+  it('yields empty publication when the query returns null data', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery({
+          getPublishedJobMarketSnapshot: async () => ({ data: null }),
+        }),
+    });
+
+    expect(result).toEqual({ status: 'empty' });
+  });
+
+  it('yields empty publication when the query returns errors', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery({
+          getPublishedJobMarketSnapshot: async () => ({
+            data: { documentCount: 1 },
+            errors: [{ message: 'Unauthorised' }],
+          }),
+        }),
+    });
+
+    expect(result).toEqual({ status: 'empty' });
+  });
+
+  it('yields published and sanitised snapshot when the query returns a payload', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery({
+          getPublishedJobMarketSnapshot: async () => ({
+            data: {
+              documentCount: 2,
+              publishedAt: '2026-07-14T12:00:00.000Z',
+              skills: [{ name: 'python', count: 2 }],
+              seniority: [{ name: 'senior', count: 1 }],
+              roleFamily: [{ name: 'engineering', count: 2 }],
+              clusters: [{ id: 0, size: 2, label: 'Theme A' }],
+              projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
+              employer: 'must-not-leak',
+            },
+          }),
+        }),
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      snapshot: {
+        documentCount: 2,
+        publishedAt: '2026-07-14T12:00:00.000Z',
+        skills: [{ name: 'python', count: 2 }],
+        seniority: [{ name: 'senior', count: 1 }],
+        roleFamily: [{ name: 'engineering', count: 2 }],
+        clusters: [{ id: 0, size: 2, label: 'Theme A' }],
+        projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
+      },
+    });
+  });
+
+  it('only invokes the published query — never lists historical snapshots', async () => {
+    const client = {
+      queries: {
+        getPublishedJobMarketSnapshot: async () => ({
+          data: {
+            documentCount: 1,
+            publishedAt: '2026-07-14T12:00:00.000Z',
+            skills: [],
+            seniority: [],
+            roleFamily: [],
+            clusters: [],
+            projection: [],
+          },
+        }),
+      },
+      models: {
+        CorpusSnapshot: {
+          list: async () => {
+            throw new Error('guests must not list CorpusSnapshot');
+          },
+        },
+        LabPublication: {
+          list: async () => {
+            throw new Error('guests must not list LabPublication');
+          },
+        },
+      },
+    };
+
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: () =>
+        fetchPublishedSnapshotViaQuery(publishedQueryFromClient(client)),
+    });
+
+    expect(result.status).toBe('published');
+  });
+});

--- a/src/lib/fetch-published-job-market-snapshot.ts
+++ b/src/lib/fetch-published-job-market-snapshot.ts
@@ -1,0 +1,55 @@
+import type { JobMarketSnapshot } from './job-market-lab';
+
+export type PublishedJobMarketQuery = {
+  getPublishedJobMarketSnapshot: () => Promise<{
+    data: unknown;
+    errors?: Array<{ message: string }>;
+  }>;
+};
+
+/** Amplify client shape limited to the guest-safe published query. */
+export type AmplifyPublishedSnapshotClient = {
+  queries: {
+    getPublishedJobMarketSnapshot: () => Promise<{
+      data: unknown;
+      errors?: Array<{ message: string }>;
+    }>;
+  };
+};
+
+/** Builds a query seam that only calls getPublishedJobMarketSnapshot — never model list APIs. */
+export function publishedQueryFromClient(
+  client: AmplifyPublishedSnapshotClient,
+): PublishedJobMarketQuery {
+  return {
+    getPublishedJobMarketSnapshot: () =>
+      client.queries.getPublishedJobMarketSnapshot(),
+  };
+}
+
+export async function fetchPublishedSnapshotViaQuery(
+  query: PublishedJobMarketQuery,
+): Promise<JobMarketSnapshot | null> {
+  const { data, errors } = await query.getPublishedJobMarketSnapshot();
+
+  if (errors?.length || data == null) {
+    return null;
+  }
+
+  if (typeof data === 'object' && !Array.isArray(data)) {
+    return data as JobMarketSnapshot;
+  }
+
+  if (typeof data === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(data);
+      if (typeof parsed === 'object' && parsed != null && !Array.isArray(parsed)) {
+        return parsed as JobMarketSnapshot;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/job-market-corpus-amplify.test.ts
+++ b/src/lib/job-market-corpus-amplify.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  archiveJobDescription,
+  restoreJobDescription,
+  type JobDescriptionCorpusRecord,
+} from './job-market-corpus';
+import {
+  createAmplifyCorpusDeps,
+  type AmplifyJobDescriptionModelClient,
+  type AmplifyJobDescriptionRow,
+} from './job-market-corpus-amplify';
+
+function row(
+  overrides: Partial<AmplifyJobDescriptionRow> & Pick<AmplifyJobDescriptionRow, 'id'>,
+): AmplifyJobDescriptionRow {
+  return {
+    s3Key: `keys/${overrides.id}.md`,
+    contentHash: 'hash',
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    title: 'Quant analyst',
+    ...overrides,
+  };
+}
+
+function createMemoryModelClient(
+  initial: AmplifyJobDescriptionRow[],
+): AmplifyJobDescriptionModelClient & { deleteS3: (key: string) => Promise<void> } {
+  const store = new Map(initial.map((item) => [item.id, { ...item }]));
+  const deleteS3 = vi.fn(async () => {
+    throw new Error('S3 delete must never be called for soft-archive');
+  });
+
+  return {
+    deleteS3,
+    async get({ id }) {
+      return { data: store.get(id) ?? null };
+    },
+    async list() {
+      return { data: [...store.values()] };
+    },
+    async update(input) {
+      const existing = store.get(input.id);
+      if (!existing) {
+        return { data: null, errors: [{ message: 'not found' }] };
+      }
+      const next = { ...existing, ...input };
+      store.set(input.id, next);
+      return { data: next };
+    },
+  };
+}
+
+describe('createAmplifyCorpusDeps', () => {
+  it('maps Amplify get/update into archive and restore without deleting storage', async () => {
+    const client = createMemoryModelClient([
+      row({ id: 'jd-1', status: 'active', title: 'Risk modeller' }),
+    ]);
+    const deps = createAmplifyCorpusDeps(client);
+
+    const archived = await archiveJobDescription('jd-1', deps);
+    expect(archived).toEqual({
+      status: 'archived',
+      record: expect.objectContaining({ id: 'jd-1', status: 'archived' }),
+    });
+    expect(client.deleteS3).not.toHaveBeenCalled();
+
+    const listed = await deps.listJobDescriptions();
+    expect(listed).toEqual([
+      expect.objectContaining({
+        id: 'jd-1',
+        title: 'Risk modeller',
+        status: 'archived',
+      }),
+    ]);
+
+    const restored = await restoreJobDescription('jd-1', deps);
+    expect(restored).toEqual({
+      status: 'restored',
+      record: expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    });
+    expect(client.deleteS3).not.toHaveBeenCalled();
+
+    const afterRestore = await deps.getJobDescription('jd-1');
+    expect(afterRestore).toEqual(
+      expect.objectContaining({
+        id: 'jd-1',
+        status: 'active',
+        s3Key: 'keys/jd-1.md',
+      } satisfies Partial<JobDescriptionCorpusRecord>),
+    );
+  });
+});

--- a/src/lib/job-market-corpus-amplify.ts
+++ b/src/lib/job-market-corpus-amplify.ts
@@ -1,0 +1,125 @@
+import type {
+  ArchiveJobDescriptionDeps,
+  JobDescriptionCorpusRecord,
+  JobDescriptionStatus,
+  PrepareActiveCorpusDeps,
+} from './job-market-corpus';
+
+export type AmplifyJobDescriptionRow = {
+  id: string;
+  s3Key: string;
+  contentHash: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string | null;
+  seniority?: string | null;
+  roleFamily?: string | null;
+  source?: string | null;
+};
+
+type AmplifyDataResult<T> = {
+  data: T;
+  errors?: Array<{ message: string }> | null;
+};
+
+export type AmplifyJobDescriptionModelClient = {
+  get: (input: { id: string }) => Promise<AmplifyDataResult<AmplifyJobDescriptionRow | null>>;
+  list: () => Promise<AmplifyDataResult<AmplifyJobDescriptionRow[] | null>>;
+  update: (
+    input: Pick<AmplifyJobDescriptionRow, 'id' | 'status'> &
+      Partial<Omit<AmplifyJobDescriptionRow, 'id' | 'status'>>,
+  ) => Promise<AmplifyDataResult<AmplifyJobDescriptionRow | null>>;
+};
+
+export type AmplifyCorpusDeps = ArchiveJobDescriptionDeps &
+  Pick<PrepareActiveCorpusDeps, 'listJobDescriptions'>;
+
+function throwIfErrors(errors: Array<{ message: string }> | null | undefined): void {
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+function toCorpusRecord(row: AmplifyJobDescriptionRow): JobDescriptionCorpusRecord {
+  return {
+    id: row.id,
+    collectedAt: row.collectedAt,
+    status: row.status,
+    s3Key: row.s3Key,
+    contentHash: row.contentHash,
+    title: row.title ?? undefined,
+    seniority: row.seniority ?? undefined,
+    roleFamily: row.roleFamily ?? undefined,
+    source: row.source ?? undefined,
+  };
+}
+
+export function createAmplifyCorpusDeps(
+  client: AmplifyJobDescriptionModelClient,
+): AmplifyCorpusDeps {
+  return {
+    async getJobDescription(id) {
+      const { data, errors } = await client.get({ id });
+      throwIfErrors(errors);
+      return data ? toCorpusRecord(data) : null;
+    },
+    async listJobDescriptions() {
+      const { data, errors } = await client.list();
+      throwIfErrors(errors);
+      return (data ?? []).map(toCorpusRecord);
+    },
+    async saveJobDescription(record) {
+      // Model update only — never remove the S3 object for soft-archive/restore.
+      const { errors } = await client.update({
+        id: record.id,
+        status: record.status,
+        ...(record.s3Key !== undefined ? { s3Key: record.s3Key } : {}),
+        ...(record.contentHash !== undefined ? { contentHash: record.contentHash } : {}),
+        ...(record.collectedAt !== undefined ? { collectedAt: record.collectedAt } : {}),
+        ...(record.title !== undefined ? { title: record.title } : {}),
+        ...(record.seniority !== undefined ? { seniority: record.seniority } : {}),
+        ...(record.roleFamily !== undefined ? { roleFamily: record.roleFamily } : {}),
+        ...(record.source !== undefined ? { source: record.source } : {}),
+      });
+      throwIfErrors(errors);
+    },
+  };
+}
+
+type AmplifyDataModelsClient = {
+  models: {
+    JobDescription: {
+      get: AmplifyJobDescriptionModelClient['get'];
+      list: AmplifyJobDescriptionModelClient['list'];
+      update: AmplifyJobDescriptionModelClient['update'];
+    };
+  };
+};
+
+export function createAmplifyJobDescriptionModelClient(
+  getClient: () => Promise<AmplifyDataModelsClient> = defaultGetAmplifyDataClient,
+): AmplifyJobDescriptionModelClient {
+  return {
+    async get(input) {
+      const client = await getClient();
+      return client.models.JobDescription.get(input);
+    },
+    async list() {
+      const client = await getClient();
+      return client.models.JobDescription.list();
+    },
+    async update(input) {
+      const client = await getClient();
+      return client.models.JobDescription.update(input);
+    },
+  };
+}
+
+async function defaultGetAmplifyDataClient(): Promise<AmplifyDataModelsClient> {
+  const { generateClient } = await import('aws-amplify/data');
+  return generateClient() as unknown as AmplifyDataModelsClient;
+}
+
+export function createDefaultAmplifyCorpusDeps(): AmplifyCorpusDeps {
+  return createAmplifyCorpusDeps(createAmplifyJobDescriptionModelClient());
+}

--- a/src/lib/job-market-corpus.test.ts
+++ b/src/lib/job-market-corpus.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  archiveJobDescription,
+  prepareActiveCorpusForAnalysis,
+  restoreJobDescription,
+  type JobDescriptionCorpusRecord,
+} from './job-market-corpus';
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('archiveJobDescription', () => {
+  it('soft-archives an active JobDescription so it no longer counts as active for analysis', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['jd-1', doc({ id: 'jd-1' })],
+      ['jd-2', doc({ id: 'jd-2' })],
+    ]);
+
+    const result = await archiveJobDescription('jd-1', {
+      getJobDescription: async (id) => store.get(id) ?? null,
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'archived',
+      record: expect.objectContaining({ id: 'jd-1', status: 'archived' }),
+    });
+    expect(store.get('jd-1')?.status).toBe('archived');
+    expect(store.has('jd-1')).toBe(true);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+    });
+
+    expect(active.map((record) => record.id)).toEqual(['jd-2']);
+  });
+
+  it('keeps soft-archived records recoverable without hard delete', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['jd-1', doc({ id: 'jd-1', status: 'archived' })],
+    ]);
+
+    const restored = await restoreJobDescription('jd-1', {
+      getJobDescription: async (id) => store.get(id) ?? null,
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+    });
+
+    expect(restored).toEqual({
+      status: 'restored',
+      record: expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    });
+    expect(store.get('jd-1')).toEqual(
+      expect.objectContaining({ id: 'jd-1', status: 'active' }),
+    );
+  });
+});
+
+describe('prepareActiveCorpusForAnalysis', () => {
+  it('auto-archives documents older than the configured age window during the sweep', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      [
+        'old',
+        doc({
+          id: 'old',
+          collectedAt: '2024-01-01T00:00:00.000Z',
+        }),
+      ],
+      [
+        'fresh',
+        doc({
+          id: 'fresh',
+          collectedAt: '2026-06-01T00:00:00.000Z',
+        }),
+      ],
+    ]);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+      maxAgeMonths: 18,
+    });
+
+    expect(store.get('old')?.status).toBe('archived');
+    expect(store.get('fresh')?.status).toBe('active');
+    expect(active.map((record) => record.id)).toEqual(['fresh']);
+  });
+
+  it('excludes archived documents from the active analysis corpus', async () => {
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [
+        doc({ id: 'active-1', status: 'active' }),
+        doc({ id: 'archived-1', status: 'archived' }),
+        doc({ id: 'active-2', status: 'active' }),
+      ],
+      saveJobDescription: async () => undefined,
+      now: new Date('2026-07-14T00:00:00.000Z'),
+    });
+
+    expect(active.map((record) => record.id)).toEqual(['active-1', 'active-2']);
+  });
+
+  it('treats the age window as exclusive of the exact cutoff instant', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      [
+        'on-cutoff',
+        doc({
+          id: 'on-cutoff',
+          // Exactly 18 months before now
+          collectedAt: '2025-01-14T00:00:00.000Z',
+        }),
+      ],
+    ]);
+
+    const active = await prepareActiveCorpusForAnalysis({
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      now: new Date('2026-07-14T00:00:00.000Z'),
+      maxAgeMonths: 18,
+    });
+
+    expect(store.get('on-cutoff')?.status).toBe('active');
+    expect(active.map((record) => record.id)).toEqual(['on-cutoff']);
+  });
+});

--- a/src/lib/job-market-corpus.ts
+++ b/src/lib/job-market-corpus.ts
@@ -1,0 +1,120 @@
+export type JobDescriptionStatus = 'active' | 'archived';
+
+export type JobDescriptionCorpusRecord = {
+  id: string;
+  collectedAt: string;
+  status: JobDescriptionStatus;
+  title?: string;
+  seniority?: string;
+  roleFamily?: string;
+  source?: string;
+  s3Key?: string;
+  contentHash?: string;
+};
+
+export const DEFAULT_MAX_AGE_MONTHS = 18;
+
+export type ArchiveJobDescriptionDeps = {
+  getJobDescription: (id: string) => Promise<JobDescriptionCorpusRecord | null>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+};
+
+export type ArchiveJobDescriptionResult =
+  | { status: 'archived'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_archived'; record: JobDescriptionCorpusRecord };
+
+export type PrepareActiveCorpusDeps = {
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  saveJobDescription: (record: JobDescriptionCorpusRecord) => Promise<void>;
+  now?: Date;
+  maxAgeMonths?: number;
+};
+
+export function selectActiveCorpus(
+  records: JobDescriptionCorpusRecord[],
+): JobDescriptionCorpusRecord[] {
+  return records.filter((record) => record.status === 'active');
+}
+
+export function isOlderThanAgeWindow(
+  collectedAt: string,
+  now: Date,
+  maxAgeMonths: number = DEFAULT_MAX_AGE_MONTHS,
+): boolean {
+  const collected = new Date(collectedAt);
+  if (Number.isNaN(collected.getTime())) {
+    return false;
+  }
+
+  const cutoff = new Date(now);
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - maxAgeMonths);
+  return collected.getTime() < cutoff.getTime();
+}
+
+export type RestoreJobDescriptionResult =
+  | { status: 'restored'; record: JobDescriptionCorpusRecord }
+  | { status: 'not_found' }
+  | { status: 'already_active'; record: JobDescriptionCorpusRecord };
+
+export async function archiveJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<ArchiveJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'archived') {
+    return { status: 'already_archived', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'archived',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'archived', record };
+}
+
+export async function restoreJobDescription(
+  id: string,
+  deps: ArchiveJobDescriptionDeps,
+): Promise<RestoreJobDescriptionResult> {
+  const existing = await deps.getJobDescription(id);
+  if (!existing) {
+    return { status: 'not_found' };
+  }
+
+  if (existing.status === 'active') {
+    return { status: 'already_active', record: existing };
+  }
+
+  const record: JobDescriptionCorpusRecord = {
+    ...existing,
+    status: 'active',
+  };
+  await deps.saveJobDescription(record);
+  return { status: 'restored', record };
+}
+
+export async function prepareActiveCorpusForAnalysis(
+  deps: PrepareActiveCorpusDeps,
+): Promise<JobDescriptionCorpusRecord[]> {
+  const now = deps.now ?? new Date();
+  const maxAgeMonths = deps.maxAgeMonths ?? DEFAULT_MAX_AGE_MONTHS;
+  const records = await deps.listJobDescriptions();
+
+  for (const record of records) {
+    if (
+      record.status === 'active' &&
+      isOlderThanAgeWindow(record.collectedAt, now, maxAgeMonths)
+    ) {
+      await deps.saveJobDescription({ ...record, status: 'archived' });
+    }
+  }
+
+  const refreshed = await deps.listJobDescriptions();
+  return selectActiveCorpus(refreshed);
+}

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getPublishedJobMarketSnapshot } from './job-market-lab';
+
+describe('getPublishedJobMarketSnapshot', () => {
+  it('returns empty when nothing is published', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () => null,
+    });
+
+    expect(result).toEqual({ status: 'empty' });
+  });
+
+  it('returns published when a snapshot is available', async () => {
+    const snapshot = {
+      documentCount: 3,
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () => snapshot,
+    });
+
+    expect(result).toEqual({ status: 'published', snapshot });
+  });
+
+  it('does not expose raw job description or employer identity fields', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () =>
+        ({
+          documentCount: 1,
+          publishedAt: '2026-07-01T00:00:00.000Z',
+          rawText: 'Acme Corp seeks a data scientist…',
+          source: 'confidential-board',
+          employer: 'Acme Corp',
+        }) as never,
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      snapshot: {
+        documentCount: 1,
+        publishedAt: '2026-07-01T00:00:00.000Z',
+      },
+    });
+  });
+});

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -70,7 +70,21 @@ describe('getPublishedJobMarketSnapshot', () => {
 });
 
 describe('startJobMarketRecompute', () => {
-  it('returns the orchestrator result through the lab facade', async () => {
+  it('returns started with runId when the injected start succeeds', async () => {
+    const result = await startJobMarketRecompute({
+      startRecompute: async () => ({
+        status: 'started',
+        runId: 'run-123',
+      }),
+    });
+
+    expect(result).toEqual({
+      status: 'started',
+      runId: 'run-123',
+    });
+  });
+
+  it('returns rejected with reason when a run is already in progress', async () => {
     const result = await startJobMarketRecompute({
       startRecompute: async () => ({
         status: 'rejected',
@@ -81,6 +95,15 @@ describe('startJobMarketRecompute', () => {
     expect(result).toEqual({
       status: 'rejected',
       reason: 'An analysis run is already in progress',
+    });
+  });
+
+  it('rejects clearly from the default Amplify path when outputs are absent', async () => {
+    const result = await startJobMarketRecompute();
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Recompute client is not configured',
     });
   });
 });

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getPublishedJobMarketSnapshot } from './job-market-lab';
+import {
+  getPublishedJobMarketSnapshot,
+  startJobMarketRecompute,
+} from './job-market-lab';
 
 describe('getPublishedJobMarketSnapshot', () => {
   it('returns empty when nothing is published', async () => {
@@ -14,6 +17,11 @@ describe('getPublishedJobMarketSnapshot', () => {
     const snapshot = {
       documentCount: 3,
       publishedAt: '2026-07-01T00:00:00.000Z',
+      skills: [{ name: 'python', count: 3 }],
+      seniority: [{ name: 'senior', count: 2 }],
+      roleFamily: [{ name: 'data-science', count: 2 }],
+      clusters: [{ id: 0, size: 3, label: 'Theme 1' }],
+      projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
     };
 
     const result = await getPublishedJobMarketSnapshot({
@@ -29,6 +37,11 @@ describe('getPublishedJobMarketSnapshot', () => {
         ({
           documentCount: 1,
           publishedAt: '2026-07-01T00:00:00.000Z',
+          skills: [],
+          seniority: [],
+          roleFamily: [],
+          clusters: [],
+          projection: [],
           rawText: 'Acme Corp seeks a data scientist…',
           source: 'confidential-board',
           employer: 'Acme Corp',
@@ -40,7 +53,28 @@ describe('getPublishedJobMarketSnapshot', () => {
       snapshot: {
         documentCount: 1,
         publishedAt: '2026-07-01T00:00:00.000Z',
+        skills: [],
+        seniority: [],
+        roleFamily: [],
+        clusters: [],
+        projection: [],
       },
+    });
+  });
+});
+
+describe('startJobMarketRecompute', () => {
+  it('returns the orchestrator result through the lab facade', async () => {
+    const result = await startJobMarketRecompute({
+      startRecompute: async () => ({
+        status: 'rejected',
+        reason: 'An analysis run is already in progress',
+      }),
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
     });
   });
 });

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -61,6 +61,12 @@ describe('getPublishedJobMarketSnapshot', () => {
       },
     });
   });
+
+  it('returns empty from the default Amplify path when outputs are absent', async () => {
+    const result = await getPublishedJobMarketSnapshot();
+
+    expect(result).toEqual({ status: 'empty' });
+  });
 });
 
 describe('startJobMarketRecompute', () => {

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -71,6 +71,12 @@ export {
   type JobDescriptionStatus,
 } from './job-market-corpus';
 
+export {
+  createAmplifyCorpusDeps,
+  createDefaultAmplifyCorpusDeps,
+  type AmplifyCorpusDeps,
+} from './job-market-corpus-amplify';
+
 function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
   return {
     documentCount: snapshot.documentCount,

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -13,6 +13,16 @@ export type GetPublishedJobMarketSnapshotDeps = {
   fetchPublished?: FetchPublishedJobMarketSnapshot;
 };
 
+export {
+  archiveJobDescription,
+  restoreJobDescription,
+  prepareActiveCorpusForAnalysis,
+  selectActiveCorpus,
+  DEFAULT_MAX_AGE_MONTHS,
+  type JobDescriptionCorpusRecord,
+  type JobDescriptionStatus,
+} from './job-market-corpus';
+
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
   // Guest publication query lands in a later slice; until then nothing is published.
   return null;

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -1,3 +1,13 @@
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { configureSiteAmplify } from './configure-site-amplify';
+import {
+  fetchPublishedSnapshotViaQuery,
+  publishedQueryFromClient,
+  type AmplifyPublishedSnapshotClient,
+} from './fetch-published-job-market-snapshot';
+import { readAmplifyOutputs } from './read-amplify-outputs';
+
 export type SkillFrequency = {
   name: string;
   count: number;
@@ -73,8 +83,25 @@ function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
 }
 
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
-  // Wiring to Amplify getPublishedJobMarketSnapshot lands with sandbox/outputs.
-  return null;
+  try {
+    const outputs = readAmplifyOutputs();
+    if (!outputs) {
+      return null;
+    }
+
+    configureSiteAmplify(outputs, (config, options) => {
+      Amplify.configure(config, options);
+    });
+
+    // Guest-safe auth: default data mode is userPool; allow.guest needs identityPool.
+    const client = generateClient({
+      authMode: 'identityPool',
+    }) as AmplifyPublishedSnapshotClient;
+
+    return fetchPublishedSnapshotViaQuery(publishedQueryFromClient(client));
+  } catch {
+    return null;
+  }
 }
 
 async function defaultStartRecompute(): Promise<StartJobMarketRecomputeResult> {

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -7,6 +7,7 @@ import {
   type AmplifyPublishedSnapshotClient,
 } from './fetch-published-job-market-snapshot';
 import { readAmplifyOutputs } from './read-amplify-outputs';
+import { defaultStartJobMarketRecompute } from './start-job-market-recompute-client';
 
 export type SkillFrequency = {
   name: string;
@@ -105,10 +106,7 @@ async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
 }
 
 async function defaultStartRecompute(): Promise<StartJobMarketRecomputeResult> {
-  return {
-    status: 'rejected',
-    reason: 'Recompute client is not configured',
-  };
+  return defaultStartJobMarketRecompute();
 }
 
 export async function getPublishedJobMarketSnapshot(

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -1,0 +1,38 @@
+export type JobMarketSnapshot = {
+  documentCount: number;
+  publishedAt: string;
+};
+
+export type PublishedJobMarketResult =
+  | { status: 'empty' }
+  | { status: 'published'; snapshot: JobMarketSnapshot };
+
+export type FetchPublishedJobMarketSnapshot = () => Promise<JobMarketSnapshot | null>;
+
+export type GetPublishedJobMarketSnapshotDeps = {
+  fetchPublished?: FetchPublishedJobMarketSnapshot;
+};
+
+async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
+  // Guest publication query lands in a later slice; until then nothing is published.
+  return null;
+}
+
+export async function getPublishedJobMarketSnapshot(
+  deps: GetPublishedJobMarketSnapshotDeps = {},
+): Promise<PublishedJobMarketResult> {
+  const fetchPublished = deps.fetchPublished ?? defaultFetchPublished;
+  const snapshot = await fetchPublished();
+
+  if (snapshot == null) {
+    return { status: 'empty' };
+  }
+
+  return {
+    status: 'published',
+    snapshot: {
+      documentCount: snapshot.documentCount,
+      publishedAt: snapshot.publishedAt,
+    },
+  };
+}

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -1,6 +1,33 @@
+export type SkillFrequency = {
+  name: string;
+  count: number;
+};
+
+export type TaxonomyBucket = {
+  name: string;
+  count: number;
+};
+
+export type ClusterSummary = {
+  id: number;
+  size: number;
+  label: string;
+};
+
+export type ProjectionPoint = {
+  x: number;
+  y: number;
+  clusterId: number;
+};
+
 export type JobMarketSnapshot = {
   documentCount: number;
   publishedAt: string;
+  skills: SkillFrequency[];
+  seniority: TaxonomyBucket[];
+  roleFamily: TaxonomyBucket[];
+  clusters: ClusterSummary[];
+  projection: ProjectionPoint[];
 };
 
 export type PublishedJobMarketResult =
@@ -13,6 +40,16 @@ export type GetPublishedJobMarketSnapshotDeps = {
   fetchPublished?: FetchPublishedJobMarketSnapshot;
 };
 
+export type StartJobMarketRecomputeResult =
+  | { status: 'started'; runId: string }
+  | { status: 'rejected'; reason: string };
+
+export type StartJobMarketRecompute = () => Promise<StartJobMarketRecomputeResult>;
+
+export type StartJobMarketRecomputeDeps = {
+  startRecompute?: StartJobMarketRecompute;
+};
+
 export {
   archiveJobDescription,
   restoreJobDescription,
@@ -23,9 +60,28 @@ export {
   type JobDescriptionStatus,
 } from './job-market-corpus';
 
+function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
+  return {
+    documentCount: snapshot.documentCount,
+    publishedAt: snapshot.publishedAt,
+    skills: snapshot.skills ?? [],
+    seniority: snapshot.seniority ?? [],
+    roleFamily: snapshot.roleFamily ?? [],
+    clusters: snapshot.clusters ?? [],
+    projection: snapshot.projection ?? [],
+  };
+}
+
 async function defaultFetchPublished(): Promise<JobMarketSnapshot | null> {
-  // Guest publication query lands in a later slice; until then nothing is published.
+  // Wiring to Amplify getPublishedJobMarketSnapshot lands with sandbox/outputs.
   return null;
+}
+
+async function defaultStartRecompute(): Promise<StartJobMarketRecomputeResult> {
+  return {
+    status: 'rejected',
+    reason: 'Recompute client is not configured',
+  };
 }
 
 export async function getPublishedJobMarketSnapshot(
@@ -40,9 +96,13 @@ export async function getPublishedJobMarketSnapshot(
 
   return {
     status: 'published',
-    snapshot: {
-      documentCount: snapshot.documentCount,
-      publishedAt: snapshot.publishedAt,
-    },
+    snapshot: sanitizeSnapshot(snapshot),
   };
+}
+
+export async function startJobMarketRecompute(
+  deps: StartJobMarketRecomputeDeps = {},
+): Promise<StartJobMarketRecomputeResult> {
+  const start = deps.startRecompute ?? defaultStartRecompute;
+  return start();
 }

--- a/src/lib/site-auth.test.ts
+++ b/src/lib/site-auth.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_NOT_CONFIGURED_REASON,
+  createAmplifySiteAuth,
+  createMemorySiteAuth,
+  createSiteAuthFromOutputs,
+  type AmplifyAuthClient,
+} from '@/lib/site-auth';
+
+function createFakeAmplifyClient(
+  overrides: Partial<AmplifyAuthClient> = {},
+): AmplifyAuthClient {
+  return {
+    getCurrentUser: vi.fn(async () => {
+      throw new Error('UserUnAuthenticatedException');
+    }),
+    fetchUserAttributes: vi.fn(async () => ({})),
+    signIn: vi.fn(async () => ({ isSignedIn: true })),
+    signOut: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('createMemorySiteAuth', () => {
+  it('getSession returns unauthenticated when starting signed out', async () => {
+    const auth = createMemorySiteAuth();
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+
+  it('after successful signIn, getSession is authenticated', async () => {
+    const auth = createMemorySiteAuth();
+
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'signed_in',
+    });
+    await expect(auth.getSession()).resolves.toEqual({
+      status: 'authenticated',
+      email: 'owner@example.com',
+    });
+  });
+
+  it('signOut clears the session to unauthenticated', async () => {
+    const auth = createMemorySiteAuth();
+    await auth.signIn('owner@example.com', 'secret');
+
+    await auth.signOut();
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+});
+
+describe('createAmplifySiteAuth', () => {
+  it('getSession returns unauthenticated when Amplify is not configured', async () => {
+    const auth = createAmplifySiteAuth({ isConfigured: false });
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+
+  it('signIn fails with a clear British English reason when Amplify is not configured', async () => {
+    const auth = createAmplifySiteAuth({ isConfigured: false });
+
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'failed',
+      reason: AUTH_NOT_CONFIGURED_REASON,
+    });
+  });
+
+  it('getSession returns authenticated email when Amplify reports a signed-in user', async () => {
+    const client = createFakeAmplifyClient({
+      getCurrentUser: vi.fn(async () => ({ username: 'owner', userId: '1' })),
+      fetchUserAttributes: vi.fn(async () => ({ email: 'owner@example.com' })),
+    });
+    const auth = createAmplifySiteAuth({ isConfigured: true, client });
+
+    await expect(auth.getSession()).resolves.toEqual({
+      status: 'authenticated',
+      email: 'owner@example.com',
+    });
+  });
+
+  it('getSession returns unauthenticated when Amplify reports no signed-in user', async () => {
+    const auth = createAmplifySiteAuth({
+      isConfigured: true,
+      client: createFakeAmplifyClient(),
+    });
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+  });
+
+  it('signIn succeeds when Amplify accepts credentials', async () => {
+    const client = createFakeAmplifyClient({
+      signIn: vi.fn(async () => ({ isSignedIn: true })),
+    });
+    const auth = createAmplifySiteAuth({ isConfigured: true, client });
+
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'signed_in',
+    });
+    expect(client.signIn).toHaveBeenCalledWith({
+      username: 'owner@example.com',
+      password: 'secret',
+    });
+  });
+
+  it('signOut clears the Amplify session', async () => {
+    const client = createFakeAmplifyClient();
+    const auth = createAmplifySiteAuth({ isConfigured: true, client });
+
+    await auth.signOut();
+
+    expect(client.signOut).toHaveBeenCalled();
+  });
+});
+
+describe('createSiteAuthFromOutputs', () => {
+  it('behaves as unconfigured when outputs are missing', async () => {
+    const auth = createSiteAuthFromOutputs(null);
+
+    await expect(auth.getSession()).resolves.toEqual({ status: 'unauthenticated' });
+    await expect(auth.signIn('owner@example.com', 'secret')).resolves.toEqual({
+      status: 'failed',
+      reason: AUTH_NOT_CONFIGURED_REASON,
+    });
+  });
+});

--- a/src/lib/site-auth.ts
+++ b/src/lib/site-auth.ts
@@ -1,0 +1,134 @@
+import type { AmplifyOutputs } from './configure-site-amplify';
+
+export type AuthSession =
+  | { status: 'authenticated'; email: string }
+  | { status: 'unauthenticated' };
+
+export type SignInResult =
+  | { status: 'signed_in' }
+  | { status: 'failed'; reason: string };
+
+export type SiteAuthPort = {
+  getSession: () => Promise<AuthSession>;
+  signIn: (email: string, password: string) => Promise<SignInResult>;
+  signOut: () => Promise<void>;
+};
+
+export const AUTH_NOT_CONFIGURED_REASON =
+  'Sign-in is unavailable because authentication is not configured.';
+
+export function createMemorySiteAuth(
+  initial: AuthSession = { status: 'unauthenticated' },
+): SiteAuthPort {
+  let session = initial;
+
+  return {
+    async getSession() {
+      return session;
+    },
+    async signIn(email: string) {
+      session = { status: 'authenticated', email };
+      return { status: 'signed_in' };
+    },
+    async signOut() {
+      session = { status: 'unauthenticated' };
+    },
+  };
+}
+
+export type AmplifyAuthClient = {
+  getCurrentUser: () => Promise<{ username: string; userId: string }>;
+  fetchUserAttributes: () => Promise<Record<string, string | undefined>>;
+  signIn: (input: {
+    username: string;
+    password: string;
+  }) => Promise<{ isSignedIn: boolean }>;
+  signOut: () => Promise<void>;
+};
+
+export function createAmplifySiteAuth(options: {
+  isConfigured: boolean;
+  client?: AmplifyAuthClient;
+}): SiteAuthPort {
+  const { isConfigured, client } = options;
+
+  return {
+    async getSession() {
+      if (!isConfigured || !client) {
+        return { status: 'unauthenticated' };
+      }
+
+      try {
+        await client.getCurrentUser();
+        const attributes = await client.fetchUserAttributes();
+        const email = attributes.email;
+        if (!email) {
+          return { status: 'unauthenticated' };
+        }
+        return { status: 'authenticated', email };
+      } catch {
+        return { status: 'unauthenticated' };
+      }
+    },
+    async signIn(email: string, password: string) {
+      if (!isConfigured || !client) {
+        return { status: 'failed', reason: AUTH_NOT_CONFIGURED_REASON };
+      }
+
+      try {
+        const result = await client.signIn({ username: email, password });
+        if (!result.isSignedIn) {
+          return {
+            status: 'failed',
+            reason: 'Sign-in could not be completed. Please try again.',
+          };
+        }
+        return { status: 'signed_in' };
+      } catch {
+        return {
+          status: 'failed',
+          reason: 'Sign-in failed. Check your email and password, then try again.',
+        };
+      }
+    },
+    async signOut() {
+      if (!isConfigured || !client) {
+        return;
+      }
+      await client.signOut();
+    },
+  };
+}
+
+export function createDefaultAmplifyAuthClient(): AmplifyAuthClient {
+  return {
+    async getCurrentUser() {
+      const { getCurrentUser } = await import('aws-amplify/auth');
+      return getCurrentUser();
+    },
+    async fetchUserAttributes() {
+      const { fetchUserAttributes } = await import('aws-amplify/auth');
+      return fetchUserAttributes();
+    },
+    async signIn(input) {
+      const { signIn } = await import('aws-amplify/auth');
+      const result = await signIn(input);
+      return { isSignedIn: result.isSignedIn };
+    },
+    async signOut() {
+      const { signOut } = await import('aws-amplify/auth');
+      await signOut();
+    },
+  };
+}
+
+export function createSiteAuthFromOutputs(
+  outputs?: AmplifyOutputs | null,
+): SiteAuthPort {
+  const isConfigured = outputs != null && Object.keys(outputs).length > 0;
+  return createAmplifySiteAuth({
+    isConfigured,
+    client: isConfigured ? createDefaultAmplifyAuthClient() : undefined,
+  });
+}
+

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -35,6 +35,18 @@ export function buildSitemap(blogDirectory?: string): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/labs`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/labs/job-market`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
     ...blogPosts.map((post) => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: new Date(post.frontmatter.date),

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -47,6 +47,12 @@ export function buildSitemap(blogDirectory?: string): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/login`,
+      lastModified,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
     ...blogPosts.map((post) => ({
       url: `${baseUrl}/blog/${post.slug}`,
       lastModified: new Date(post.frontmatter.date),

--- a/src/lib/start-job-market-recompute-client.test.ts
+++ b/src/lib/start-job-market-recompute-client.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultStartJobMarketRecompute,
+  isAmplifyClientConfigured,
+  startJobMarketRecomputeViaMutation,
+  type StartJobMarketRecomputeMutation,
+} from './start-job-market-recompute-client';
+
+describe('startJobMarketRecomputeViaMutation', () => {
+  it('returns started with runId when the mutation starts a run', async () => {
+    const mutation: StartJobMarketRecomputeMutation = {
+      startJobMarketRecompute: async () => ({
+        data: { status: 'started', runId: 'run-abc' },
+      }),
+    };
+
+    const result = await startJobMarketRecomputeViaMutation(mutation);
+
+    expect(result).toEqual({ status: 'started', runId: 'run-abc' });
+  });
+
+  it('returns rejected with reason when a run is already in progress', async () => {
+    const mutation: StartJobMarketRecomputeMutation = {
+      startJobMarketRecompute: async () => ({
+        data: {
+          status: 'rejected',
+          reason: 'An analysis run is already in progress',
+        },
+      }),
+    };
+
+    const result = await startJobMarketRecomputeViaMutation(mutation);
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'An analysis run is already in progress',
+    });
+  });
+
+  it('returns rejected with reason when the active corpus is over cap', async () => {
+    const mutation: StartJobMarketRecomputeMutation = {
+      startJobMarketRecompute: async () => ({
+        data: {
+          status: 'rejected',
+          reason: 'Active corpus exceeds the 150-document cap (151 active)',
+        },
+      }),
+    };
+
+    const result = await startJobMarketRecomputeViaMutation(mutation);
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Active corpus exceeds the 150-document cap (151 active)',
+    });
+  });
+
+  it('rejects clearly when Amplify reports an unauthenticated error', async () => {
+    const mutation: StartJobMarketRecomputeMutation = {
+      startJobMarketRecompute: async () => ({
+        data: null,
+        errors: [{ message: 'No current user' }],
+      }),
+    };
+
+    const result = await startJobMarketRecomputeViaMutation(mutation);
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'You must be signed in to start a recompute.',
+    });
+  });
+
+  it('treats an empty Amplify config as not configured', () => {
+    expect(isAmplifyClientConfigured(() => ({}))).toBe(false);
+    expect(isAmplifyClientConfigured(() => ({ Auth: {} }))).toBe(true);
+  });
+
+  it('rejects clearly from the default path when Amplify is not configured', async () => {
+    const result = await defaultStartJobMarketRecompute();
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Recompute client is not configured',
+    });
+  });
+});

--- a/src/lib/start-job-market-recompute-client.ts
+++ b/src/lib/start-job-market-recompute-client.ts
@@ -1,0 +1,130 @@
+import { Amplify } from 'aws-amplify';
+import type { StartJobMarketRecomputeResult } from './job-market-lab';
+
+export type StartJobMarketRecomputeMutationResult = {
+  status: string;
+  runId?: string | null;
+  reason?: string | null;
+};
+
+export type StartJobMarketRecomputeMutation = {
+  startJobMarketRecompute: () => Promise<{
+    data?: StartJobMarketRecomputeMutationResult | null;
+    errors?: Array<{ message: string }>;
+  }>;
+};
+
+/** Amplify client shape limited to the authenticated start mutation. */
+export type AmplifyStartRecomputeClient = {
+  mutations: {
+    startJobMarketRecompute: () => Promise<{
+      data?: StartJobMarketRecomputeMutationResult | null;
+      errors?: Array<{ message: string }>;
+    }>;
+  };
+};
+
+export const RECOMPUTE_UNAUTHENTICATED_REASON =
+  'You must be signed in to start a recompute.';
+
+export const RECOMPUTE_CLIENT_NOT_CONFIGURED_REASON =
+  'Recompute client is not configured';
+
+export const RECOMPUTE_FAILED_REASON =
+  'Unable to start recompute. Please try again.';
+
+function isUnauthenticatedError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('no current user') ||
+    lower.includes('not authorized') ||
+    lower.includes('unauthorised') ||
+    lower.includes('unauthorized') ||
+    lower.includes('not authenticated') ||
+    lower.includes('user is not authenticated')
+  );
+}
+
+export function isAmplifyClientConfigured(
+  getConfig: () => object = () => Amplify.getConfig(),
+): boolean {
+  return Object.keys(getConfig()).length > 0;
+}
+
+/** Builds a mutation seam that only calls startJobMarketRecompute. */
+export function startMutationFromClient(
+  client: AmplifyStartRecomputeClient,
+): StartJobMarketRecomputeMutation {
+  return {
+    startJobMarketRecompute: () => client.mutations.startJobMarketRecompute(),
+  };
+}
+
+export async function startJobMarketRecomputeViaMutation(
+  mutation: StartJobMarketRecomputeMutation,
+): Promise<StartJobMarketRecomputeResult> {
+  try {
+    const { data, errors } = await mutation.startJobMarketRecompute();
+
+    if (errors?.length) {
+      if (errors.some((error) => isUnauthenticatedError(error.message))) {
+        return { status: 'rejected', reason: RECOMPUTE_UNAUTHENTICATED_REASON };
+      }
+      return {
+        status: 'rejected',
+        reason: errors[0]?.message ?? RECOMPUTE_FAILED_REASON,
+      };
+    }
+
+    if (data == null) {
+      return { status: 'rejected', reason: RECOMPUTE_FAILED_REASON };
+    }
+
+    if (data.status === 'started' && data.runId) {
+      return { status: 'started', runId: data.runId };
+    }
+
+    if (data.status === 'rejected') {
+      return {
+        status: 'rejected',
+        reason: data.reason?.trim() || RECOMPUTE_FAILED_REASON,
+      };
+    }
+
+    return { status: 'rejected', reason: RECOMPUTE_FAILED_REASON };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (isUnauthenticatedError(message)) {
+      return { status: 'rejected', reason: RECOMPUTE_UNAUTHENTICATED_REASON };
+    }
+    return { status: 'rejected', reason: RECOMPUTE_FAILED_REASON };
+  }
+}
+
+/**
+ * Client-safe default start path. Relies on AmplifyProvider having configured
+ * Amplify already — avoids node:fs / readAmplifyOutputs in the browser bundle.
+ */
+export async function defaultStartJobMarketRecompute(): Promise<StartJobMarketRecomputeResult> {
+  if (!isAmplifyClientConfigured()) {
+    return {
+      status: 'rejected',
+      reason: RECOMPUTE_CLIENT_NOT_CONFIGURED_REASON,
+    };
+  }
+
+  try {
+    const { generateClient } = await import('aws-amplify/data');
+    const client = generateClient({
+      authMode: 'userPool',
+    }) as AmplifyStartRecomputeClient;
+
+    return startJobMarketRecomputeViaMutation(startMutationFromClient(client));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (isUnauthenticatedError(message)) {
+      return { status: 'rejected', reason: RECOMPUTE_UNAUTHENTICATED_REASON };
+    }
+    return { status: 'rejected', reason: RECOMPUTE_FAILED_REASON };
+  }
+}


### PR DESCRIPTION
## Summary
- Promotes `develop` to `main`: job market signal lab (Labs shell, public aggregates dashboard, owner Cognito login, recompute admin, soft-archive/restore).
- Amplify Gen 2 backend wiring (auth, data, storage, ingest/analyse/recompute/publication) with sandbox schema and nested-stack fixes from #60.
- Includes follow-up fixes for login validate/types (#59) and CI flake in corpus admin tests.

Closes #34
Closes #49
Closes #50
Closes #51
Closes #52
Closes #53

## Test plan
- [ ] GitHub Actions quality green on this PR
- [ ] Amplify Hosting Gen 2 `pipeline-deploy` succeeds on `main`
- [ ] Guest: `/labs` and `/labs/job-market` load; empty or published snapshot; no raw JD text
- [ ] Owner: invite Cognito user if needed; `/login` works; recompute + archive/restore on lab admin
- [ ] Marketing pages and blog sync still behave as before
