### PR TITLE
Fix job market lab Hosting prerender failure

### DIFF
--- a/src/app/labs/job-market/page.test.ts
+++ b/src/app/labs/job-market/page.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { metadata } from '@/app/labs/job-market/page';
+import { dynamic, metadata } from '@/app/labs/job-market/page';
 import { jobMarketLab, site } from '@/data';
 
 describe('Job market lab page metadata', () => {
+  it('forces dynamic rendering so Amplify is not called during static prerender', () => {
+    expect(dynamic).toBe('force-dynamic');
+  });
+
   it('derives title and description from job market lab page data', () => {
     expect(metadata).toMatchObject({
       title: `${jobMarketLab.heading} - ${site.metadata.author}`,

--- a/src/app/labs/job-market/page.tsx
+++ b/src/app/labs/job-market/page.tsx
@@ -6,6 +6,9 @@ import { getPublishedJobMarketSnapshot } from '@/lib/job-market-lab';
 
 const jobMarketLab = getPageData('/labs/job-market');
 
+/** Live Amplify published-snapshot fetch must not run at static build time. */
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: `${jobMarketLab.heading} - ${site.metadata.author}`,
   description: jobMarketLab.description,


### PR DESCRIPTION
## Summary
- Marks `/labs/job-market` as `force-dynamic` so Next does not prerender it at build time.
- Hosting failed after a successful Gen 2 backend deploy when the page called Cognito identity during static generation (`revalidate: 0` / dynamic server usage).

## Test plan
- [ ] CI quality green
- [ ] Amplify Hosting frontend build completes past `/labs/job-market`
- [ ] Live `/labs/job-market` still loads published or empty state
