### PR TITLE
Add owner console JD upload via job-market-lab facade

### DIFF
--- a/src/components/sections/labs/job-market-lab-console-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.test.tsx
@@ -83,6 +83,9 @@ describe('JobMarketLabConsoleSection', () => {
       screen.getByRole('heading', { name: jobMarketLab.admin.heading }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: jobMarketLab.upload.heading }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
     ).toBeInTheDocument();
     expect(

--- a/src/components/sections/labs/job-market-lab-console-section.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.tsx
@@ -5,6 +5,7 @@ import { Container, Section, SectionHeader, Text } from '@/components/ui';
 import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
 import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-lab-corpus-admin';
 import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
+import { JobMarketLabUploadPanel } from '@/components/sections/labs/job-market-lab-upload-panel';
 import { jobMarketLab } from '@/data';
 import { useSiteAuth } from '@/hooks/use-site-auth';
 import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
@@ -65,6 +66,7 @@ export function JobMarketLabConsoleSection({
         </div>
 
         <JobMarketLabAdminSection startRecompute={startRecompute} />
+        <JobMarketLabUploadPanel />
         <JobMarketLabCorpusAdmin corpus={corpus} />
         <JobMarketLabRunsPanel analysisRuns={analysisRuns} />
       </Container>

--- a/src/components/sections/labs/job-market-lab-upload-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-upload-panel.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JobMarketLabUploadPanel } from '@/components/sections/labs/job-market-lab-upload-panel';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+import type { UploadJobDescriptionDeps } from '@/lib/job-market-lab';
+
+afterEach(() => {
+  cleanup();
+});
+
+const validMarkdown = `---
+collectedAt: 2026-06-15T10:00:00.000Z
+title: Senior Data Scientist
+---
+
+# Senior Data Scientist
+`;
+
+function renderUpload(options?: {
+  auth?: ReturnType<typeof createMemorySiteAuth>;
+  upload?: (input: { fileName: string; body: string }, deps?: UploadJobDescriptionDeps) => Promise<
+    | { status: 'uploaded'; s3Key: string }
+    | { status: 'rejected'; reason: string }
+  >;
+}) {
+  const auth = options?.auth ?? createMemorySiteAuth();
+  const upload =
+    options?.upload ??
+    vi.fn(async () => ({
+      status: 'uploaded' as const,
+      s3Key: 'raw/senior-data-scientist.md',
+    }));
+
+  return {
+    upload,
+    ...render(
+      <SiteAuthProvider auth={auth}>
+        <JobMarketLabUploadPanel uploadJobDescription={upload} />
+      </SiteAuthProvider>,
+    ),
+  };
+}
+
+const ownerAuth = () =>
+  createMemorySiteAuth({ status: 'authenticated', email: 'owner@example.com' });
+
+describe('JobMarketLabUploadPanel', () => {
+  it('shows no upload controls to guests', async () => {
+    renderUpload({ auth: createMemorySiteAuth({ status: 'unauthenticated' }) });
+
+    expect(screen.queryByText(jobMarketLab.upload.heading)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: jobMarketLab.upload.uploadButtonLabel }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('surfaces frontmatter validation errors before calling upload', async () => {
+    const user = userEvent.setup();
+    const upload = vi.fn(async () => ({
+      status: 'uploaded' as const,
+      s3Key: 'raw/should-not-run.md',
+    }));
+    renderUpload({ auth: ownerAuth(), upload });
+
+    const file = new File(['# Role title\n\nBody copy.'], 'invalid.md', {
+      type: 'text/markdown',
+    });
+    const input = await screen.findByLabelText(jobMarketLab.upload.fileLabel);
+    await user.upload(input, file);
+    await user.click(
+      screen.getByRole('button', { name: jobMarketLab.upload.uploadButtonLabel }),
+    );
+
+    expect(
+      await screen.findByText(jobMarketLab.upload.rejectedHeading),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Missing YAML frontmatter')).toBeInTheDocument();
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('uploads valid markdown through the facade and shows the storage key', async () => {
+    const user = userEvent.setup();
+    const upload = vi.fn(async () => ({
+      status: 'uploaded' as const,
+      s3Key: 'raw/senior-data-scientist.md',
+    }));
+    renderUpload({ auth: ownerAuth(), upload });
+
+    const file = new File([validMarkdown], 'senior-data-scientist.md', {
+      type: 'text/markdown',
+    });
+    const input = await screen.findByLabelText(jobMarketLab.upload.fileLabel);
+    await user.upload(input, file);
+    await user.click(
+      screen.getByRole('button', { name: jobMarketLab.upload.uploadButtonLabel }),
+    );
+
+    await waitFor(() => {
+      expect(upload).toHaveBeenCalledOnce();
+    });
+    expect(upload).toHaveBeenCalledWith({
+      fileName: 'senior-data-scientist.md',
+      body: validMarkdown,
+    });
+    expect(
+      screen.getByText(
+        jobMarketLab.upload.uploadedMessage.replace(
+          '{s3Key}',
+          'raw/senior-data-scientist.md',
+        ),
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-upload-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-upload-panel.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Button, Heading, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import {
+  uploadJobDescription as defaultUploadJobDescription,
+  validateJobDescriptionMarkdown,
+  type UploadJobDescriptionResult,
+} from '@/lib/job-market-lab';
+
+export type UploadJobDescriptionFn = (
+  input: { fileName: string; body: string },
+) => Promise<UploadJobDescriptionResult>;
+
+export type JobMarketLabUploadPanelProps = {
+  uploadJobDescription?: UploadJobDescriptionFn;
+};
+
+async function readFileAsText(file: File): Promise<string> {
+  if (typeof file.text === 'function') {
+    return file.text();
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsText(file);
+  });
+}
+
+export function JobMarketLabUploadPanel({
+  uploadJobDescription = defaultUploadJobDescription,
+}: JobMarketLabUploadPanelProps) {
+  const { session, isLoading } = useSiteAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [result, setResult] = useState<UploadJobDescriptionResult | null>(null);
+
+  if (isLoading || session === null || session.status !== 'authenticated') {
+    return null;
+  }
+
+  async function handleUpload() {
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) {
+      setResult({ status: 'rejected', reason: jobMarketLab.upload.noFileSelected });
+      return;
+    }
+
+    setIsUploading(true);
+    setResult(null);
+
+    const body = await readFileAsText(file);
+    const validation = validateJobDescriptionMarkdown(body);
+    if (validation.status === 'rejected') {
+      setResult(validation);
+      setIsUploading(false);
+      return;
+    }
+
+    const next = await uploadJobDescription({
+      fileName: file.name,
+      body,
+    });
+
+    setResult(next);
+    setIsUploading(false);
+
+    if (next.status === 'uploaded' && fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <section className="mt-16 space-y-6" aria-labelledby="job-market-upload-heading">
+      <div className="max-w-2xl space-y-4">
+        <SectionHeader
+          id="job-market-upload-heading"
+          as="h2"
+          size="md"
+          animated={false}
+          showLeftAccent={false}
+        >
+          {jobMarketLab.upload.heading}
+        </SectionHeader>
+        <Text variant="muted">{jobMarketLab.upload.description}</Text>
+      </div>
+
+      <div className="max-w-2xl space-y-4">
+        <label className="block space-y-2" htmlFor="job-market-upload-file">
+          <Text size="sm">{jobMarketLab.upload.fileLabel}</Text>
+          <input
+            ref={fileInputRef}
+            id="job-market-upload-file"
+            type="file"
+            accept=".md,text/markdown"
+            className="block w-full font-body text-base text-[var(--foreground)]"
+          />
+        </label>
+
+        <Button
+          type="button"
+          onClick={() => void handleUpload()}
+          disabled={isUploading}
+        >
+          {isUploading
+            ? jobMarketLab.upload.uploadingLabel
+            : jobMarketLab.upload.uploadButtonLabel}
+        </Button>
+      </div>
+
+      {result?.status === 'uploaded' ? (
+        <p role="status" className="font-body text-base leading-relaxed text-[var(--foreground)]">
+          {jobMarketLab.upload.uploadedMessage.replace('{s3Key}', result.s3Key)}
+        </p>
+      ) : null}
+
+      {result?.status === 'rejected' ? (
+        <div role="alert" className="space-y-2">
+          <Heading as="h3" size="sm">
+            {jobMarketLab.upload.rejectedHeading}
+          </Heading>
+          <Text>{result.reason}</Text>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -31,6 +31,16 @@
     "untitledLabel": "Untitled document",
     "errorLabel": "Corpus management is temporarily unavailable."
   },
+  "upload": {
+    "heading": "Upload job description",
+    "description": "Add a markdown file with YAML frontmatter. Frontmatter must include a valid collectedAt timestamp. Upload writes to the private raw corpus; ingest runs automatically. Recompute is not started.",
+    "fileLabel": "Markdown file",
+    "uploadButtonLabel": "Upload to corpus",
+    "uploadingLabel": "Uploading…",
+    "uploadedMessage": "Uploaded to {s3Key}. Ingest will update corpus metadata shortly.",
+    "rejectedHeading": "Could not upload job description",
+    "noFileSelected": "Choose a markdown file to upload."
+  },
   "console": {
     "heading": "Job market owner console",
     "description": "Manage the private corpus, start recomputes, and review analysis run history. Guests cannot access this console.",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -162,6 +162,17 @@ export interface JobMarketLabCorpusAdminData {
   errorLabel: string;
 }
 
+export interface JobMarketLabUploadCopy {
+  heading: string;
+  description: string;
+  fileLabel: string;
+  uploadButtonLabel: string;
+  uploadingLabel: string;
+  uploadedMessage: string;
+  rejectedHeading: string;
+  noFileSelected: string;
+}
+
 export interface JobMarketLabConsoleCopy {
   heading: string;
   description: string;
@@ -196,6 +207,7 @@ export interface JobMarketLabPageData {
   clustersHeading: string;
   admin: JobMarketLabAdminCopy;
   corpusAdmin: JobMarketLabCorpusAdminData;
+  upload: JobMarketLabUploadCopy;
   console: JobMarketLabConsoleCopy;
 }
 

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -161,6 +161,15 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(corpusAdmin, 'loadingLabel', 'jobMarketLab.corpusAdmin');
   requireString(corpusAdmin, 'untitledLabel', 'jobMarketLab.corpusAdmin');
   requireString(corpusAdmin, 'errorLabel', 'jobMarketLab.corpusAdmin');
+  const upload = requireRecord(page.upload, 'jobMarketLab.upload');
+  requireString(upload, 'heading', 'jobMarketLab.upload');
+  requireString(upload, 'description', 'jobMarketLab.upload');
+  requireString(upload, 'fileLabel', 'jobMarketLab.upload');
+  requireString(upload, 'uploadButtonLabel', 'jobMarketLab.upload');
+  requireString(upload, 'uploadingLabel', 'jobMarketLab.upload');
+  requireString(upload, 'uploadedMessage', 'jobMarketLab.upload');
+  requireString(upload, 'rejectedHeading', 'jobMarketLab.upload');
+  requireString(upload, 'noFileSelected', 'jobMarketLab.upload');
   const consoleCopy = requireRecord(page.console, 'jobMarketLab.console');
   requireString(consoleCopy, 'heading', 'jobMarketLab.console');
   requireString(consoleCopy, 'description', 'jobMarketLab.console');

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   getPublishedJobMarketSnapshot,
   startJobMarketRecompute,
+  uploadJobDescription,
 } from './job-market-lab';
 
 describe('getPublishedJobMarketSnapshot', () => {
@@ -104,6 +105,104 @@ describe('startJobMarketRecompute', () => {
     expect(result).toEqual({
       status: 'rejected',
       reason: 'Recompute client is not configured',
+    });
+  });
+});
+
+describe('uploadJobDescription', () => {
+  it('rejects markdown without YAML frontmatter before storage write', async () => {
+    const putRawObject = vi.fn(async () => undefined);
+
+    const result = await uploadJobDescription(
+      { fileName: 'missing-frontmatter.md', body: '# Role title\n\nBody copy.' },
+      { putRawObject },
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Missing YAML frontmatter',
+    });
+    expect(putRawObject).not.toHaveBeenCalled();
+  });
+
+  it('rejects markdown with missing collectedAt before storage write', async () => {
+    const putRawObject = vi.fn(async () => undefined);
+
+    const result = await uploadJobDescription(
+      {
+        fileName: 'missing-collected-at.md',
+        body: '---\ntitle: Sample role\n---\n\nBody copy.',
+      },
+      { putRawObject },
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Frontmatter requires a valid collectedAt',
+    });
+    expect(putRawObject).not.toHaveBeenCalled();
+  });
+
+  it('uploads valid markdown to the raw/ prefix via injected storage', async () => {
+    const putRawObject = vi.fn(async () => undefined);
+    const body = `---
+collectedAt: 2026-06-15T10:00:00.000Z
+title: Senior Data Scientist
+---
+
+# Senior Data Scientist
+`;
+
+    const result = await uploadJobDescription(
+      { fileName: 'senior-data-scientist.md', body },
+      { putRawObject },
+    );
+
+    expect(result).toEqual({
+      status: 'uploaded',
+      s3Key: 'raw/senior-data-scientist.md',
+    });
+    expect(putRawObject).toHaveBeenCalledOnce();
+    expect(putRawObject).toHaveBeenCalledWith({
+      key: 'raw/senior-data-scientist.md',
+      body,
+    });
+  });
+
+  it('does not start corpus recompute on upload', async () => {
+    const putRawObject = vi.fn(async () => undefined);
+    const startRecompute = vi.fn(async () => ({ status: 'started', runId: 'run-1' }));
+    const body = `---
+collectedAt: 2026-06-15T10:00:00.000Z
+---
+
+# Role
+`;
+
+    const result = await uploadJobDescription(
+      { fileName: 'role.md', body },
+      { putRawObject },
+    );
+
+    expect(result.status).toBe('uploaded');
+    expect(putRawObject).toHaveBeenCalledOnce();
+    expect(startRecompute).not.toHaveBeenCalled();
+  });
+
+  it('rejects clearly from the default path when the upload client is not configured', async () => {
+    const result = await uploadJobDescription({
+      fileName: 'role.md',
+      body: `---
+collectedAt: 2026-06-15T10:00:00.000Z
+---
+
+# Role
+`,
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Upload client is not configured',
     });
   });
 });

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -152,3 +152,12 @@ export async function startJobMarketRecompute(
   const start = deps.startRecompute ?? defaultStartRecompute;
   return start();
 }
+
+export {
+  uploadJobDescription,
+  type UploadJobDescriptionResult,
+  type UploadJobDescriptionDeps,
+  type PutRawObject,
+} from './upload-job-description';
+
+export { validateJobDescriptionMarkdown } from './validate-job-description-markdown';

--- a/src/lib/upload-job-description-client.test.ts
+++ b/src/lib/upload-job-description-client.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDefaultPutRawObject,
+  putRawObjectViaUploadData,
+  putRawObjectWithAuthHandling,
+} from './upload-job-description-client';
+
+describe('putRawObjectViaUploadData', () => {
+  it('writes markdown to the given raw key via Amplify uploadData', async () => {
+    const uploadData = vi.fn(() => ({
+      result: Promise.resolve({ path: 'raw/role.md' }),
+    }));
+
+    await putRawObjectViaUploadData(
+      { key: 'raw/role.md', body: '# Role' },
+      uploadData,
+    );
+
+    expect(uploadData).toHaveBeenCalledWith({
+      path: 'raw/role.md',
+      data: '# Role',
+      options: {
+        contentType: 'text/markdown; charset=utf-8',
+      },
+    });
+  });
+});
+
+describe('putRawObjectWithAuthHandling', () => {
+  it('maps unauthenticated storage errors to a clear rejection reason', async () => {
+    const putRawObject = vi.fn(async () => {
+      throw new Error('No current user');
+    });
+
+    const result = await putRawObjectWithAuthHandling(putRawObject, {
+      key: 'raw/role.md',
+      body: '# Role',
+    });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'You must be signed in to upload a job description.',
+    });
+  });
+});
+
+describe('createDefaultPutRawObject', () => {
+  it('returns null when Amplify is not configured', async () => {
+    const result = await createDefaultPutRawObject();
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/upload-job-description-client.ts
+++ b/src/lib/upload-job-description-client.ts
@@ -1,0 +1,75 @@
+import type { PutRawObject } from './upload-job-description';
+import { isAmplifyClientConfigured } from './start-job-market-recompute-client';
+
+export const UPLOAD_CLIENT_NOT_CONFIGURED_REASON =
+  'Upload client is not configured';
+
+export const UPLOAD_UNAUTHENTICATED_REASON =
+  'You must be signed in to upload a job description.';
+
+export const UPLOAD_FAILED_REASON =
+  'Unable to upload job description. Please try again.';
+
+function isUnauthenticatedError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('no current user') ||
+    lower.includes('not authorized') ||
+    lower.includes('unauthorised') ||
+    lower.includes('unauthorized') ||
+    lower.includes('not authenticated') ||
+    lower.includes('user is not authenticated')
+  );
+}
+
+export type AmplifyUploadData = (input: {
+  path: string;
+  data: string;
+  options?: { contentType?: string };
+}) => { result: Promise<unknown> };
+
+export async function putRawObjectViaUploadData(
+  input: { key: string; body: string },
+  uploadData: AmplifyUploadData,
+): Promise<void> {
+  await uploadData({
+    path: input.key,
+    data: input.body,
+    options: {
+      contentType: 'text/markdown; charset=utf-8',
+    },
+  }).result;
+}
+
+export async function createDefaultPutRawObject(): Promise<PutRawObject | null> {
+  if (!isAmplifyClientConfigured()) {
+    return null;
+  }
+
+  try {
+    const { uploadData } = await import('aws-amplify/storage');
+    return (input) =>
+      putRawObjectViaUploadData(input, uploadData as AmplifyUploadData);
+  } catch {
+    return null;
+  }
+}
+
+export async function putRawObjectWithAuthHandling(
+  putRawObject: PutRawObject,
+  input: { key: string; body: string },
+): Promise<{ status: 'uploaded' } | { status: 'rejected'; reason: string }> {
+  try {
+    await putRawObject(input);
+    return { status: 'uploaded' };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (isUnauthenticatedError(message)) {
+      return { status: 'rejected', reason: UPLOAD_UNAUTHENTICATED_REASON };
+    }
+    return {
+      status: 'rejected',
+      reason: message.trim() || UPLOAD_FAILED_REASON,
+    };
+  }
+}

--- a/src/lib/upload-job-description.ts
+++ b/src/lib/upload-job-description.ts
@@ -1,0 +1,68 @@
+import { validateJobDescriptionMarkdown } from './validate-job-description-markdown';
+import {
+  createDefaultPutRawObject,
+  putRawObjectWithAuthHandling,
+  UPLOAD_CLIENT_NOT_CONFIGURED_REASON,
+} from './upload-job-description-client';
+
+export type UploadJobDescriptionResult =
+  | { status: 'uploaded'; s3Key: string }
+  | { status: 'rejected'; reason: string };
+
+export type PutRawObject = (input: { key: string; body: string }) => Promise<void>;
+
+export type UploadJobDescriptionDeps = {
+  putRawObject?: PutRawObject;
+};
+
+function normaliseFileName(fileName: string): string | null {
+  const trimmed = fileName.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const baseName = trimmed.replace(/^.*[/\\]/, '');
+  if (!baseName.toLowerCase().endsWith('.md')) {
+    return null;
+  }
+
+  return baseName;
+}
+
+export async function uploadJobDescription(
+  input: { fileName: string; body: string },
+  deps: UploadJobDescriptionDeps = {},
+): Promise<UploadJobDescriptionResult> {
+  const validation = validateJobDescriptionMarkdown(input.body);
+  if (validation.status === 'rejected') {
+    return validation;
+  }
+
+  const fileName = normaliseFileName(input.fileName);
+  if (!fileName) {
+    return {
+      status: 'rejected',
+      reason: 'File name must end with .md',
+    };
+  }
+
+  const putRawObject = deps.putRawObject ?? (await createDefaultPutRawObject());
+  if (!putRawObject) {
+    return {
+      status: 'rejected',
+      reason: UPLOAD_CLIENT_NOT_CONFIGURED_REASON,
+    };
+  }
+
+  const s3Key = `raw/${fileName}`;
+  const uploadResult = await putRawObjectWithAuthHandling(putRawObject, {
+    key: s3Key,
+    body: input.body,
+  });
+
+  if (uploadResult.status === 'rejected') {
+    return uploadResult;
+  }
+
+  return { status: 'uploaded', s3Key };
+}

--- a/src/lib/validate-job-description-markdown.ts
+++ b/src/lib/validate-job-description-markdown.ts
@@ -1,0 +1,48 @@
+import matter from 'gray-matter';
+
+export type JobDescriptionMarkdownValidation =
+  | { status: 'valid' }
+  | { status: 'rejected'; reason: string };
+
+function formatCollectedAt(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return undefined;
+    }
+    return parsed.toISOString();
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+
+  return undefined;
+}
+
+export function validateJobDescriptionMarkdown(body: string): JobDescriptionMarkdownValidation {
+  if (!body.startsWith('---')) {
+    return {
+      status: 'rejected',
+      reason: 'Missing YAML frontmatter',
+    };
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    ({ data } = matter(body) as { data: Record<string, unknown> });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid frontmatter';
+    return { status: 'rejected', reason: message };
+  }
+
+  const collectedAt = formatCollectedAt(data.collectedAt);
+  if (!collectedAt) {
+    return {
+      status: 'rejected',
+      reason: 'Frontmatter requires a valid collectedAt',
+    };
+  }
+
+  return { status: 'valid' };
+}


### PR DESCRIPTION
## Summary
- Add `uploadJobDescription` to the job-market-lab facade with client-side YAML frontmatter validation (including `collectedAt`) and an injectable `putRawObject` adapter defaulting to Amplify Storage `uploadData`.
- Add an owner-console upload panel wired into `JobMarketLabConsoleSection`; successful uploads write to `raw/*` and rely on the existing ingest trigger without starting recompute.
- Add British English upload copy under `jobMarketLab.upload` with types and validation.

Closes #67

## Test plan
- [x] `npm test` (158 tests)
- [x] Facade tests: frontmatter/collectedAt rejection, `raw/` upload path, no recompute, unconfigured client rejection
- [x] Upload panel tests: guest gating, client-side validation before facade call, successful upload message
- [x] Console section test: upload panel visible when authenticated
- [ ] Manual: sign in on sandbox, upload a valid `test_jds/*.md` file, confirm object appears under `raw/` and ingest upserts metadata
- [ ] Manual: upload invalid markdown and confirm rejection copy is shown