### PR TITLE
Stable theme labels with optional owner overrides

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -80,6 +80,15 @@ const schema = a
         allow.authenticated().to(['read', 'create', 'update']),
       ]),
 
+    ThemeLabelOverride: a
+      .model({
+        clusterKey: a.string().required(),
+        label: a.string().required(),
+      })
+      .authorization((allow) => [
+        allow.authenticated().to(['read', 'create', 'update', 'delete']),
+      ]),
+
     startJobMarketRecompute: a
       .mutation()
       .returns(

--- a/amplify/functions/job-market-analyse/analyse.test.ts
+++ b/amplify/functions/job-market-analyse/analyse.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   analyseCorpus,
+  buildClusterLabel,
+  deriveClusterKey,
   MAX_CLUSTER_K,
   MAX_PROJECTION_POINTS,
   MAX_SKILLS,
+  resolveClusterLabel,
   type AnalyzableDocument,
 } from './analyse';
 import { matchTechnologiesInDocuments } from './technology-ontology';
@@ -34,6 +37,53 @@ const docs: AnalyzableDocument[] = [
   },
 ];
 
+describe('buildClusterLabel', () => {
+  it('joins the top two matched technologies in cluster documents', () => {
+    const documents = [
+      { markdown: 'Python, SQL, and dbt experience required.' },
+      { markdown: 'Strong Python and SQL background.' },
+    ];
+
+    expect(buildClusterLabel(0, documents)).toBe('python, sql');
+  });
+
+  it('falls back to a requirement theme label when no technologies match', () => {
+    expect(buildClusterLabel(2, [{ markdown: 'Excellent communication and teamwork.' }])).toBe(
+      'Requirement theme 3',
+    );
+  });
+});
+
+describe('deriveClusterKey', () => {
+  it('builds a stable key from the top matched technologies', () => {
+    const documents = [{ markdown: 'Python, SQL, and teamwork.' }];
+
+    expect(deriveClusterKey(documents)).toBe('python|sql');
+  });
+
+  it('returns an empty key when no technologies match', () => {
+    expect(deriveClusterKey([{ markdown: 'Communication and stakeholder management.' }])).toBe('');
+  });
+});
+
+describe('resolveClusterLabel', () => {
+  it('prefers an owner override keyed by cluster id', () => {
+    const documents = [{ markdown: 'Python and SQL required.' }];
+
+    expect(
+      resolveClusterLabel(1, documents, {
+        '1': 'Data platform hiring signal',
+      }),
+    ).toBe('Data platform hiring signal');
+  });
+
+  it('falls back to the deterministic technology label', () => {
+    const documents = [{ markdown: 'Python and SQL required.' }];
+
+    expect(resolveClusterLabel(0, documents, {})).toBe('python, sql');
+  });
+});
+
 describe('matchTechnologiesInDocuments', () => {
   it('matches canonical technology names and aliases once per document', () => {
     const documents = [
@@ -47,6 +97,76 @@ describe('matchTechnologiesInDocuments', () => {
       { name: 'sql', count: 2 },
       { name: 'kubernetes', count: 1 },
       { name: 'snowflake', count: 1 },
+    ]);
+  });
+});
+
+describe('analyseCorpus cluster labels', () => {
+  it('publishes deterministic technology labels instead of Theme N placeholders', async () => {
+    const clusterDocs: AnalyzableDocument[] = [
+      {
+        id: 'jd-a',
+        contentHash: 'hash-a',
+        markdown: 'Python, SQL, and modelling experience.',
+      },
+      {
+        id: 'jd-b',
+        contentHash: 'hash-b',
+        markdown: 'Tableau, communication, and stakeholder management.',
+      },
+    ];
+
+    const result = await analyseCorpus(clusterDocs, {
+      embed: async () => ({
+        vector: [0.9, 0.1, 0.2, 0.3],
+        inputTokens: 4,
+        estimatedCostUsd: 0.0001,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      cluster: () => ({ assignments: [0, 1], centroids: [[0.9], [0.1]] }),
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.snapshot.clusters).toEqual([
+      { id: 0, size: 1, label: 'python, sql' },
+      { id: 1, size: 1, label: 'tableau' },
+    ]);
+    expect(result.snapshot.clusters.map((cluster) => cluster.label)).not.toContain('Theme 1');
+  });
+
+  it('applies owner theme label overrides when publishing clusters', async () => {
+    const clusterDocs: AnalyzableDocument[] = [
+      {
+        id: 'jd-a',
+        contentHash: 'hash-a',
+        markdown: 'Python, SQL, and modelling experience.',
+      },
+      {
+        id: 'jd-b',
+        contentHash: 'hash-b',
+        markdown: 'Tableau, communication, and stakeholder management.',
+      },
+    ];
+
+    const result = await analyseCorpus(clusterDocs, {
+      embed: async () => ({
+        vector: [0.9, 0.1, 0.2, 0.3],
+        inputTokens: 4,
+        estimatedCostUsd: 0.0001,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      cluster: () => ({ assignments: [0, 1], centroids: [[0.9], [0.1]] }),
+      themeLabelOverrides: {
+        '1': 'Visual analytics demand',
+      },
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.snapshot.clusters).toEqual([
+      { id: 0, size: 1, label: 'python, sql' },
+      { id: 1, size: 1, label: 'Visual analytics demand' },
     ]);
   });
 });

--- a/amplify/functions/job-market-analyse/analyse.ts
+++ b/amplify/functions/job-market-analyse/analyse.ts
@@ -69,6 +69,7 @@ export type AnalyseCorpusDeps = {
   maxSkills?: number;
   maxProjectionPoints?: number;
   maxClusters?: number;
+  themeLabelOverrides?: Record<string, string>;
   cluster?: (
     vectors: number[][],
     k: number,
@@ -166,6 +167,48 @@ export function kMeansCluster(
   return { assignments, centroids };
 }
 
+export function deriveClusterKey(
+  documents: Array<{ markdown: string }>,
+): string {
+  const technologies = matchTechnologiesInDocuments(documents, { maxTechnologies: 2 });
+  if (technologies.length === 0) {
+    return '';
+  }
+
+  return technologies
+    .map((technology) => technology.name)
+    .sort((a, b) => a.localeCompare(b))
+    .join('|');
+}
+
+export function buildClusterLabel(
+  clusterId: number,
+  documents: Array<{ markdown: string }>,
+): string {
+  const technologies = matchTechnologiesInDocuments(documents, { maxTechnologies: 2 });
+  if (technologies.length === 0) {
+    return `Requirement theme ${clusterId + 1}`;
+  }
+
+  return technologies.map((technology) => technology.name).join(', ');
+}
+
+export function resolveClusterLabel(
+  clusterId: number,
+  documents: Array<{ markdown: string }>,
+  overrides: Record<string, string> | undefined,
+): string {
+  const keys = [String(clusterId), deriveClusterKey(documents)].filter(Boolean);
+  for (const key of keys) {
+    const override = overrides?.[key]?.trim();
+    if (override) {
+      return override;
+    }
+  }
+
+  return buildClusterLabel(clusterId, documents);
+}
+
 export async function analyseCorpus(
   documents: AnalyzableDocument[],
   deps: AnalyseCorpusDeps,
@@ -205,8 +248,16 @@ export async function analyseCorpus(
   const { assignments } = cluster(vectors, k);
 
   const clusterSizes = new Map<number, number>();
-  for (const assignment of assignments) {
-    clusterSizes.set(assignment, (clusterSizes.get(assignment) ?? 0) + 1);
+  const clusterDocuments = new Map<number, AnalyzableDocument[]>();
+  for (let index = 0; index < assignments.length; index += 1) {
+    const clusterId = assignments[index] ?? 0;
+    clusterSizes.set(clusterId, (clusterSizes.get(clusterId) ?? 0) + 1);
+    const documentsInCluster = clusterDocuments.get(clusterId) ?? [];
+    const document = documents[index];
+    if (document) {
+      documentsInCluster.push(document);
+      clusterDocuments.set(clusterId, documentsInCluster);
+    }
   }
 
   const clusters = [...clusterSizes.entries()]
@@ -214,7 +265,11 @@ export async function analyseCorpus(
     .map(([id, size]) => ({
       id,
       size,
-      label: `Theme ${id + 1}`,
+      label: resolveClusterLabel(
+        id,
+        clusterDocuments.get(id) ?? [],
+        deps.themeLabelOverrides,
+      ),
     }));
 
   const projection = documents.slice(0, maxProjectionPoints).map((document, index) => ({

--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -200,6 +200,19 @@ async function getPublication() {
   return { currentSnapshotId: data.currentSnapshotId };
 }
 
+async function listThemeLabelOverrides(): Promise<Record<string, string>> {
+  const { data, errors } = await client.models.ThemeLabelOverride.list();
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+
+  const overrides: Record<string, string> = {};
+  for (const row of data ?? []) {
+    overrides[row.clusterKey] = row.label;
+  }
+  return overrides;
+}
+
 export const handler: Handler<AnalyseEvent> = async (event) => {
   const runId = event.runId;
   if (!runId) {
@@ -218,6 +231,7 @@ export const handler: Handler<AnalyseEvent> = async (event) => {
     updateRun,
     updatePublication,
     getPublication,
+    listThemeLabelOverrides,
   });
 
   if (result.status === 'failed') {

--- a/amplify/functions/job-market-analyse/run.test.ts
+++ b/amplify/functions/job-market-analyse/run.test.ts
@@ -15,6 +15,57 @@ function doc(
 }
 
 describe('executeAnalysisRun', () => {
+  it('applies stored theme label overrides when publishing a snapshot', async () => {
+    const store = new Map<string, JobDescriptionCorpusRecord>([
+      ['active', doc({ id: 'active', title: 'Active role', seniority: 'senior' })],
+    ]);
+    const publication = { currentSnapshotId: 'snap-old' };
+    const snapshots = new Map<string, unknown>();
+    const runs = new Map<string, { id: string; status: string }>([
+      ['run-1', { id: 'run-1', status: 'queued' }],
+    ]);
+
+    const result = await executeAnalysisRun({
+      runId: 'run-1',
+      listJobDescriptions: async () => [...store.values()],
+      saveJobDescription: async (record) => {
+        store.set(record.id, record);
+      },
+      loadMarkdown: async () => 'Python SQL modelling experience required',
+      embed: async () => ({
+        vector: [0.1, 0.2, 0.3, 0.4],
+        inputTokens: 8,
+        estimatedCostUsd: 0.0002,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      listThemeLabelOverrides: async () => ({
+        '0': 'Core data engineering demand',
+      }),
+      saveSnapshot: async (snapshot) => {
+        snapshots.set(snapshot.id, snapshot);
+        return snapshot;
+      },
+      updateRun: async (run) => {
+        runs.set(run.id, run);
+        return run;
+      },
+      updatePublication: async (next) => {
+        publication.currentSnapshotId = next.currentSnapshotId;
+      },
+      getPublication: async () => publication,
+      createSnapshotId: () => 'snap-new',
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(snapshots.get('snap-new')).toMatchObject({
+      payload: expect.objectContaining({
+        clusters: [{ id: 0, size: 1, label: 'Core data engineering demand' }],
+      }),
+    });
+  });
+
   it('excludes archived documents from analysis and publishes on success', async () => {
     const store = new Map<string, JobDescriptionCorpusRecord>([
       ['active', doc({ id: 'active', title: 'Active role', seniority: 'senior' })],

--- a/amplify/functions/job-market-analyse/run.ts
+++ b/amplify/functions/job-market-analyse/run.ts
@@ -28,6 +28,7 @@ export type ExecuteAnalysisRunDeps = {
   embed: AnalyseCorpusDeps['embed'];
   getCachedEmbedding: AnalyseCorpusDeps['getCachedEmbedding'];
   putCachedEmbedding: AnalyseCorpusDeps['putCachedEmbedding'];
+  listThemeLabelOverrides?: () => Promise<Record<string, string>>;
   saveSnapshot: (snapshot: StoredCorpusSnapshot) => Promise<StoredCorpusSnapshot>;
   updateRun: (run: AnalysisRunRecord) => Promise<AnalysisRunRecord>;
   updatePublication: (publication: LabPublicationPointer) => Promise<void>;
@@ -85,6 +86,9 @@ export async function executeAnalysisRun(
       embed: deps.embed,
       getCachedEmbedding: deps.getCachedEmbedding,
       putCachedEmbedding: deps.putCachedEmbedding,
+      themeLabelOverrides: deps.listThemeLabelOverrides
+        ? await deps.listThemeLabelOverrides()
+        : undefined,
       now,
     });
 

--- a/amplify/functions/job-market-recompute/wiring.test.ts
+++ b/amplify/functions/job-market-recompute/wiring.test.ts
@@ -35,5 +35,6 @@ describe('job market recompute wiring', () => {
     expect(dataTs).toMatch(/AnalysisRun/);
     expect(dataTs).toMatch(/CorpusSnapshot/);
     expect(dataTs).toMatch(/LabPublication/);
+    expect(dataTs).toMatch(/ThemeLabelOverride/);
   });
 });

--- a/src/components/sections/labs/job-market-lab-console-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.test.tsx
@@ -112,6 +112,9 @@ describe('JobMarketLabConsoleSection', () => {
       screen.getByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: jobMarketLab.console.themeLabelsHeading }),
+    ).toBeInTheDocument();
+    expect(
       await screen.findByRole('heading', { name: jobMarketLab.console.runsHeading }),
     ).toBeInTheDocument();
     expect(await screen.findByText('run-fail')).toBeInTheDocument();

--- a/src/components/sections/labs/job-market-lab-console-section.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.tsx
@@ -7,6 +7,7 @@ import { JobMarketLabCorpusAdmin } from '@/components/sections/labs/job-market-l
 import { JobMarketLabCvPanel } from '@/components/sections/labs/job-market-lab-cv-panel';
 import { JobMarketLabHitlQueuePanel } from '@/components/sections/labs/job-market-lab-hitl-queue-panel';
 import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
+import { JobMarketLabThemeLabelsPanel } from '@/components/sections/labs/job-market-lab-theme-labels-panel';
 import { JobMarketLabUploadPanel } from '@/components/sections/labs/job-market-lab-upload-panel';
 import { jobMarketLab } from '@/data';
 import { useSiteAuth } from '@/hooks/use-site-auth';
@@ -75,6 +76,7 @@ export function JobMarketLabConsoleSection({
         <JobMarketLabUploadPanel />
         <JobMarketLabHitlQueuePanel />
         <JobMarketLabCorpusAdmin corpus={corpus} />
+        <JobMarketLabThemeLabelsPanel />
         <JobMarketLabRunsPanel analysisRuns={analysisRuns} />
       </Container>
     </Section>

--- a/src/components/sections/labs/job-market-lab-theme-labels-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-theme-labels-panel.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobMarketLabThemeLabelsPanel } from '@/components/sections/labs/job-market-lab-theme-labels-panel';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('JobMarketLabThemeLabelsPanel', () => {
+  it('lets authenticated owners save theme label overrides from the published pulse', async () => {
+    const user = userEvent.setup();
+    const saved: Array<{ clusterKey: string; label: string }> = [];
+
+    render(
+      <SiteAuthProvider
+        auth={createMemorySiteAuth({
+          status: 'authenticated',
+          email: 'owner@example.com',
+        })}
+      >
+        <JobMarketLabThemeLabelsPanel
+          publication={{
+            fetchPublished: async () => ({
+              documentCount: 2,
+              publishedAt: '2026-07-14T12:00:00.000Z',
+              skills: [],
+              seniority: [],
+              roleFamily: [],
+              clusters: [{ id: 0, size: 2, label: 'python, sql' }],
+              projection: [],
+            }),
+          }}
+          themeLabels={{
+            listOverrides: async () => [],
+            saveOverride: async (record) => {
+              saved.push(record);
+            },
+          }}
+        />
+      </SiteAuthProvider>,
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: jobMarketLab.console.themeLabelsHeading,
+      }),
+    ).toBeInTheDocument();
+
+    const input = await screen.findByDisplayValue('python, sql');
+    await user.clear(input);
+    await user.type(input, 'Core data engineering demand');
+    await user.click(
+      screen.getByRole('button', { name: jobMarketLab.console.themeLabelSaveLabel }),
+    );
+
+    await waitFor(() => {
+      expect(saved).toEqual([
+        { clusterKey: '0', label: 'Core data engineering demand' },
+      ]);
+    });
+    expect(
+      screen.getByText(
+        jobMarketLab.console.themeLabelSavedMessage.replace('{clusterKey}', '0'),
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-theme-labels-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-theme-labels-panel.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import {
+  getPublishedJobMarketSnapshot,
+  setThemeLabelOverride,
+  type ClusterSummary,
+  type GetPublishedJobMarketSnapshotDeps,
+  type ListThemeLabelOverridesDeps,
+  type SetThemeLabelOverrideDeps,
+} from '@/lib/job-market-lab';
+import { createDefaultAmplifyThemeLabelOverrideDeps } from '@/lib/job-market-theme-labels-amplify';
+
+export type JobMarketLabThemeLabelsPanelProps = {
+  publication?: GetPublishedJobMarketSnapshotDeps;
+  themeLabels?: ListThemeLabelOverridesDeps & SetThemeLabelOverrideDeps;
+};
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'empty' }
+  | { status: 'ready'; clusters: ClusterSummary[] }
+  | { status: 'error' };
+
+function formatSavedMessage(clusterKey: string): string {
+  return jobMarketLab.console.themeLabelSavedMessage.replace('{clusterKey}', clusterKey);
+}
+
+export function JobMarketLabThemeLabelsPanel({
+  publication,
+  themeLabels,
+}: JobMarketLabThemeLabelsPanelProps) {
+  const { session, isLoading } = useSiteAuth();
+  const [deps] = useState(
+    () => themeLabels ?? createDefaultAmplifyThemeLabelOverrideDeps(),
+  );
+  const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
+  const [draftLabels, setDraftLabels] = useState<Record<string, string>>({});
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [savedKey, setSavedKey] = useState<string | null>(null);
+
+  const loadClusters = useCallback(async () => {
+    const result = await getPublishedJobMarketSnapshot(publication);
+    if (result.status === 'empty') {
+      return { status: 'empty' as const };
+    }
+    return {
+      status: 'ready' as const,
+      clusters: result.snapshot.clusters,
+    };
+  }, [publication]);
+
+  useEffect(() => {
+    if (isLoading || session?.status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      setLoadState({ status: 'loading' });
+      try {
+        const next = await loadClusters();
+        if (!cancelled) {
+          setLoadState(next);
+          if (next.status === 'ready') {
+            setDraftLabels(
+              Object.fromEntries(
+                next.clusters.map((cluster) => [String(cluster.id), cluster.label]),
+              ),
+            );
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setLoadState({ status: 'error' });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, session, loadClusters]);
+
+  if (isLoading || session?.status !== 'authenticated') {
+    return null;
+  }
+
+  async function handleSave(clusterKey: string) {
+    const label = draftLabels[clusterKey]?.trim();
+    if (!label) {
+      return;
+    }
+
+    setPendingKey(clusterKey);
+    setSavedKey(null);
+    try {
+      await setThemeLabelOverride(clusterKey, label, deps);
+      setSavedKey(clusterKey);
+    } finally {
+      setPendingKey(null);
+    }
+  }
+
+  return (
+    <section className="mt-16 space-y-6" aria-labelledby="job-market-theme-labels-heading">
+      <div className="space-y-2">
+        <SectionHeader
+          id="job-market-theme-labels-heading"
+          as="h2"
+          size="md"
+          animated={false}
+          showLeftAccent={false}
+        >
+          {jobMarketLab.console.themeLabelsHeading}
+        </SectionHeader>
+        <Text variant="muted">{jobMarketLab.console.themeLabelsDescription}</Text>
+      </div>
+
+      {loadState.status === 'loading' || loadState.status === 'idle' ? (
+        <Text variant="muted">{jobMarketLab.console.themeLabelsLoading}</Text>
+      ) : null}
+
+      {loadState.status === 'error' ? (
+        <p role="alert" className="font-body text-lg leading-relaxed text-[var(--foreground)]">
+          {jobMarketLab.console.themeLabelsError}
+        </p>
+      ) : null}
+
+      {loadState.status === 'empty' ? (
+        <Text>{jobMarketLab.console.themeLabelsEmpty}</Text>
+      ) : null}
+
+      {loadState.status === 'ready' ? (
+        <ul className="space-y-4">
+          {loadState.clusters.map((cluster) => {
+            const clusterKey = String(cluster.id);
+            const inputId = `theme-label-${clusterKey}`;
+            return (
+              <li
+                key={clusterKey}
+                className="grid gap-3 border border-[color-mix(in_oklab,var(--foreground)_14%,transparent)] p-4 md:grid-cols-[minmax(0,1fr)_auto]"
+              >
+                <div className="space-y-2">
+                  <label className="block space-y-2" htmlFor={inputId}>
+                    <Text size="sm" variant="muted">
+                      {jobMarketLab.console.themeLabelInputLabel} ·{' '}
+                      {jobMarketLab.console.themeLabelSizeLabel}: {cluster.size}
+                    </Text>
+                    <input
+                      id={inputId}
+                      className="w-full border border-[color-mix(in_oklab,var(--foreground)_18%,transparent)] bg-transparent px-3 py-2 font-body text-sm"
+                      value={draftLabels[clusterKey] ?? cluster.label}
+                      onChange={(event) => {
+                        setDraftLabels((current) => ({
+                          ...current,
+                          [clusterKey]: event.target.value,
+                        }));
+                        setSavedKey(null);
+                      }}
+                    />
+                  </label>
+                  {savedKey === clusterKey ? (
+                    <p
+                      role="status"
+                      className="font-body text-base leading-normal text-[var(--foreground)]"
+                    >
+                      {formatSavedMessage(clusterKey)}
+                    </p>
+                  ) : null}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={pendingKey === clusterKey}
+                  onClick={() => {
+                    void handleSave(clusterKey);
+                  }}
+                >
+                  {pendingKey === clusterKey
+                    ? jobMarketLab.console.themeLabelSavingLabel
+                    : jobMarketLab.console.themeLabelSaveLabel}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -86,6 +86,16 @@
       "savingLabel": "Saving…",
       "savedMessage": "Canonical CV saved.",
       "errorLabel": "Canonical CV is temporarily unavailable."
-    }
+    },
+    "themeLabelsHeading": "Theme label overrides",
+    "themeLabelsDescription": "Rename requirement themes for the published pulse. Overrides take effect on the next recompute and use the same publication path as the public lab view.",
+    "themeLabelsEmpty": "No published themes yet. Start a recompute after the corpus has active documents.",
+    "themeLabelsLoading": "Loading published themes…",
+    "themeLabelsError": "Theme label overrides are temporarily unavailable.",
+    "themeLabelInputLabel": "Theme label",
+    "themeLabelSaveLabel": "Save override",
+    "themeLabelSavingLabel": "Saving…",
+    "themeLabelSavedMessage": "Override saved for theme {clusterKey}. It will appear after the next recompute.",
+    "themeLabelSizeLabel": "Documents"
   }
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -222,6 +222,16 @@ export interface JobMarketLabConsoleCopy {
   runStatusFailed: string;
   failureReasonLabel: string;
   cv: JobMarketLabCvCopy;
+  themeLabelsHeading: string;
+  themeLabelsDescription: string;
+  themeLabelsEmpty: string;
+  themeLabelsLoading: string;
+  themeLabelsError: string;
+  themeLabelInputLabel: string;
+  themeLabelSaveLabel: string;
+  themeLabelSavingLabel: string;
+  themeLabelSavedMessage: string;
+  themeLabelSizeLabel: string;
 }
 
 export interface JobMarketLabPageData {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -214,6 +214,16 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(cv, 'savingLabel', 'jobMarketLab.console.cv');
   requireString(cv, 'savedMessage', 'jobMarketLab.console.cv');
   requireString(cv, 'errorLabel', 'jobMarketLab.console.cv');
+  requireString(consoleCopy, 'themeLabelsHeading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelsDescription', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelsEmpty', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelsLoading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelsError', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelInputLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelSaveLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelSavingLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelSavedMessage', 'jobMarketLab.console');
+  requireString(consoleCopy, 'themeLabelSizeLabel', 'jobMarketLab.console');
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -185,3 +185,17 @@ export {
 } from './scrape-candidates-amplify';
 
 export { createDefaultPutCandidateObject } from './scrape-candidates-client';
+
+export {
+  listThemeLabelOverrides,
+  setThemeLabelOverride,
+  type ThemeLabelOverrideRecord,
+  type ListThemeLabelOverridesDeps,
+  type SetThemeLabelOverrideDeps,
+} from './job-market-theme-labels';
+
+export {
+  createAmplifyThemeLabelOverrideDeps,
+  createDefaultAmplifyThemeLabelOverrideDeps,
+  type AmplifyThemeLabelOverrideModelClient,
+} from './job-market-theme-labels-amplify';

--- a/src/lib/job-market-theme-labels-amplify.test.ts
+++ b/src/lib/job-market-theme-labels-amplify.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAmplifyThemeLabelOverrideDeps,
+  type AmplifyThemeLabelOverrideModelClient,
+} from './job-market-theme-labels-amplify';
+import {
+  listThemeLabelOverrides,
+  setThemeLabelOverride,
+} from './job-market-theme-labels';
+
+function createMemoryClient(): AmplifyThemeLabelOverrideModelClient & {
+  rows: Map<string, { clusterKey: string; label: string }>;
+} {
+  const rows = new Map<string, { clusterKey: string; label: string }>();
+
+  return {
+    rows,
+    async list() {
+      return { data: [...rows.values()], errors: null };
+    },
+    async get(input) {
+      return { data: rows.get(input.id) ?? null, errors: null };
+    },
+    async create(input) {
+      rows.set(input.id, {
+        clusterKey: input.clusterKey,
+        label: input.label,
+      });
+      return { data: rows.get(input.id) ?? null, errors: null };
+    },
+    async update(input) {
+      const existing = rows.get(input.id);
+      if (!existing) {
+        return { data: null, errors: [{ message: 'Not found' }] };
+      }
+      rows.set(input.id, {
+        clusterKey: input.clusterKey ?? existing.clusterKey,
+        label: input.label ?? existing.label,
+      });
+      return { data: rows.get(input.id) ?? null, errors: null };
+    },
+  };
+}
+
+describe('job-market-theme-labels amplify adapter', () => {
+  it('lists and upserts overrides through the facade seam', async () => {
+    const client = createMemoryClient();
+    const deps = createAmplifyThemeLabelOverrideDeps(client);
+
+    await setThemeLabelOverride('1', 'Visual analytics demand', deps);
+    await setThemeLabelOverride('1', 'Updated analytics demand', deps);
+
+    const overrides = await listThemeLabelOverrides(deps);
+    expect(overrides).toEqual([
+      { clusterKey: '1', label: 'Updated analytics demand' },
+    ]);
+  });
+});

--- a/src/lib/job-market-theme-labels-amplify.ts
+++ b/src/lib/job-market-theme-labels-amplify.ts
@@ -1,0 +1,114 @@
+import type {
+  ListThemeLabelOverridesDeps,
+  SetThemeLabelOverrideDeps,
+  ThemeLabelOverrideRecord,
+} from './job-market-theme-labels';
+
+export type AmplifyThemeLabelOverrideRow = {
+  clusterKey: string;
+  label: string;
+};
+
+type AmplifyDataResult<T> = {
+  data: T;
+  errors?: Array<{ message: string }> | null;
+};
+
+export type AmplifyThemeLabelOverrideModelClient = {
+  list: () => Promise<AmplifyDataResult<AmplifyThemeLabelOverrideRow[] | null>>;
+  get: (input: { id: string }) => Promise<AmplifyDataResult<AmplifyThemeLabelOverrideRow | null>>;
+  create: (
+    input: { id: string; clusterKey: string; label: string },
+  ) => Promise<AmplifyDataResult<AmplifyThemeLabelOverrideRow | null>>;
+  update: (
+    input: { id: string; clusterKey?: string; label?: string },
+  ) => Promise<AmplifyDataResult<AmplifyThemeLabelOverrideRow | null>>;
+};
+
+function throwIfErrors(errors: Array<{ message: string }> | null | undefined): void {
+  if (errors?.length) {
+    throw new Error(errors.map((error) => error.message).join('; '));
+  }
+}
+
+export function createAmplifyThemeLabelOverrideDeps(
+  client: AmplifyThemeLabelOverrideModelClient,
+): ListThemeLabelOverridesDeps & SetThemeLabelOverrideDeps {
+  return {
+    async listOverrides() {
+      const { data, errors } = await client.list();
+      throwIfErrors(errors);
+      return (data ?? []).map((row) => ({
+        clusterKey: row.clusterKey,
+        label: row.label,
+      }));
+    },
+    async saveOverride(record: ThemeLabelOverrideRecord) {
+      const existing = await client.get({ id: record.clusterKey });
+      throwIfErrors(existing.errors);
+
+      if (existing.data) {
+        const { errors } = await client.update({
+          id: record.clusterKey,
+          clusterKey: record.clusterKey,
+          label: record.label,
+        });
+        throwIfErrors(errors);
+        return;
+      }
+
+      const { errors } = await client.create({
+        id: record.clusterKey,
+        clusterKey: record.clusterKey,
+        label: record.label,
+      });
+      throwIfErrors(errors);
+    },
+  };
+}
+
+type AmplifyDataModelsClient = {
+  models: {
+    ThemeLabelOverride: {
+      list: AmplifyThemeLabelOverrideModelClient['list'];
+      get: AmplifyThemeLabelOverrideModelClient['get'];
+      create: AmplifyThemeLabelOverrideModelClient['create'];
+      update: AmplifyThemeLabelOverrideModelClient['update'];
+    };
+  };
+};
+
+export function createAmplifyThemeLabelOverrideModelClient(
+  getClient: () => Promise<AmplifyDataModelsClient> = defaultGetAmplifyDataClient,
+): AmplifyThemeLabelOverrideModelClient {
+  return {
+    async list() {
+      const client = await getClient();
+      return client.models.ThemeLabelOverride.list();
+    },
+    async get(input) {
+      const client = await getClient();
+      return client.models.ThemeLabelOverride.get(input);
+    },
+    async create(input) {
+      const client = await getClient();
+      return client.models.ThemeLabelOverride.create(input);
+    },
+    async update(input) {
+      const client = await getClient();
+      return client.models.ThemeLabelOverride.update(input);
+    },
+  };
+}
+
+async function defaultGetAmplifyDataClient(): Promise<AmplifyDataModelsClient> {
+  const { generateClient } = await import('aws-amplify/data');
+  return generateClient() as unknown as AmplifyDataModelsClient;
+}
+
+export function createDefaultAmplifyThemeLabelOverrideDeps(): ListThemeLabelOverridesDeps &
+  SetThemeLabelOverrideDeps {
+  return createAmplifyThemeLabelOverrideDeps(
+    createAmplifyThemeLabelOverrideModelClient(),
+  );
+}

--- a/src/lib/job-market-theme-labels.test.ts
+++ b/src/lib/job-market-theme-labels.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  listThemeLabelOverrides,
+  setThemeLabelOverride,
+  type ThemeLabelOverrideRecord,
+} from './job-market-theme-labels';
+
+describe('job-market-theme-labels facade', () => {
+  it('lists stored theme label overrides', async () => {
+    const overrides: ThemeLabelOverrideRecord[] = [
+      { clusterKey: '1', label: 'Visual analytics demand' },
+    ];
+
+    const result = await listThemeLabelOverrides({
+      listOverrides: async () => overrides,
+    });
+
+    expect(result).toEqual(overrides);
+  });
+
+  it('rejects blank override labels', async () => {
+    await expect(
+      setThemeLabelOverride('0', '   ', {
+        saveOverride: async () => undefined,
+      }),
+    ).rejects.toThrow('Theme label override cannot be empty');
+  });
+
+  it('persists a trimmed override label by cluster key', async () => {
+    const saved: ThemeLabelOverrideRecord[] = [];
+
+    await setThemeLabelOverride('0', '  Core data engineering demand  ', {
+      saveOverride: async (record) => {
+        saved.push(record);
+      },
+    });
+
+    expect(saved).toEqual([
+      { clusterKey: '0', label: 'Core data engineering demand' },
+    ]);
+  });
+});

--- a/src/lib/job-market-theme-labels.ts
+++ b/src/lib/job-market-theme-labels.ts
@@ -1,0 +1,41 @@
+export type ThemeLabelOverrideRecord = {
+  clusterKey: string;
+  label: string;
+};
+
+export type ListThemeLabelOverridesDeps = {
+  listOverrides?: () => Promise<ThemeLabelOverrideRecord[]>;
+};
+
+export type SetThemeLabelOverrideDeps = {
+  saveOverride?: (record: ThemeLabelOverrideRecord) => Promise<void>;
+};
+
+export async function listThemeLabelOverrides(
+  deps: ListThemeLabelOverridesDeps = {},
+): Promise<ThemeLabelOverrideRecord[]> {
+  if (!deps.listOverrides) {
+    return [];
+  }
+  return deps.listOverrides();
+}
+
+export async function setThemeLabelOverride(
+  clusterKey: string,
+  label: string,
+  deps: SetThemeLabelOverrideDeps = {},
+): Promise<void> {
+  const trimmed = label.trim();
+  if (!trimmed) {
+    throw new Error('Theme label override cannot be empty');
+  }
+
+  if (!deps.saveOverride) {
+    throw new Error('Theme label overrides are not configured');
+  }
+
+  await deps.saveOverride({
+    clusterKey,
+    label: trimmed,
+  });
+}


### PR DESCRIPTION
## Summary
- Derive requirement theme labels from top matched technologies in each cluster (fallback: "Requirement theme {n}") instead of Theme N placeholders; no LLM on the recompute path.
- Add authenticated ThemeLabelOverride storage and apply overrides when publishing snapshots so guest and owner views share the same publication pulse.
- Add owner console panel to edit theme label overrides against the published snapshot, with British English copy in the data layer.

Closes #69

## Test plan
- [x] npm test — 175 tests passed (47 files), including analyse label/override seams, run orchestration, theme-label facades, and console panel UI.
- [ ] Deploy Amplify sandbox and verify recompute publishes technology-based labels.
- [ ] Save a theme override in the owner console, recompute, and confirm guest /labs/job-market shows the overridden label.
