### PR TITLE
Add owner canonical CV to job market console

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -56,6 +56,15 @@ const schema = a
         allow.authenticated().to(['read', 'create', 'update']),
       ]),
 
+    CanonicalCv: a
+      .model({
+        body: a.string().required(),
+        updatedAt: a.datetime().required(),
+      })
+      .authorization((allow) => [
+        allow.authenticated().to(['read', 'create', 'update']),
+      ]),
+
     startJobMarketRecompute: a
       .mutation()
       .returns(

--- a/src/components/sections/labs/job-market-lab-console-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.test.tsx
@@ -4,6 +4,7 @@ import { JobMarketLabConsoleSection } from '@/components/sections/labs/job-marke
 import { SiteAuthProvider } from '@/hooks/use-site-auth';
 import { jobMarketLab } from '@/data';
 import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import type { CanonicalCvDeps } from '@/lib/canonical-cv';
 import { createMemorySiteAuth } from '@/lib/site-auth';
 import type { ListAnalysisRunsDeps } from '@/lib/job-market-lab';
 
@@ -19,9 +20,21 @@ function createMemoryCorpus(): AmplifyCorpusDeps {
   };
 }
 
+function createMemoryCanonicalCv(): CanonicalCvDeps {
+  return {
+    getCanonicalCv: async () => null,
+    saveCanonicalCv: async (input) => ({
+      id: 'current',
+      body: input.body,
+      updatedAt: input.updatedAt,
+    }),
+  };
+}
+
 function renderConsole(options?: {
   auth?: ReturnType<typeof createMemorySiteAuth>;
   analysisRuns?: ListAnalysisRunsDeps;
+  canonicalCv?: CanonicalCvDeps;
 }) {
   const auth = options?.auth ?? createMemorySiteAuth();
   return render(
@@ -29,6 +42,7 @@ function renderConsole(options?: {
       <JobMarketLabConsoleSection
         corpus={createMemoryCorpus()}
         analysisRuns={options?.analysisRuns}
+        canonicalCv={options?.canonicalCv ?? createMemoryCanonicalCv()}
       />
     </SiteAuthProvider>,
   );
@@ -56,6 +70,9 @@ describe('JobMarketLabConsoleSection', () => {
     expect(
       screen.queryByRole('heading', { name: jobMarketLab.console.runsHeading }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.console.cv.heading }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows facade-backed management and live run history when authenticated', async () => {
@@ -81,6 +98,9 @@ describe('JobMarketLabConsoleSection', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: jobMarketLab.admin.heading }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: jobMarketLab.console.cv.heading }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: jobMarketLab.upload.heading }),

--- a/src/components/sections/labs/job-market-lab-console-section.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.tsx
@@ -4,23 +4,27 @@ import Link from 'next/link';
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
 import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
 import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-lab-corpus-admin';
+import { JobMarketLabCvPanel } from '@/components/sections/labs/job-market-lab-cv-panel';
 import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
 import { JobMarketLabUploadPanel } from '@/components/sections/labs/job-market-lab-upload-panel';
 import { jobMarketLab } from '@/data';
 import { useSiteAuth } from '@/hooks/use-site-auth';
 import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import type { CanonicalCvDeps } from '@/lib/canonical-cv';
 import type { ListAnalysisRunsDeps, StartJobMarketRecompute } from '@/lib/job-market-lab';
 
 export type JobMarketLabConsoleSectionProps = {
   corpus?: AmplifyCorpusDeps;
   analysisRuns?: ListAnalysisRunsDeps;
   startRecompute?: StartJobMarketRecompute;
+  canonicalCv?: CanonicalCvDeps;
 };
 
 export function JobMarketLabConsoleSection({
   corpus,
   analysisRuns,
   startRecompute,
+  canonicalCv,
 }: JobMarketLabConsoleSectionProps) {
   const { session, isLoading } = useSiteAuth();
 
@@ -66,6 +70,7 @@ export function JobMarketLabConsoleSection({
         </div>
 
         <JobMarketLabAdminSection startRecompute={startRecompute} />
+        <JobMarketLabCvPanel canonicalCv={canonicalCv} />
         <JobMarketLabUploadPanel />
         <JobMarketLabCorpusAdmin corpus={corpus} />
         <JobMarketLabRunsPanel analysisRuns={analysisRuns} />

--- a/src/components/sections/labs/job-market-lab-cv-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-cv-panel.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JobMarketLabCvPanel } from '@/components/sections/labs/job-market-lab-cv-panel';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { careerProfile, jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+import type { CanonicalCvDeps } from '@/lib/canonical-cv';
+import { seedCanonicalCvFromProfile } from '@/lib/canonical-cv';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createMemoryCanonicalCv(initial: string | null = null): CanonicalCvDeps & {
+  getStoredBody: () => string | null;
+} {
+  let body = initial;
+  return {
+    getStoredBody: () => body,
+    async getCanonicalCv() {
+      if (body === null) {
+        return null;
+      }
+      return {
+        id: 'current',
+        body,
+        updatedAt: '2026-07-14T12:00:00.000Z',
+      };
+    },
+    async saveCanonicalCv(input) {
+      body = input.body;
+      return {
+        id: 'current',
+        body: input.body,
+        updatedAt: input.updatedAt,
+      };
+    },
+  };
+}
+
+function renderCvPanel(options?: {
+  auth?: ReturnType<typeof createMemorySiteAuth>;
+  canonicalCv?: CanonicalCvDeps;
+}) {
+  const auth = options?.auth ?? createMemorySiteAuth();
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <JobMarketLabCvPanel canonicalCv={options?.canonicalCv} />
+    </SiteAuthProvider>,
+  );
+}
+
+const ownerAuth = () =>
+  createMemorySiteAuth({ status: 'authenticated', email: 'owner@example.com' });
+
+describe('JobMarketLabCvPanel', () => {
+  it('shows no CV controls to guests', async () => {
+    renderCvPanel({ auth: createMemorySiteAuth({ status: 'unauthenticated' }) });
+
+    expect(
+      screen.queryByRole('heading', { name: jobMarketLab.console.cv.heading }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers seed from profile when no canonical CV exists', async () => {
+    const user = userEvent.setup();
+    const deps = createMemoryCanonicalCv(null);
+    renderCvPanel({ auth: ownerAuth(), canonicalCv: deps });
+
+    expect(
+      await screen.findByText(jobMarketLab.console.cv.emptyHint),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', { name: jobMarketLab.console.cv.seedButtonLabel }),
+    );
+
+    expect(
+      await screen.findByText(jobMarketLab.console.cv.seededMessage),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(jobMarketLab.console.cv.bodyLabel)).toHaveValue(
+      seedCanonicalCvFromProfile(careerProfile),
+    );
+  });
+
+  it('loads, edits and saves the canonical CV through injectable deps', async () => {
+    const user = userEvent.setup();
+    const deps = createMemoryCanonicalCv('## Experience\n\nInitial body.');
+    renderCvPanel({ auth: ownerAuth(), canonicalCv: deps });
+
+    const textarea = await screen.findByLabelText(jobMarketLab.console.cv.bodyLabel);
+    expect(textarea).toHaveValue('## Experience\n\nInitial body.');
+
+    await user.clear(textarea);
+    await user.type(textarea, '## Experience\n\nEdited body.');
+    await user.click(
+      screen.getByRole('button', { name: jobMarketLab.console.cv.saveButtonLabel }),
+    );
+
+    await waitFor(() => {
+      expect(deps.getStoredBody()).toBe('## Experience\n\nEdited body.');
+    });
+    expect(
+      screen.getByText(jobMarketLab.console.cv.savedMessage),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-cv-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-cv-panel.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button, SectionHeader, Text } from '@/components/ui';
+import { careerProfile, jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import {
+  getCanonicalCv,
+  saveCanonicalCv,
+  seedCanonicalCvFromProfile,
+  type CanonicalCvDeps,
+} from '@/lib/canonical-cv';
+import { createDefaultAmplifyCanonicalCvDeps } from '@/lib/canonical-cv-amplify';
+
+export type JobMarketLabCvPanelProps = {
+  canonicalCv?: CanonicalCvDeps;
+};
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; body: string }
+  | { status: 'error' };
+
+export function JobMarketLabCvPanel({
+  canonicalCv,
+}: JobMarketLabCvPanelProps) {
+  const { session, isLoading } = useSiteAuth();
+  const [deps] = useState(() => canonicalCv ?? createDefaultAmplifyCanonicalCvDeps());
+  const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
+  const [draftBody, setDraftBody] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSeeding, setIsSeeding] = useState(false);
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
+  const [seededMessage, setSeededMessage] = useState<string | null>(null);
+
+  const loadCv = useCallback(async () => {
+    const record = await getCanonicalCv(deps);
+    return record?.body ?? '';
+  }, [deps]);
+
+  useEffect(() => {
+    if (isLoading || session?.status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      setLoadState({ status: 'loading' });
+      try {
+        const body = await loadCv();
+        if (!cancelled) {
+          setDraftBody(body);
+          setLoadState({ status: 'ready', body });
+        }
+      } catch {
+        if (!cancelled) {
+          setLoadState({ status: 'error' });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, session, loadCv]);
+
+  if (isLoading || session?.status !== 'authenticated') {
+    return null;
+  }
+
+  const cvCopy = jobMarketLab.console.cv;
+  const isEmpty = loadState.status === 'ready' && loadState.body.trim() === '';
+
+  async function handleSeed() {
+    setIsSeeding(true);
+    setSeededMessage(null);
+    setSavedMessage(null);
+    const seeded = seedCanonicalCvFromProfile(careerProfile);
+    setDraftBody(seeded);
+    setIsSeeding(false);
+    setSeededMessage(cvCopy.seededMessage);
+  }
+
+  async function handleSave() {
+    setIsSaving(true);
+    setSavedMessage(null);
+    setSeededMessage(null);
+    try {
+      await saveCanonicalCv(draftBody, deps);
+      setLoadState({ status: 'ready', body: draftBody });
+      setSavedMessage(cvCopy.savedMessage);
+    } catch {
+      setLoadState({ status: 'error' });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <section className="mt-16 space-y-6" aria-labelledby="job-market-cv-heading">
+      <div className="max-w-2xl space-y-4">
+        <SectionHeader
+          id="job-market-cv-heading"
+          as="h2"
+          size="md"
+          animated={false}
+          showLeftAccent={false}
+        >
+          {cvCopy.heading}
+        </SectionHeader>
+        <Text variant="muted">{cvCopy.description}</Text>
+      </div>
+
+      {loadState.status === 'loading' ? (
+        <Text variant="muted">{cvCopy.loadingLabel}</Text>
+      ) : null}
+
+      {loadState.status === 'error' ? (
+        <Text role="alert">{cvCopy.errorLabel}</Text>
+      ) : null}
+
+      {loadState.status === 'ready' || loadState.status === 'idle' ? (
+        <div className="max-w-2xl space-y-4">
+          {isEmpty ? (
+            <Text variant="muted">{cvCopy.emptyHint}</Text>
+          ) : null}
+
+          <label className="block space-y-2" htmlFor="job-market-cv-body">
+            <Text size="sm">{cvCopy.bodyLabel}</Text>
+            <textarea
+              id="job-market-cv-body"
+              value={draftBody}
+              onChange={(event) => setDraftBody(event.target.value)}
+              rows={16}
+              className="block w-full rounded border border-[var(--border)] bg-[var(--background)] p-3 font-body text-base leading-relaxed text-[var(--foreground)]"
+            />
+          </label>
+
+          <div className="flex flex-wrap gap-3">
+            {isEmpty ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleSeed()}
+                disabled={isSeeding}
+              >
+                {isSeeding ? cvCopy.seedingLabel : cvCopy.seedButtonLabel}
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={isSaving || draftBody.trim() === ''}
+            >
+              {isSaving ? cvCopy.savingLabel : cvCopy.saveButtonLabel}
+            </Button>
+          </div>
+
+          {seededMessage ? (
+            <p role="status" className="font-body text-base leading-relaxed text-[var(--foreground)]">
+              {seededMessage}
+            </p>
+          ) : null}
+
+          {savedMessage ? (
+            <p role="status" className="font-body text-base leading-relaxed text-[var(--foreground)]">
+              {savedMessage}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -57,6 +57,20 @@
     "runStatusRunning": "Running",
     "runStatusSucceeded": "Succeeded",
     "runStatusFailed": "Failed",
-    "failureReasonLabel": "Failure reason"
+    "failureReasonLabel": "Failure reason",
+    "cv": {
+      "heading": "Canonical CV",
+      "description": "Private owner CV for later fit comparison against job descriptions and market signals. Never published to guests.",
+      "loadingLabel": "Loading canonical CV…",
+      "emptyHint": "No canonical CV saved yet. Seed from your About profile or write one below.",
+      "seedButtonLabel": "Seed from profile",
+      "seedingLabel": "Seeding…",
+      "seededMessage": "Seeded from your About profile. Review and save when ready.",
+      "bodyLabel": "CV body",
+      "saveButtonLabel": "Save CV",
+      "savingLabel": "Saving…",
+      "savedMessage": "Canonical CV saved.",
+      "errorLabel": "Canonical CV is temporarily unavailable."
+    }
   }
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -173,6 +173,21 @@ export interface JobMarketLabUploadCopy {
   noFileSelected: string;
 }
 
+export interface JobMarketLabCvCopy {
+  heading: string;
+  description: string;
+  loadingLabel: string;
+  emptyHint: string;
+  seedButtonLabel: string;
+  seedingLabel: string;
+  seededMessage: string;
+  bodyLabel: string;
+  saveButtonLabel: string;
+  savingLabel: string;
+  savedMessage: string;
+  errorLabel: string;
+}
+
 export interface JobMarketLabConsoleCopy {
   heading: string;
   description: string;
@@ -190,6 +205,7 @@ export interface JobMarketLabConsoleCopy {
   runStatusSucceeded: string;
   runStatusFailed: string;
   failureReasonLabel: string;
+  cv: JobMarketLabCvCopy;
 }
 
 export interface JobMarketLabPageData {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -187,6 +187,19 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(consoleCopy, 'runStatusSucceeded', 'jobMarketLab.console');
   requireString(consoleCopy, 'runStatusFailed', 'jobMarketLab.console');
   requireString(consoleCopy, 'failureReasonLabel', 'jobMarketLab.console');
+  const cv = requireRecord(consoleCopy.cv, 'jobMarketLab.console.cv');
+  requireString(cv, 'heading', 'jobMarketLab.console.cv');
+  requireString(cv, 'description', 'jobMarketLab.console.cv');
+  requireString(cv, 'loadingLabel', 'jobMarketLab.console.cv');
+  requireString(cv, 'emptyHint', 'jobMarketLab.console.cv');
+  requireString(cv, 'seedButtonLabel', 'jobMarketLab.console.cv');
+  requireString(cv, 'seedingLabel', 'jobMarketLab.console.cv');
+  requireString(cv, 'seededMessage', 'jobMarketLab.console.cv');
+  requireString(cv, 'bodyLabel', 'jobMarketLab.console.cv');
+  requireString(cv, 'saveButtonLabel', 'jobMarketLab.console.cv');
+  requireString(cv, 'savingLabel', 'jobMarketLab.console.cv');
+  requireString(cv, 'savedMessage', 'jobMarketLab.console.cv');
+  requireString(cv, 'errorLabel', 'jobMarketLab.console.cv');
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/lib/canonical-cv-amplify.test.ts
+++ b/src/lib/canonical-cv-amplify.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CANONICAL_CV_ID,
+  createAmplifyCanonicalCvDeps,
+  type AmplifyCanonicalCvModelClient,
+  type AmplifyCanonicalCvRow,
+} from './canonical-cv-amplify';
+import { getCanonicalCv, saveCanonicalCv } from './canonical-cv';
+
+function createMemoryModelClient(
+  initial: AmplifyCanonicalCvRow | null,
+): AmplifyCanonicalCvModelClient {
+  let row = initial ? { ...initial } : null;
+
+  return {
+    async get({ id }) {
+      if (!row || row.id !== id) {
+        return { data: null };
+      }
+      return { data: row };
+    },
+    async create(input) {
+      row = { ...input };
+      return { data: row };
+    },
+    async update(input) {
+      if (!row || row.id !== input.id) {
+        return { data: null, errors: [{ message: 'not found' }] };
+      }
+      row = { ...row, ...input };
+      return { data: row };
+    },
+  };
+}
+
+describe('createAmplifyCanonicalCvDeps', () => {
+  it('maps Amplify get into facade load', async () => {
+    const client = createMemoryModelClient({
+      id: CANONICAL_CV_ID,
+      body: '## Experience\n\nStored CV.',
+      updatedAt: '2026-07-14T10:00:00.000Z',
+    });
+    const deps = createAmplifyCanonicalCvDeps(client);
+
+    await expect(getCanonicalCv(deps)).resolves.toEqual({
+      id: CANONICAL_CV_ID,
+      body: '## Experience\n\nStored CV.',
+      updatedAt: '2026-07-14T10:00:00.000Z',
+    });
+  });
+
+  it('creates the fixed-id record on first save and updates thereafter', async () => {
+    const client = createMemoryModelClient(null);
+    const deps = createAmplifyCanonicalCvDeps(client);
+
+    const created = await saveCanonicalCv('Initial body.', deps);
+    expect(created.body).toBe('Initial body.');
+
+    const updated = await saveCanonicalCv('Revised body.', deps);
+    expect(updated.body).toBe('Revised body.');
+    await expect(getCanonicalCv(deps)).resolves.toEqual(updated);
+  });
+});

--- a/src/lib/canonical-cv-amplify.ts
+++ b/src/lib/canonical-cv-amplify.ts
@@ -1,0 +1,116 @@
+import {
+  CANONICAL_CV_ID,
+  type CanonicalCvDeps,
+  type CanonicalCvRecord,
+} from './canonical-cv';
+
+export type AmplifyCanonicalCvRow = {
+  id: string;
+  body: string;
+  updatedAt: string;
+};
+
+type AmplifyDataResult<T> = {
+  data: T;
+  errors?: Array<{ message: string }> | null;
+};
+
+export type AmplifyCanonicalCvModelClient = {
+  get: (input: { id: string }) => Promise<AmplifyDataResult<AmplifyCanonicalCvRow | null>>;
+  create: (
+    input: Pick<AmplifyCanonicalCvRow, 'id' | 'body' | 'updatedAt'>,
+  ) => Promise<AmplifyDataResult<AmplifyCanonicalCvRow | null>>;
+  update: (
+    input: Pick<AmplifyCanonicalCvRow, 'id' | 'body' | 'updatedAt'>,
+  ) => Promise<AmplifyDataResult<AmplifyCanonicalCvRow | null>>;
+};
+
+function throwIfErrors(errors: Array<{ message: string }> | null | undefined): void {
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+function toCanonicalCvRecord(row: AmplifyCanonicalCvRow): CanonicalCvRecord {
+  return {
+    id: CANONICAL_CV_ID,
+    body: row.body,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createAmplifyCanonicalCvDeps(
+  client: AmplifyCanonicalCvModelClient,
+): CanonicalCvDeps {
+  return {
+    async getCanonicalCv() {
+      const { data, errors } = await client.get({ id: CANONICAL_CV_ID });
+      throwIfErrors(errors);
+      return data ? toCanonicalCvRecord(data) : null;
+    },
+    async saveCanonicalCv(input) {
+      const existing = await client.get({ id: CANONICAL_CV_ID });
+      throwIfErrors(existing.errors);
+
+      if (existing.data) {
+        const { data, errors } = await client.update({
+          id: CANONICAL_CV_ID,
+          body: input.body,
+          updatedAt: input.updatedAt,
+        });
+        throwIfErrors(errors);
+        if (!data) {
+          throw new Error('Canonical CV update returned no data');
+        }
+        return toCanonicalCvRecord(data);
+      }
+
+      const { data, errors } = await client.create({
+        id: CANONICAL_CV_ID,
+        body: input.body,
+        updatedAt: input.updatedAt,
+      });
+      throwIfErrors(errors);
+      if (!data) {
+        throw new Error('Canonical CV create returned no data');
+      }
+      return toCanonicalCvRecord(data);
+    },
+  };
+}
+
+type AmplifyDataModelsClient = {
+  models: {
+    CanonicalCv: AmplifyCanonicalCvModelClient;
+  };
+};
+
+export function createAmplifyCanonicalCvModelClient(
+  getClient: () => Promise<AmplifyDataModelsClient> = defaultGetAmplifyDataClient,
+): AmplifyCanonicalCvModelClient {
+  return {
+    async get(input) {
+      const client = await getClient();
+      return client.models.CanonicalCv.get(input);
+    },
+    async create(input) {
+      const client = await getClient();
+      return client.models.CanonicalCv.create(input);
+    },
+    async update(input) {
+      const client = await getClient();
+      return client.models.CanonicalCv.update(input);
+    },
+  };
+}
+
+async function defaultGetAmplifyDataClient(): Promise<AmplifyDataModelsClient> {
+  const { generateClient } = await import('aws-amplify/data');
+  return generateClient({ authMode: 'userPool' }) as unknown as AmplifyDataModelsClient;
+}
+
+export function createDefaultAmplifyCanonicalCvDeps(): CanonicalCvDeps {
+  return createAmplifyCanonicalCvDeps(createAmplifyCanonicalCvModelClient());
+}
+
+export { CANONICAL_CV_ID };

--- a/src/lib/canonical-cv-publication.test.ts
+++ b/src/lib/canonical-cv-publication.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const handlerDir = dirname(fileURLToPath(import.meta.url));
+
+describe('job-market publication handler', () => {
+  it('never reads CanonicalCv — guests cannot reach owner CV storage', () => {
+    const source = readFileSync(
+      join(handlerDir, '../../amplify/functions/job-market-publication/handler.ts'),
+      'utf8',
+    );
+
+    expect(source).not.toMatch(/CanonicalCv/);
+    expect(source).toMatch(/getPublishedJobMarketSnapshot/);
+  });
+});
+
+describe('CanonicalCv Amplify authorisation', () => {
+  it('restricts CanonicalCv to authenticated owners only', () => {
+    const source = readFileSync(
+      join(handlerDir, '../../amplify/data/resource.ts'),
+      'utf8',
+    );
+
+    const canonicalCvBlock = source.slice(
+      source.indexOf('CanonicalCv:'),
+      source.indexOf('startJobMarketRecompute'),
+    );
+
+    expect(canonicalCvBlock).toMatch(/CanonicalCv/);
+    expect(canonicalCvBlock).toMatch(/allow\.authenticated\(\)/);
+    expect(canonicalCvBlock).not.toMatch(/allow\.guest\(\)/);
+  });
+});

--- a/src/lib/canonical-cv.test.ts
+++ b/src/lib/canonical-cv.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CareerProfile } from '@/data/types';
+import {
+  CANONICAL_CV_ID,
+  getCanonicalCv,
+  saveCanonicalCv,
+  seedCanonicalCvFromProfile,
+  type CanonicalCvDeps,
+} from './canonical-cv';
+
+const fixtureProfile: CareerProfile = {
+  experience: {
+    companies: [
+      {
+        name: 'Deloitte LLP',
+        location: 'London, United Kingdom',
+        roles: [
+          {
+            role: 'Consultant',
+            period: 'Jun 2026 - Present',
+            description: 'Technology and Transformation | AI and Data.',
+          },
+        ],
+      },
+    ],
+  },
+  education: {
+    entries: [
+      {
+        institution: 'UCL',
+        qualification: 'Mechanical Engineering (MEng)',
+        period: 'Sep 2019 - Jul 2023',
+        description: 'Third Year Individual Project: lap-time simulator.',
+      },
+    ],
+  },
+  certifications: {
+    items: [
+      {
+        name: 'AWS Certified Cloud Practitioner',
+        issuer: 'Amazon Web Services',
+        issued: 'Issued Feb 2026',
+      },
+    ],
+  },
+};
+
+function createMemoryDeps(initial: { body: string; updatedAt: string } | null = null): CanonicalCvDeps & {
+  store: { body: string; updatedAt: string } | null;
+} {
+  const store = { current: initial };
+  return {
+    store: store.current,
+    async getCanonicalCv() {
+      if (!store.current) {
+        return null;
+      }
+      return {
+        id: CANONICAL_CV_ID,
+        body: store.current.body,
+        updatedAt: store.current.updatedAt,
+      };
+    },
+    async saveCanonicalCv(input) {
+      store.current = { body: input.body, updatedAt: input.updatedAt };
+      return {
+        id: CANONICAL_CV_ID,
+        body: input.body,
+        updatedAt: input.updatedAt,
+      };
+    },
+  };
+}
+
+describe('seedCanonicalCvFromProfile', () => {
+  it('converts experience, education and certifications into markdown', () => {
+    const body = seedCanonicalCvFromProfile(fixtureProfile);
+
+    expect(body).toContain('## Experience');
+    expect(body).toContain('### Deloitte LLP');
+    expect(body).toContain('London, United Kingdom');
+    expect(body).toContain('**Consultant** · Jun 2026 - Present');
+    expect(body).toContain('Technology and Transformation | AI and Data.');
+    expect(body).toContain('## Education');
+    expect(body).toContain('### UCL — Mechanical Engineering (MEng)');
+    expect(body).toContain('Sep 2019 - Jul 2023');
+    expect(body).toContain('lap-time simulator');
+    expect(body).toContain('## Certifications');
+    expect(body).toContain(
+      '**AWS Certified Cloud Practitioner** — Amazon Web Services · Issued Feb 2026',
+    );
+  });
+});
+
+describe('getCanonicalCv', () => {
+  it('returns null when no CV is stored', async () => {
+    const deps = createMemoryDeps(null);
+    await expect(getCanonicalCv(deps)).resolves.toBeNull();
+  });
+
+  it('returns the stored CV record', async () => {
+    const deps = createMemoryDeps({
+      body: '# Owner CV',
+      updatedAt: '2026-07-14T12:00:00.000Z',
+    });
+
+    await expect(getCanonicalCv(deps)).resolves.toEqual({
+      id: CANONICAL_CV_ID,
+      body: '# Owner CV',
+      updatedAt: '2026-07-14T12:00:00.000Z',
+    });
+  });
+});
+
+describe('saveCanonicalCv', () => {
+  it('persists body through injectable deps with a fresh updatedAt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T15:30:00.000Z'));
+
+    const deps = createMemoryDeps(null);
+    const saved = await saveCanonicalCv('## Experience\n\nEdited copy.', deps);
+
+    expect(saved).toEqual({
+      id: CANONICAL_CV_ID,
+      body: '## Experience\n\nEdited copy.',
+      updatedAt: '2026-07-14T15:30:00.000Z',
+    });
+    await expect(getCanonicalCv(deps)).resolves.toEqual(saved);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/canonical-cv.ts
+++ b/src/lib/canonical-cv.ts
@@ -1,0 +1,71 @@
+import type { CareerProfile } from '@/data/types';
+import { getAboutCareerViews } from '@/data/profile/about-career-slices';
+
+export const CANONICAL_CV_ID = 'current' as const;
+
+export type CanonicalCvRecord = {
+  id: typeof CANONICAL_CV_ID;
+  body: string;
+  updatedAt: string;
+};
+
+export type CanonicalCvDeps = {
+  getCanonicalCv: () => Promise<CanonicalCvRecord | null>;
+  saveCanonicalCv: (input: {
+    body: string;
+    updatedAt: string;
+  }) => Promise<CanonicalCvRecord>;
+};
+
+export async function getCanonicalCv(
+  deps: Pick<CanonicalCvDeps, 'getCanonicalCv'>,
+): Promise<CanonicalCvRecord | null> {
+  return deps.getCanonicalCv();
+}
+
+export async function saveCanonicalCv(
+  body: string,
+  deps: CanonicalCvDeps,
+): Promise<CanonicalCvRecord> {
+  const updatedAt = new Date().toISOString();
+  return deps.saveCanonicalCv({ body, updatedAt });
+}
+
+export function seedCanonicalCvFromProfile(profile: CareerProfile): string {
+  const views = getAboutCareerViews(profile);
+  const sections: string[] = [];
+
+  const experienceLines: string[] = ['## Experience', ''];
+  for (const company of views.experience.companies) {
+    experienceLines.push(`### ${company.name}`);
+    experienceLines.push(company.location);
+    experienceLines.push('');
+    for (const role of company.roles) {
+      experienceLines.push(`**${role.role}** · ${role.period}`);
+      experienceLines.push('');
+      experienceLines.push(role.description);
+      experienceLines.push('');
+    }
+  }
+  sections.push(experienceLines.join('\n').trimEnd());
+
+  const educationLines: string[] = ['## Education', ''];
+  for (const entry of views.education.entries) {
+    educationLines.push(`### ${entry.institution} — ${entry.qualification}`);
+    educationLines.push(entry.period);
+    educationLines.push('');
+    educationLines.push(entry.description);
+    educationLines.push('');
+  }
+  sections.push(educationLines.join('\n').trimEnd());
+
+  const certificationLines: string[] = ['## Certifications', ''];
+  for (const item of views.certifications.items) {
+    certificationLines.push(
+      `- **${item.name}** — ${item.issuer} · ${item.issued}`,
+    );
+  }
+  sections.push(certificationLines.join('\n').trimEnd());
+
+  return sections.join('\n\n');
+}


### PR DESCRIPTION
## Summary

- Adds authenticated-only `CanonicalCv` Amplify model (fixed id `current`) with facade seams for load, save, and profile seeding.
- Adds console CV panel on `/labs/job-market/console` to view, edit, save, and seed from `careerProfile` when empty.
- Adds British English copy under `jobMarketLab.console.cv` with validation; publication path tests confirm guests never reach owner CV storage.

Closes #70.

## Test plan

- [x] `npm test` — 172 tests passed (48 files)
- [x] Facade: `canonical-cv.test.ts`, `canonical-cv-amplify.test.ts`
- [x] Guest isolation: `canonical-cv-publication.test.ts`
- [x] Console UI: `job-market-lab-cv-panel.test.tsx`, `job-market-lab-console-section.test.tsx`
- [x] Data validation: `validate.test.ts`
- [ ] Manual: sign in as owner, seed CV from profile, edit and save; confirm guests cannot see console CV section