### PR TITLE
Fix CorpusSnapshot AWSJSON payload on analyse write

### DIFF
--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -142,7 +142,8 @@ async function saveSnapshot(
   const { errors } = await client.models.CorpusSnapshot.create({
     id: snapshot.id,
     runId: snapshot.runId,
-    payload: snapshot.payload,
+    // a.json() / AWSJSON inputs must be serialised JSON strings.
+    payload: JSON.stringify(snapshot.payload),
   });
   if (errors?.length) {
     throw new Error(errors.map((error) => error.message).join('; '));

--- a/amplify/functions/job-market-publication/handler.ts
+++ b/amplify/functions/job-market-publication/handler.ts
@@ -23,9 +23,18 @@ export const handler: Schema['getPublishedJobMarketSnapshot']['functionHandler']
     }
 
     const snapshot = await client.models.CorpusSnapshot.get({ id: snapshotId });
-    if (!snapshot.data?.payload) {
+    const rawPayload = snapshot.data?.payload;
+    if (rawPayload == null) {
       return null;
     }
 
-    return snapshot.data.payload as CorpusSnapshotPayload;
+    if (typeof rawPayload === 'string') {
+      try {
+        return JSON.parse(rawPayload) as CorpusSnapshotPayload;
+      } catch {
+        return null;
+      }
+    }
+
+    return rawPayload as CorpusSnapshotPayload;
   };


### PR DESCRIPTION
## Summary
- Analyse worker now `JSON.stringify`s `CorpusSnapshot.payload` before create (fixes `Variable 'payload' has an invalid value.`).
- Publication query tolerates string or already-parsed JSON when reading the snapshot.

## Test plan
- [ ] CI quality green
- [ ] Redeploy Hosting; sign in; Start recompute on the 3 ingested JDs
- [ ] Run reaches succeeded; `/labs/job-market` shows published aggregates
