### PR TITLE
Technology ontology in the analyse pipeline

### DIFF
--- a/amplify/functions/job-market-analyse/analyse.test.ts
+++ b/amplify/functions/job-market-analyse/analyse.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_SKILLS,
   type AnalyzableDocument,
 } from './analyse';
+import { matchTechnologiesInDocuments } from './technology-ontology';
 
 const docs: AnalyzableDocument[] = [
   {
@@ -32,6 +33,51 @@ const docs: AnalyzableDocument[] = [
     roleFamily: 'data-science',
   },
 ];
+
+describe('matchTechnologiesInDocuments', () => {
+  it('matches canonical technology names and aliases once per document', () => {
+    const documents = [
+      { markdown: 'We need Python, SQL, and teamwork.' },
+      { markdown: 'Looking for py, Snowflake, and k8s experience.' },
+      { markdown: 'We need Python, SQL, and teamwork.' },
+    ];
+
+    expect(matchTechnologiesInDocuments(documents)).toEqual([
+      { name: 'python', count: 2 },
+      { name: 'sql', count: 2 },
+      { name: 'kubernetes', count: 1 },
+      { name: 'snowflake', count: 1 },
+    ]);
+  });
+});
+
+describe('analyseCorpus technologies pulse', () => {
+  it('publishes curated technologies instead of bag-of-words tokens', async () => {
+    const result = await analyseCorpus(docs, {
+      embed: async () => ({
+        vector: [0.1, 0.2, 0.3, 0.4],
+        inputTokens: 4,
+        estimatedCostUsd: 0.0001,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.snapshot.technologies).toEqual([
+      { name: 'python', count: 3 },
+      { name: 'sql', count: 2 },
+      { name: 'tableau', count: 1 },
+    ]);
+    expect(result.snapshot.skills).toEqual(result.snapshot.technologies);
+    expect(result.snapshot.technologies.map((item) => item.name)).not.toContain(
+      'teamwork',
+    );
+    expect(result.snapshot.technologies.map((item) => item.name)).not.toContain(
+      'communication',
+    );
+  });
+});
 
 describe('analyseCorpus', () => {
   it('publishes a snapshot within caps and accounts for embedding cache hits', async () => {

--- a/amplify/functions/job-market-analyse/analyse.ts
+++ b/amplify/functions/job-market-analyse/analyse.ts
@@ -1,3 +1,8 @@
+import {
+  matchTechnologiesInDocuments,
+  type TechnologyFrequency,
+} from './technology-ontology';
+
 export const MAX_SKILLS = 40;
 export const MAX_PROJECTION_POINTS = 200;
 export const MAX_CLUSTER_K = 12;
@@ -11,10 +16,7 @@ export type AnalyzableDocument = {
   title?: string;
 };
 
-export type SkillFrequency = {
-  name: string;
-  count: number;
-};
+export type SkillFrequency = TechnologyFrequency;
 
 export type TaxonomyBucket = {
   name: string;
@@ -36,6 +38,7 @@ export type ProjectionPoint = {
 export type CorpusSnapshotPayload = {
   documentCount: number;
   publishedAt: string;
+  technologies: SkillFrequency[];
   skills: SkillFrequency[];
   seniority: TaxonomyBucket[];
   roleFamily: TaxonomyBucket[];
@@ -76,61 +79,6 @@ export type AnalyseCorpusResult = {
   snapshot: CorpusSnapshotPayload;
   metrics: AnalysisMetrics;
 };
-
-const STOPWORDS = new Set([
-  'a',
-  'an',
-  'and',
-  'are',
-  'as',
-  'at',
-  'be',
-  'by',
-  'for',
-  'from',
-  'in',
-  'is',
-  'it',
-  'of',
-  'on',
-  'or',
-  'the',
-  'to',
-  'we',
-  'with',
-  'you',
-  'your',
-  'need',
-  'looking',
-  'role',
-  'skills',
-]);
-
-export function extractSkillFrequencies(
-  documents: AnalyzableDocument[],
-  maxSkills: number = MAX_SKILLS,
-): SkillFrequency[] {
-  const counts = new Map<string, number>();
-
-  for (const document of documents) {
-    const tokens = document.markdown
-      .toLowerCase()
-      .match(/[a-z][a-z0-9+.#-]{1,}/g) ?? [];
-    const seen = new Set<string>();
-    for (const token of tokens) {
-      if (STOPWORDS.has(token) || seen.has(token)) {
-        continue;
-      }
-      seen.add(token);
-      counts.set(token, (counts.get(token) ?? 0) + 1);
-    }
-  }
-
-  return [...counts.entries()]
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
-    .slice(0, maxSkills);
-}
 
 function taxonomyBreakdown(
   documents: AnalyzableDocument[],
@@ -275,11 +223,16 @@ export async function analyseCorpus(
     clusterId: assignments[index] ?? 0,
   }));
 
+  const technologies = matchTechnologiesInDocuments(documents, {
+    maxTechnologies: maxSkills,
+  });
+
   return {
     snapshot: {
       documentCount: documents.length,
       publishedAt: now.toISOString(),
-      skills: extractSkillFrequencies(documents, maxSkills),
+      technologies,
+      skills: technologies,
       seniority: taxonomyBreakdown(documents, 'seniority'),
       roleFamily: taxonomyBreakdown(documents, 'roleFamily'),
       clusters,

--- a/amplify/functions/job-market-analyse/technology-ontology.ts
+++ b/amplify/functions/job-market-analyse/technology-ontology.ts
@@ -1,0 +1,149 @@
+export const MAX_TECHNOLOGIES = 40;
+
+export type TechnologyFrequency = {
+  name: string;
+  count: number;
+};
+
+export type TechnologyEntry = {
+  canonical: string;
+  aliases: string[];
+};
+
+export type MatchTechnologiesOptions = {
+  maxTechnologies?: number;
+  dictionary?: TechnologyEntry[];
+};
+
+export const FINSERV_AI_TECHNOLOGY_DICTIONARY: TechnologyEntry[] = [
+  { canonical: 'python', aliases: ['python'] },
+  { canonical: 'pandas', aliases: ['pandas'] },
+  { canonical: 'pytorch', aliases: ['pytorch', 'torch'] },
+  { canonical: 'bedrock', aliases: ['bedrock', 'amazon bedrock', 'aws bedrock'] },
+  {
+    canonical: 'sagemaker',
+    aliases: ['sagemaker', 'amazon sagemaker', 'aws sagemaker'],
+  },
+  { canonical: 'sql', aliases: ['sql'] },
+  { canonical: 'snowflake', aliases: ['snowflake'] },
+  { canonical: 'dbt', aliases: ['dbt'] },
+  { canonical: 'spark', aliases: ['spark', 'apache spark', 'pyspark'] },
+  { canonical: 'kafka', aliases: ['kafka', 'apache kafka'] },
+  { canonical: 'terraform', aliases: ['terraform'] },
+  { canonical: 'kubernetes', aliases: ['kubernetes', 'k8s'] },
+  {
+    canonical: 'kubernetes aks',
+    aliases: ['kubernetes aks', 'azure kubernetes service', 'aks'],
+  },
+  { canonical: 'docker', aliases: ['docker'] },
+  { canonical: 'langchain', aliases: ['langchain'] },
+  {
+    canonical: 'rag',
+    aliases: [
+      'rag',
+      'retrieval-augmented generation',
+      'retrieval augmented generation',
+    ],
+  },
+  { canonical: 'tableau', aliases: ['tableau'] },
+  { canonical: 'power bi', aliases: ['power bi', 'powerbi'] },
+  { canonical: 'databricks', aliases: ['databricks'] },
+  { canonical: 'airflow', aliases: ['airflow', 'apache airflow'] },
+  { canonical: 'looker', aliases: ['looker'] },
+  { canonical: 'scikit-learn', aliases: ['scikit-learn', 'sklearn'] },
+  { canonical: 'huggingface', aliases: ['huggingface', 'hugging face'] },
+  { canonical: 'openai', aliases: ['openai', 'gpt-4', 'gpt-3'] },
+  { canonical: 'anthropic', aliases: ['anthropic', 'claude'] },
+  { canonical: 'vector database', aliases: ['vector database', 'vector db'] },
+  { canonical: 'pinecone', aliases: ['pinecone'] },
+  { canonical: 'postgresql', aliases: ['postgresql', 'postgres'] },
+  { canonical: 'redis', aliases: ['redis'] },
+  { canonical: 'aws', aliases: ['aws', 'amazon web services'] },
+  { canonical: 'azure', aliases: ['azure', 'microsoft azure'] },
+  { canonical: 'gcp', aliases: ['gcp', 'google cloud platform'] },
+];
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+type AliasPattern = {
+  canonical: string;
+  alias: string;
+};
+
+function buildAliasPatterns(dictionary: TechnologyEntry[]): AliasPattern[] {
+  return dictionary
+    .flatMap((entry) =>
+      entry.aliases.map((alias) => ({
+        canonical: entry.canonical,
+        alias,
+      })),
+    )
+    .sort((a, b) => b.alias.length - a.alias.length);
+}
+
+function aliasPattern(alias: string): RegExp {
+  if (alias.includes(' ')) {
+    return new RegExp(escapeRegex(alias), 'i');
+  }
+  return new RegExp(`\\b${escapeRegex(alias)}\\b`, 'i');
+}
+
+function findNonOverlappingMatches(
+  text: string,
+  patterns: AliasPattern[],
+): Set<string> {
+  const matchedCanonicals = new Set<string>();
+  const matchedRanges: Array<{ start: number; end: number }> = [];
+
+  for (const { canonical, alias } of patterns) {
+    if (matchedCanonicals.has(canonical)) {
+      continue;
+    }
+
+    const pattern = aliasPattern(alias);
+    const match = pattern.exec(text);
+    if (!match || match.index === undefined) {
+      continue;
+    }
+
+    const start = match.index;
+    const end = start + match[0].length;
+    const overlaps = matchedRanges.some(
+      (range) => start < range.end && end > range.start,
+    );
+    if (overlaps) {
+      continue;
+    }
+
+    matchedCanonicals.add(canonical);
+    matchedRanges.push({ start, end });
+  }
+
+  return matchedCanonicals;
+}
+
+export function matchTechnologiesInDocuments(
+  documents: Array<{ markdown: string }>,
+  options: MatchTechnologiesOptions = {},
+): TechnologyFrequency[] {
+  const dictionary = options.dictionary ?? FINSERV_AI_TECHNOLOGY_DICTIONARY;
+  const maxTechnologies = options.maxTechnologies ?? MAX_TECHNOLOGIES;
+  const patterns = buildAliasPatterns(dictionary);
+  const counts = new Map<string, number>();
+
+  for (const document of documents) {
+    const normalised = document.markdown.toLowerCase();
+    const matched = findNonOverlappingMatches(normalised, patterns);
+
+    for (const canonical of matched) {
+      counts.set(canonical, (counts.get(canonical) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, maxTechnologies);
+}

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -30,6 +30,10 @@ const published: PublishedJobMarketResult = {
       { name: 'python', count: 9 },
       { name: 'sql', count: 7 },
     ],
+    technologies: [
+      { name: 'python', count: 9 },
+      { name: 'sql', count: 7 },
+    ],
     seniority: [
       { name: 'senior', count: 8 },
       { name: 'mid', count: 4 },

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -127,9 +127,10 @@ function ClusterProjection({ snapshot }: { snapshot: JobMarketSnapshot }) {
 }
 
 function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
-  const skillsId = 'job-market-skills-heading';
+  const technologiesId = 'job-market-technologies-heading';
   const taxonomyId = 'job-market-taxonomy-heading';
   const clustersId = 'job-market-clusters-heading';
+  const technologyPulse = snapshot.technologies ?? snapshot.skills;
 
   return (
     <div className="space-y-14">
@@ -157,11 +158,11 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
         </div>
       </section>
 
-      <section className="space-y-4" aria-labelledby={skillsId}>
-        <SectionHeader id={skillsId} as="h2" size="md" animated={false} showLeftAccent={false}>
+      <section className="space-y-4" aria-labelledby={technologiesId}>
+        <SectionHeader id={technologiesId} as="h2" size="md" animated={false} showLeftAccent={false}>
           {jobMarketLab.skillsHeading}
         </SectionHeader>
-        <FrequencyBars items={snapshot.skills.slice(0, 40)} labelledBy={skillsId} />
+        <FrequencyBars items={technologyPulse.slice(0, 40)} labelledBy={technologiesId} />
       </section>
 
       <section className="space-y-6" aria-labelledby={taxonomyId}>

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -6,7 +6,7 @@
   "metricsHeading": "Corpus freshness",
   "documentCountLabel": "Active documents in latest snapshot",
   "publishedAtLabel": "Last published",
-  "skillsHeading": "Skill and tool frequencies",
+  "skillsHeading": "Technology frequencies",
   "taxonomyHeading": "Seniority and role family",
   "seniorityLabel": "Seniority",
   "roleFamilyLabel": "Role family",

--- a/src/lib/fetch-published-job-market-snapshot.test.ts
+++ b/src/lib/fetch-published-job-market-snapshot.test.ts
@@ -55,6 +55,7 @@ describe('fetchPublishedSnapshotViaQuery', () => {
       snapshot: {
         documentCount: 2,
         publishedAt: '2026-07-14T12:00:00.000Z',
+        technologies: [{ name: 'python', count: 2 }],
         skills: [{ name: 'python', count: 2 }],
         seniority: [{ name: 'senior', count: 1 }],
         roleFamily: [{ name: 'engineering', count: 2 }],

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -17,6 +17,7 @@ describe('getPublishedJobMarketSnapshot', () => {
     const snapshot = {
       documentCount: 3,
       publishedAt: '2026-07-01T00:00:00.000Z',
+      technologies: [{ name: 'python', count: 3 }],
       skills: [{ name: 'python', count: 3 }],
       seniority: [{ name: 'senior', count: 2 }],
       roleFamily: [{ name: 'data-science', count: 2 }],
@@ -29,6 +30,34 @@ describe('getPublishedJobMarketSnapshot', () => {
     });
 
     expect(result).toEqual({ status: 'published', snapshot });
+  });
+
+  it('maps legacy skills-only snapshots onto the technologies pulse', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () => ({
+        documentCount: 2,
+        publishedAt: '2026-07-01T00:00:00.000Z',
+        skills: [{ name: 'sql', count: 2 }],
+        seniority: [],
+        roleFamily: [],
+        clusters: [],
+        projection: [],
+      }),
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      snapshot: {
+        documentCount: 2,
+        publishedAt: '2026-07-01T00:00:00.000Z',
+        technologies: [{ name: 'sql', count: 2 }],
+        skills: [{ name: 'sql', count: 2 }],
+        seniority: [],
+        roleFamily: [],
+        clusters: [],
+        projection: [],
+      },
+    });
   });
 
   it('does not expose raw job description or employer identity fields', async () => {
@@ -53,6 +82,7 @@ describe('getPublishedJobMarketSnapshot', () => {
       snapshot: {
         documentCount: 1,
         publishedAt: '2026-07-01T00:00:00.000Z',
+        technologies: [],
         skills: [],
         seniority: [],
         roleFamily: [],

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -34,6 +34,7 @@ export type ProjectionPoint = {
 export type JobMarketSnapshot = {
   documentCount: number;
   publishedAt: string;
+  technologies?: SkillFrequency[];
   skills: SkillFrequency[];
   seniority: TaxonomyBucket[];
   roleFamily: TaxonomyBucket[];
@@ -93,10 +94,12 @@ export {
 } from './job-market-analysis-runs-amplify';
 
 function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
+  const technologies = snapshot.technologies ?? snapshot.skills ?? [];
   return {
     documentCount: snapshot.documentCount,
     publishedAt: snapshot.publishedAt,
-    skills: snapshot.skills ?? [],
+    technologies,
+    skills: technologies,
     seniority: snapshot.seniority ?? [],
     roleFamily: snapshot.roleFamily ?? [],
     clusters: snapshot.clusters ?? [],


### PR DESCRIPTION
## Summary

- Replace bag-of-words token extraction with a FinServ/AI technology dictionary and alias matcher on the analyse recompute path (no new LLM calls).
- Published snapshots now include a curated `technologies` pulse; `skills` is populated with the same values for backward compatibility.
- Guest lab UI and snapshot sanitisation prefer `technologies` while mapping legacy skills-only payloads; public heading copy updated to "Technology frequencies".

Closes #66

## Test plan

- [x] `npm test -- amplify/functions/job-market-analyse/analyse.test.ts`
- [x] `npm test -- amplify/functions/job-market-analyse/run.test.ts`
- [x] `npm test -- src/lib/job-market-lab.test.ts src/lib/fetch-published-job-market-snapshot.test.ts src/components/sections/labs/job-market-lab-section.test.tsx`
- [ ] Manual: trigger a corpus recompute and confirm published charts show ontology terms (e.g. python, sql) rather than token noise (e.g. teamwork)
