### PR TITLE
Add owner console shell with facade-backed corpus and run status

### DIFF
--- a/src/app/labs/job-market/console/page.tsx
+++ b/src/app/labs/job-market/console/page.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from 'next';
+import { SitePage } from '@/components/layout/site-page';
+import { JobMarketLabConsoleSection } from '@/components/sections/labs/job-market-lab-console-section';
+import { getPageData, site } from '@/data';
+
+const jobMarketLab = getPageData('/labs/job-market');
+
+export const metadata: Metadata = {
+  title: `${jobMarketLab.console.heading} - ${site.metadata.author}`,
+  description: jobMarketLab.console.description,
+  openGraph: {
+    title: `${jobMarketLab.console.heading} - ${site.metadata.author}`,
+    description: jobMarketLab.console.description,
+    url: `${site.metadata.siteUrl}/labs/job-market/console`,
+    type: 'website',
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function JobMarketLabConsolePage() {
+  return (
+    <SitePage mainClassName="min-h-screen pt-20">
+      <JobMarketLabConsoleSection />
+    </SitePage>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-console-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobMarketLabConsoleSection } from '@/components/sections/labs/job-market-lab-console-section';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+import type { ListAnalysisRunsDeps } from '@/lib/job-market-lab';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createMemoryCorpus(): AmplifyCorpusDeps {
+  return {
+    getJobDescription: async () => null,
+    listJobDescriptions: async () => [],
+    saveJobDescription: async () => undefined,
+  };
+}
+
+function renderConsole(options?: {
+  auth?: ReturnType<typeof createMemorySiteAuth>;
+  analysisRuns?: ListAnalysisRunsDeps;
+}) {
+  const auth = options?.auth ?? createMemorySiteAuth();
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <JobMarketLabConsoleSection
+        corpus={createMemoryCorpus()}
+        analysisRuns={options?.analysisRuns}
+      />
+    </SiteAuthProvider>,
+  );
+}
+
+describe('JobMarketLabConsoleSection', () => {
+  it('blocks unauthenticated visitors from corpus and run management', async () => {
+    renderConsole();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking session/i)).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('heading', {
+        name: jobMarketLab.console.unauthenticatedHeading,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.console.runsHeading }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows facade-backed management and live run history when authenticated', async () => {
+    renderConsole({
+      auth: createMemorySiteAuth({
+        status: 'authenticated',
+        email: 'owner@example.com',
+      }),
+      analysisRuns: {
+        listRuns: async () => [
+          {
+            id: 'run-fail',
+            status: 'failed',
+            errorMessage: 'Embedding cache write failed',
+            updatedAt: '2026-07-04T12:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: jobMarketLab.console.heading }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: jobMarketLab.console.runsHeading }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('run-fail')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${jobMarketLab.console.failureReasonLabel}: Embedding cache write failed`,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-console-section.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import Link from 'next/link';
+import { Container, Section, SectionHeader, Text } from '@/components/ui';
+import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
+import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-lab-corpus-admin';
+import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import type { ListAnalysisRunsDeps, StartJobMarketRecompute } from '@/lib/job-market-lab';
+
+export type JobMarketLabConsoleSectionProps = {
+  corpus?: AmplifyCorpusDeps;
+  analysisRuns?: ListAnalysisRunsDeps;
+  startRecompute?: StartJobMarketRecompute;
+};
+
+export function JobMarketLabConsoleSection({
+  corpus,
+  analysisRuns,
+  startRecompute,
+}: JobMarketLabConsoleSectionProps) {
+  const { session, isLoading } = useSiteAuth();
+
+  if (isLoading) {
+    return (
+      <Section className="py-20">
+        <Container>
+          <Text variant="muted">Checking session…</Text>
+        </Container>
+      </Section>
+    );
+  }
+
+  if (session === null || session.status !== 'authenticated') {
+    return (
+      <Section className="py-20">
+        <Container>
+          <div className="max-w-2xl space-y-4">
+            <SectionHeader animated={false}>
+              {jobMarketLab.console.unauthenticatedHeading}
+            </SectionHeader>
+            <Text variant="muted">
+              {jobMarketLab.console.unauthenticatedDescription}
+            </Text>
+            <Link
+              href="/login"
+              className="inline-flex font-body text-base text-[var(--foreground)] underline underline-offset-4"
+            >
+              {jobMarketLab.console.signInLabel}
+            </Link>
+          </div>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <Section className="py-20">
+      <Container>
+        <div className="mb-12 max-w-2xl space-y-4">
+          <SectionHeader animated={false}>{jobMarketLab.console.heading}</SectionHeader>
+          <Text variant="muted">{jobMarketLab.console.description}</Text>
+        </div>
+
+        <JobMarketLabAdminSection startRecompute={startRecompute} />
+        <JobMarketLabCorpusAdmin corpus={corpus} />
+        <JobMarketLabRunsPanel analysisRuns={analysisRuns} />
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-runs-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-runs-panel.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Heading, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import {
+  listAnalysisRuns,
+  type AnalysisRunRecord,
+  type AnalysisRunStatus,
+  type ListAnalysisRunsDeps,
+} from '@/lib/job-market-lab';
+import { createDefaultAmplifyAnalysisRunDeps } from '@/lib/job-market-analysis-runs-amplify';
+
+export type JobMarketLabRunsPanelProps = {
+  analysisRuns?: ListAnalysisRunsDeps;
+};
+
+function statusLabel(status: AnalysisRunStatus): string {
+  const copy = jobMarketLab.console;
+  switch (status) {
+    case 'queued':
+      return copy.runStatusQueued;
+    case 'running':
+      return copy.runStatusRunning;
+    case 'succeeded':
+      return copy.runStatusSucceeded;
+    case 'failed':
+      return copy.runStatusFailed;
+  }
+}
+
+export function JobMarketLabRunsPanel({ analysisRuns }: JobMarketLabRunsPanelProps) {
+  const [runs, setRuns] = useState<AnalysisRunRecord[] | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const deps = analysisRuns ?? (await createDefaultAmplifyAnalysisRunDeps());
+        const next = await listAnalysisRuns(deps);
+        if (!cancelled) {
+          setRuns(next);
+          setError(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setRuns(null);
+          setError(true);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [analysisRuns]);
+
+  return (
+    <div className="mt-16 max-w-2xl space-y-6 border-t border-[var(--border)] pt-12">
+      <div className="space-y-3">
+        <SectionHeader as="h2" size="md" animated={false} showLeftAccent={false}>
+          {jobMarketLab.console.runsHeading}
+        </SectionHeader>
+        <Text variant="muted">{jobMarketLab.console.runsDescription}</Text>
+      </div>
+
+      {error ? (
+        <p role="alert" className="font-body text-base text-[var(--foreground)]">
+          {jobMarketLab.console.runsError}
+        </p>
+      ) : null}
+
+      {!error && runs === null ? (
+        <Text variant="muted">{jobMarketLab.console.runsLoading}</Text>
+      ) : null}
+
+      {!error && runs !== null && runs.length === 0 ? (
+        <Text variant="muted">{jobMarketLab.console.runsEmpty}</Text>
+      ) : null}
+
+      {!error && runs !== null && runs.length > 0 ? (
+        <ul className="space-y-4">
+          {runs.map((run) => (
+            <li key={run.id} className="space-y-1 border-b border-[var(--border)] pb-4 last:border-b-0">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <Heading as="h3" size="sm">
+                  {run.id}
+                </Heading>
+                <Text size="sm">{statusLabel(run.status)}</Text>
+              </div>
+              {run.status === 'failed' && run.errorMessage ? (
+                <Text size="sm" variant="muted">
+                  {jobMarketLab.console.failureReasonLabel}: {run.errorMessage}
+                </Text>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -75,6 +75,29 @@ describe('JobMarketLabSection', () => {
       screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(jobMarketLab.corpusAdmin.heading)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: jobMarketLab.console.openConsoleLabel }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('never embeds owner management panels even for signed-in owners', async () => {
+    renderLab(
+      published,
+      createMemorySiteAuth({
+        status: 'authenticated',
+        email: 'owner@example.com',
+      }),
+    );
+
+    expect(
+      await screen.findByRole('link', { name: jobMarketLab.console.openConsoleLabel }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
+    ).not.toBeInTheDocument();
   });
 
   it('still shows the empty state when nothing is published', () => {

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -1,8 +1,7 @@
 'use client';
 
+import Link from 'next/link';
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
-import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
-import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-lab-corpus-admin';
 import { jobMarketLab } from '@/data';
 import type {
   JobMarketSnapshot,
@@ -10,13 +9,12 @@ import type {
   SkillFrequency,
   TaxonomyBucket,
 } from '@/lib/job-market-lab';
-import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import { useSiteAuth } from '@/hooks/use-site-auth';
 import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 import { cn } from '@/lib/utils';
 
 interface JobMarketLabSectionProps {
   publication: PublishedJobMarketResult;
-  corpus?: AmplifyCorpusDeps;
 }
 
 function formatPublishedAt(iso: string): string {
@@ -202,7 +200,11 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
   );
 }
 
-export function JobMarketLabSection({ publication, corpus }: JobMarketLabSectionProps) {
+export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
+  const { session, isLoading } = useSiteAuth();
+  const showConsoleLink =
+    !isLoading && session !== null && session.status === 'authenticated';
+
   return (
     <Section className="py-20">
       <Container>
@@ -212,6 +214,14 @@ export function JobMarketLabSection({ publication, corpus }: JobMarketLabSection
           <Text size="sm" variant="muted">
             {jobMarketLab.corpusNote}
           </Text>
+          {showConsoleLink ? (
+            <Link
+              href="/labs/job-market/console"
+              className="inline-flex font-body text-sm text-[var(--foreground)] underline underline-offset-4"
+            >
+              {jobMarketLab.console.openConsoleLabel}
+            </Link>
+          ) : null}
         </div>
 
         {publication.status === 'empty' ? (
@@ -221,9 +231,6 @@ export function JobMarketLabSection({ publication, corpus }: JobMarketLabSection
         ) : (
           <PublishedDashboard snapshot={publication.snapshot} />
         )}
-
-        <JobMarketLabAdminSection />
-        <JobMarketLabCorpusAdmin corpus={corpus} />
       </Container>
     </Section>
   );

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -16,7 +16,7 @@
     "description": "Start an analysis run against the active corpus. Only one run may be queued or in progress at a time.",
     "startButtonLabel": "Start recompute",
     "startingLabel": "Starting…",
-    "startedMessage": "Recompute started. Run id: {runId}. Status: queued.",
+    "startedMessage": "Recompute started. Run id: {runId}. Check analysis runs below for live status.",
     "rejectedHeading": "Could not start recompute"
   },
   "corpusAdmin": {
@@ -30,5 +30,23 @@
     "loadingLabel": "Loading corpus…",
     "untitledLabel": "Untitled document",
     "errorLabel": "Corpus management is temporarily unavailable."
+  },
+  "console": {
+    "heading": "Job market owner console",
+    "description": "Manage the private corpus, start recomputes, and review analysis run history. Guests cannot access this console.",
+    "unauthenticatedHeading": "Owner sign-in required",
+    "unauthenticatedDescription": "Sign in to open the job market owner console.",
+    "signInLabel": "Sign in",
+    "openConsoleLabel": "Open owner console",
+    "runsHeading": "Analysis runs",
+    "runsDescription": "Recent recompute lifecycle status. Failed runs include the failure reason.",
+    "runsEmpty": "No analysis runs yet.",
+    "runsLoading": "Loading analysis runs…",
+    "runsError": "Analysis run history is temporarily unavailable.",
+    "runStatusQueued": "Queued",
+    "runStatusRunning": "Running",
+    "runStatusSucceeded": "Succeeded",
+    "runStatusFailed": "Failed",
+    "failureReasonLabel": "Failure reason"
   }
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -162,6 +162,25 @@ export interface JobMarketLabCorpusAdminData {
   errorLabel: string;
 }
 
+export interface JobMarketLabConsoleCopy {
+  heading: string;
+  description: string;
+  unauthenticatedHeading: string;
+  unauthenticatedDescription: string;
+  signInLabel: string;
+  openConsoleLabel: string;
+  runsHeading: string;
+  runsDescription: string;
+  runsEmpty: string;
+  runsLoading: string;
+  runsError: string;
+  runStatusQueued: string;
+  runStatusRunning: string;
+  runStatusSucceeded: string;
+  runStatusFailed: string;
+  failureReasonLabel: string;
+}
+
 export interface JobMarketLabPageData {
   heading: string;
   description: string;
@@ -177,6 +196,7 @@ export interface JobMarketLabPageData {
   clustersHeading: string;
   admin: JobMarketLabAdminCopy;
   corpusAdmin: JobMarketLabCorpusAdminData;
+  console: JobMarketLabConsoleCopy;
 }
 
 export interface LoginPageErrors {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -161,6 +161,23 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(corpusAdmin, 'loadingLabel', 'jobMarketLab.corpusAdmin');
   requireString(corpusAdmin, 'untitledLabel', 'jobMarketLab.corpusAdmin');
   requireString(corpusAdmin, 'errorLabel', 'jobMarketLab.corpusAdmin');
+  const consoleCopy = requireRecord(page.console, 'jobMarketLab.console');
+  requireString(consoleCopy, 'heading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'description', 'jobMarketLab.console');
+  requireString(consoleCopy, 'unauthenticatedHeading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'unauthenticatedDescription', 'jobMarketLab.console');
+  requireString(consoleCopy, 'signInLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'openConsoleLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsHeading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsDescription', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsEmpty', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsLoading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsError', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runStatusQueued', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runStatusRunning', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runStatusSucceeded', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runStatusFailed', 'jobMarketLab.console');
+  requireString(consoleCopy, 'failureReasonLabel', 'jobMarketLab.console');
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/lib/job-market-analysis-runs-amplify.test.ts
+++ b/src/lib/job-market-analysis-runs-amplify.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAmplifyAnalysisRunDeps,
+  type AmplifyAnalysisRunModelClient,
+  type AmplifyAnalysisRunRow,
+} from './job-market-analysis-runs-amplify';
+import { getAnalysisRun, listAnalysisRuns } from './job-market-analysis-runs';
+
+function createMemoryClient(
+  rows: AmplifyAnalysisRunRow[],
+): AmplifyAnalysisRunModelClient {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return {
+    async get({ id }) {
+      return { data: byId.get(id) ?? null };
+    },
+    async list() {
+      return { data: [...byId.values()] };
+    },
+  };
+}
+
+describe('createAmplifyAnalysisRunDeps', () => {
+  it('lists and loads analysis runs through the Amplify model client seam', async () => {
+    const deps = createAmplifyAnalysisRunDeps(
+      createMemoryClient([
+        {
+          id: 'run-1',
+          status: 'failed',
+          errorMessage: 'Worker timed out',
+          createdAt: '2026-07-04T09:00:00.000Z',
+          updatedAt: '2026-07-04T09:10:00.000Z',
+        },
+      ]),
+    );
+
+    const listed = await listAnalysisRuns(deps);
+    expect(listed).toEqual([
+      {
+        id: 'run-1',
+        status: 'failed',
+        errorMessage: 'Worker timed out',
+        createdAt: '2026-07-04T09:00:00.000Z',
+        updatedAt: '2026-07-04T09:10:00.000Z',
+        docsConsidered: undefined,
+        docsEmbedded: undefined,
+        docsCacheHit: undefined,
+        clusterCount: undefined,
+        bedrockInputTokens: undefined,
+        estimatedCostUsd: undefined,
+      },
+    ]);
+
+    const single = await getAnalysisRun('run-1', deps);
+    expect(single?.errorMessage).toBe('Worker timed out');
+  });
+});

--- a/src/lib/job-market-analysis-runs-amplify.ts
+++ b/src/lib/job-market-analysis-runs-amplify.ts
@@ -1,0 +1,81 @@
+import type {
+  AnalysisRunRecord,
+  AnalysisRunStatus,
+  GetAnalysisRunDeps,
+  ListAnalysisRunsDeps,
+} from './job-market-analysis-runs';
+
+export type AmplifyAnalysisRunRow = {
+  id: string;
+  status: AnalysisRunStatus;
+  errorMessage?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  docsConsidered?: number | null;
+  docsEmbedded?: number | null;
+  docsCacheHit?: number | null;
+  clusterCount?: number | null;
+  bedrockInputTokens?: number | null;
+  estimatedCostUsd?: number | null;
+};
+
+type AmplifyDataResult<T> = {
+  data: T;
+  errors?: Array<{ message: string }> | null;
+};
+
+export type AmplifyAnalysisRunModelClient = {
+  get: (input: { id: string }) => Promise<AmplifyDataResult<AmplifyAnalysisRunRow | null>>;
+  list: () => Promise<AmplifyDataResult<AmplifyAnalysisRunRow[] | null>>;
+};
+
+function throwIfErrors(errors: Array<{ message: string }> | null | undefined): void {
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+function toAnalysisRunRecord(row: AmplifyAnalysisRunRow): AnalysisRunRecord {
+  return {
+    id: row.id,
+    status: row.status,
+    errorMessage: row.errorMessage ?? undefined,
+    createdAt: row.createdAt ?? undefined,
+    updatedAt: row.updatedAt ?? undefined,
+    docsConsidered: row.docsConsidered ?? undefined,
+    docsEmbedded: row.docsEmbedded ?? undefined,
+    docsCacheHit: row.docsCacheHit ?? undefined,
+    clusterCount: row.clusterCount ?? undefined,
+    bedrockInputTokens: row.bedrockInputTokens ?? undefined,
+    estimatedCostUsd: row.estimatedCostUsd ?? undefined,
+  };
+}
+
+export function createAmplifyAnalysisRunDeps(
+  client: AmplifyAnalysisRunModelClient,
+): ListAnalysisRunsDeps & GetAnalysisRunDeps {
+  return {
+    async listRuns() {
+      const { data, errors } = await client.list();
+      throwIfErrors(errors);
+      return (data ?? []).map(toAnalysisRunRecord);
+    },
+    async getRun(id) {
+      const { data, errors } = await client.get({ id });
+      throwIfErrors(errors);
+      return data ? toAnalysisRunRecord(data) : null;
+    },
+  };
+}
+
+export async function createDefaultAmplifyAnalysisRunDeps(): Promise<
+  ListAnalysisRunsDeps & GetAnalysisRunDeps
+> {
+  const { generateClient } = await import('aws-amplify/data');
+  const client = generateClient({ authMode: 'userPool' }) as {
+    models: {
+      AnalysisRun: AmplifyAnalysisRunModelClient;
+    };
+  };
+  return createAmplifyAnalysisRunDeps(client.models.AnalysisRun);
+}

--- a/src/lib/job-market-analysis-runs.test.ts
+++ b/src/lib/job-market-analysis-runs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getAnalysisRun,
+  listAnalysisRuns,
+  type AnalysisRunRecord,
+} from './job-market-analysis-runs';
+
+describe('listAnalysisRuns', () => {
+  it('returns recent analysis runs with failure reasons for failed runs', async () => {
+    const runs: AnalysisRunRecord[] = [
+      {
+        id: 'run-old',
+        status: 'succeeded',
+        createdAt: '2026-07-01T10:00:00.000Z',
+        updatedAt: '2026-07-01T10:05:00.000Z',
+      },
+      {
+        id: 'run-failed',
+        status: 'failed',
+        errorMessage: 'Bedrock quota exceeded',
+        createdAt: '2026-07-02T10:00:00.000Z',
+        updatedAt: '2026-07-02T10:01:00.000Z',
+      },
+      {
+        id: 'run-current',
+        status: 'running',
+        createdAt: '2026-07-03T10:00:00.000Z',
+        updatedAt: '2026-07-03T10:00:30.000Z',
+      },
+    ];
+
+    const result = await listAnalysisRuns({
+      listRuns: async () => runs,
+    });
+
+    expect(result.map((run) => run.id)).toEqual([
+      'run-current',
+      'run-failed',
+      'run-old',
+    ]);
+    expect(result[1]).toMatchObject({
+      id: 'run-failed',
+      status: 'failed',
+      errorMessage: 'Bedrock quota exceeded',
+    });
+  });
+});
+
+describe('getAnalysisRun', () => {
+  it('returns a single run by id through the injected seam', async () => {
+    const run: AnalysisRunRecord = {
+      id: 'run-42',
+      status: 'queued',
+      createdAt: '2026-07-03T12:00:00.000Z',
+    };
+
+    const result = await getAnalysisRun('run-42', {
+      getRun: async (id) => (id === 'run-42' ? run : null),
+    });
+
+    expect(result).toEqual(run);
+  });
+
+  it('returns null when the run is missing', async () => {
+    const result = await getAnalysisRun('missing', {
+      getRun: async () => null,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/job-market-analysis-runs.ts
+++ b/src/lib/job-market-analysis-runs.ts
@@ -1,0 +1,43 @@
+export type AnalysisRunStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export type AnalysisRunRecord = {
+  id: string;
+  status: AnalysisRunStatus;
+  errorMessage?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  docsConsidered?: number;
+  docsEmbedded?: number;
+  docsCacheHit?: number;
+  clusterCount?: number;
+  bedrockInputTokens?: number;
+  estimatedCostUsd?: number;
+};
+
+export type ListAnalysisRunsDeps = {
+  listRuns: () => Promise<AnalysisRunRecord[]>;
+};
+
+export type GetAnalysisRunDeps = {
+  getRun: (id: string) => Promise<AnalysisRunRecord | null>;
+};
+
+function byRecency(a: AnalysisRunRecord, b: AnalysisRunRecord): number {
+  const aKey = a.updatedAt ?? a.createdAt ?? '';
+  const bKey = b.updatedAt ?? b.createdAt ?? '';
+  return bKey.localeCompare(aKey);
+}
+
+export async function listAnalysisRuns(
+  deps: ListAnalysisRunsDeps,
+): Promise<AnalysisRunRecord[]> {
+  const runs = await deps.listRuns();
+  return [...runs].sort(byRecency);
+}
+
+export async function getAnalysisRun(
+  id: string,
+  deps: GetAnalysisRunDeps,
+): Promise<AnalysisRunRecord | null> {
+  return deps.getRun(id);
+}

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -77,6 +77,21 @@ export {
   type AmplifyCorpusDeps,
 } from './job-market-corpus-amplify';
 
+export {
+  listAnalysisRuns,
+  getAnalysisRun,
+  type AnalysisRunRecord,
+  type AnalysisRunStatus,
+  type ListAnalysisRunsDeps,
+  type GetAnalysisRunDeps,
+} from './job-market-analysis-runs';
+
+export {
+  createAmplifyAnalysisRunDeps,
+  createDefaultAmplifyAnalysisRunDeps,
+  type AmplifyAnalysisRunModelClient,
+} from './job-market-analysis-runs-amplify';
+
 function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
   return {
     documentCount: snapshot.documentCount,


### PR DESCRIPTION
## Summary
- Adds auth-gated `/labs/job-market/console` for corpus management, recompute, and analysis run history with failure reasons
- Removes owner management chrome from the public lab page; signed-in owners get a console link only
- Extends the job-market facade with injectable `listAnalysisRuns` / `getAnalysisRun` Amplify seams covered by Vitest

Closes #65

## Test plan
- [ ] `npm test -- src/lib/job-market-analysis-runs.test.ts src/lib/job-market-analysis-runs-amplify.test.ts src/components/sections/labs/job-market-lab-console-section.test.tsx src/components/sections/labs/job-market-lab-section.test.tsx`
- [ ] Unauthenticated visit to `/labs/job-market/console` shows sign-in prompt only
- [ ] Authenticated owner sees recompute, corpus admin, and run history
- [ ] Public `/labs/job-market` shows no archive/recompute panels

Made with [Cursor](https://cursor.com)