### PR TITLE
Optional LLM assist on HITL accept

### DIFF
--- a/src/components/sections/labs/job-market-lab-hitl-queue-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-hitl-queue-panel.test.tsx
@@ -87,7 +87,7 @@ describe('JobMarketLabHitlQueuePanel', () => {
     expect(screen.getByText('example-board')).toBeInTheDocument();
   });
 
-  it('accepts a candidate through the injected facade', async () => {
+  it('accepts a candidate through the injected facade without LLM assist by default', async () => {
     const acceptScrapeCandidateFn = vi.fn(async () => ({
       status: 'accepted' as const,
       s3Key: 'raw/quant-analyst.md',
@@ -104,13 +104,37 @@ describe('JobMarketLabHitlQueuePanel', () => {
     );
 
     await waitFor(() => {
-      expect(acceptScrapeCandidateFn).toHaveBeenCalledWith('c-1');
+      expect(acceptScrapeCandidateFn).toHaveBeenCalledWith('c-1', { llmAssist: false });
     });
     expect(
       screen.getByText(
         jobMarketLab.hitlQueue.acceptedMessage.replace('{s3Key}', 'raw/quant-analyst.md'),
       ),
     ).toBeInTheDocument();
+  });
+
+  it('passes llmAssist true when the owner opts into LLM assist', async () => {
+    const acceptScrapeCandidateFn = vi.fn(async () => ({
+      status: 'accepted' as const,
+      s3Key: 'raw/quant-analyst.md',
+      candidate: pendingCandidate({ id: 'c-1', status: 'accepted' }),
+    }));
+
+    renderPanel({
+      candidates: [pendingCandidate({ id: 'c-1' })],
+      acceptScrapeCandidateFn,
+    });
+
+    fireEvent.click(
+      await screen.findByRole('checkbox', { name: jobMarketLab.hitlQueue.llmAssistLabel }),
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: jobMarketLab.hitlQueue.acceptLabel }),
+    );
+
+    await waitFor(() => {
+      expect(acceptScrapeCandidateFn).toHaveBeenCalledWith('c-1', { llmAssist: true });
+    });
   });
 
   it('rejects a candidate without promoting to raw/', async () => {

--- a/src/components/sections/labs/job-market-lab-hitl-queue-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-hitl-queue-panel.tsx
@@ -16,6 +16,7 @@ import {
 import {
   createDefaultAmplifyScrapeCandidateDeps,
 } from '@/lib/scrape-candidates-amplify';
+import { defaultAssistWithLlm } from '@/lib/scrape-candidates-llm-assist';
 
 export type ScrapeCandidateQueueDeps = {
   listScrapeCandidates: () => Promise<ScrapeCandidateRecord[]>;
@@ -25,6 +26,7 @@ export type ScrapeCandidateQueueDeps = {
 
 export type AcceptScrapeCandidateFn = (
   id: string,
+  options?: { llmAssist?: boolean },
 ) => Promise<AcceptScrapeCandidateResult>;
 
 export type RejectScrapeCandidateFn = (
@@ -49,11 +51,16 @@ type ActionFeedback =
   | { kind: 'error'; reason: string };
 
 function defaultAcceptFn(deps: ScrapeCandidateQueueDeps): AcceptScrapeCandidateFn {
-  return (id) =>
-    acceptScrapeCandidate(id, {
-      ...deps,
-      uploadJobDescription,
-    });
+  return (id, options) =>
+    acceptScrapeCandidate(
+      id,
+      {
+        ...deps,
+        uploadJobDescription,
+        assistWithLlm: defaultAssistWithLlm,
+      },
+      options,
+    );
 }
 
 function defaultRejectFn(deps: ScrapeCandidateQueueDeps): RejectScrapeCandidateFn {
@@ -77,6 +84,7 @@ export function JobMarketLabHitlQueuePanel({
     null,
   );
   const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+  const [llmAssistOptIn, setLlmAssistOptIn] = useState(false);
 
   const loadCandidates = useCallback(async () => {
     return listPendingScrapeCandidates(deps);
@@ -126,7 +134,7 @@ export function JobMarketLabHitlQueuePanel({
     setPendingAction('accept');
     setFeedback(null);
     try {
-      const result = await acceptFn(id);
+      const result = await acceptFn(id, { llmAssist: llmAssistOptIn });
       if (result.status === 'accepted') {
         setFeedback({ kind: 'accepted', s3Key: result.s3Key });
         await refresh();
@@ -180,6 +188,21 @@ export function JobMarketLabHitlQueuePanel({
           {jobMarketLab.hitlQueue.heading}
         </SectionHeader>
         <Text variant="muted">{jobMarketLab.hitlQueue.description}</Text>
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={llmAssistOptIn}
+            onChange={(event) => setLlmAssistOptIn(event.target.checked)}
+            aria-label={jobMarketLab.hitlQueue.llmAssistLabel}
+          />
+          <span className="space-y-1">
+            <Text size="sm">{jobMarketLab.hitlQueue.llmAssistLabel}</Text>
+            <Text size="sm" variant="muted">
+              {jobMarketLab.hitlQueue.llmAssistDescription}
+            </Text>
+          </span>
+        </label>
       </div>
 
       {loadState.status === 'loading' || loadState.status === 'idle' ? (

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -54,7 +54,9 @@
     "rejectingLabel": "RejectingÔÇª",
     "acceptedMessage": "Accepted into {s3Key}. Ingest will update corpus metadata shortly.",
     "rejectedMessage": "Candidate rejected and will not enter the corpus.",
-    "actionErrorHeading": "Could not update scrape candidate"
+    "actionErrorHeading": "Could not update scrape candidate",
+    "llmAssistLabel": "Use LLM assist to fill missing fields",
+    "llmAssistDescription": "Optional. Infers title, source, or collection date when absent. Accept still works without it."
   },
   "console": {
     "heading": "Job market owner console",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -202,6 +202,8 @@ export interface JobMarketLabHitlQueueCopy {
   acceptedMessage: string;
   rejectedMessage: string;
   actionErrorHeading: string;
+  llmAssistLabel: string;
+  llmAssistDescription: string;
 }
 
 export interface JobMarketLabEmployerAdminCopy {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -184,6 +184,8 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(hitlQueue, 'acceptedMessage', 'jobMarketLab.hitlQueue');
   requireString(hitlQueue, 'rejectedMessage', 'jobMarketLab.hitlQueue');
   requireString(hitlQueue, 'actionErrorHeading', 'jobMarketLab.hitlQueue');
+  requireString(hitlQueue, 'llmAssistLabel', 'jobMarketLab.hitlQueue');
+  requireString(hitlQueue, 'llmAssistDescription', 'jobMarketLab.hitlQueue');
   const employerAdmin = requireRecord(page.employerAdmin, 'jobMarketLab.employerAdmin');
   requireString(employerAdmin, 'heading', 'jobMarketLab.employerAdmin');
   requireString(employerAdmin, 'description', 'jobMarketLab.employerAdmin');

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -173,12 +173,17 @@ export {
   listPendingScrapeCandidates,
   listScrapeCandidates,
   rejectScrapeCandidate,
+  type AcceptScrapeCandidateOptions,
   type AcceptScrapeCandidateResult,
+  type AssistWithLlm,
   type EnqueueScrapeCandidateResult,
   type RejectScrapeCandidateResult,
+  type ScrapeCandidateLlmEnrichment,
   type ScrapeCandidateRecord,
   type ScrapeCandidateStatus,
 } from './scrape-candidates';
+
+export { defaultAssistWithLlm } from './scrape-candidates-llm-assist';
 
 export {
   createAmplifyScrapeCandidateDeps,

--- a/src/lib/scrape-candidates-llm-assist.test.ts
+++ b/src/lib/scrape-candidates-llm-assist.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  defaultAssistWithLlm,
+  LLM_ASSIST_ENABLED_ENV,
+} from './scrape-candidates-llm-assist';
+import type { ScrapeCandidateRecord } from './scrape-candidates';
+
+const candidate: ScrapeCandidateRecord = {
+  id: 'candidate-1',
+  fileName: 'role.md',
+  body: `---
+collectedAt: 2026-06-15T10:00:00.000Z
+---
+
+# Role title
+`,
+  status: 'pending',
+};
+
+describe('defaultAssistWithLlm', () => {
+  it('returns no enrichment when LLM assist is not enabled via environment', async () => {
+    vi.stubEnv(LLM_ASSIST_ENABLED_ENV, '');
+
+    const enrichment = await defaultAssistWithLlm(candidate);
+
+    expect(enrichment).toEqual({});
+  });
+
+  it('returns no enrichment when enabled but Bedrock adapter is not implemented yet', async () => {
+    vi.stubEnv(LLM_ASSIST_ENABLED_ENV, 'true');
+
+    const enrichment = await defaultAssistWithLlm(candidate);
+
+    expect(enrichment).toEqual({});
+  });
+});

--- a/src/lib/scrape-candidates-llm-assist.ts
+++ b/src/lib/scrape-candidates-llm-assist.ts
@@ -1,0 +1,15 @@
+import type { ScrapeCandidateLlmEnrichment, ScrapeCandidateRecord } from './scrape-candidates';
+
+export const LLM_ASSIST_ENABLED_ENV = 'NEXT_PUBLIC_JOB_MARKET_LLM_ASSIST_ENABLED';
+
+export async function defaultAssistWithLlm(
+  _candidate: ScrapeCandidateRecord,
+): Promise<ScrapeCandidateLlmEnrichment> {
+  // TODO(#76): invoke Bedrock to infer missing title, source, and collectedAt from body text
+  // when LLM assist is enabled via environment configuration.
+  if (process.env[LLM_ASSIST_ENABLED_ENV] !== 'true') {
+    return {};
+  }
+
+  return {};
+}

--- a/src/lib/scrape-candidates-recompute-isolation.test.ts
+++ b/src/lib/scrape-candidates-recompute-isolation.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const libDir = dirname(fileURLToPath(import.meta.url));
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(libDir, relativePath), 'utf8');
+}
+
+describe('recompute path LLM isolation', () => {
+  it('does not invoke scrape LLM assist from the recompute client', () => {
+    const source = readSource('./start-job-market-recompute-client.ts');
+
+    expect(source).not.toMatch(/assistWithLlm|defaultAssistWithLlm|scrape-candidates-llm-assist/);
+  });
+
+  it('does not invoke scrape LLM assist from the recompute orchestrator', () => {
+    const source = readSource('../../amplify/functions/job-market-recompute/orchestrator.ts');
+
+    expect(source).not.toMatch(/assistWithLlm|defaultAssistWithLlm|scrape-candidates-llm-assist/);
+  });
+});

--- a/src/lib/scrape-candidates.test.ts
+++ b/src/lib/scrape-candidates.test.ts
@@ -191,6 +191,98 @@ describe('acceptScrapeCandidate', () => {
     });
     expect(saveScrapeCandidate).not.toHaveBeenCalled();
   });
+
+  it('does not call LLM assist by default', async () => {
+    const candidate = pendingCandidate({ id: 'candidate-no-llm' });
+    const assistWithLlm = vi.fn(async () => ({
+      title: 'LLM title',
+    }));
+    const uploadJobDescription = vi.fn(async () => ({
+      status: 'uploaded' as const,
+      s3Key: 'raw/senior-data-scientist.md',
+    }));
+
+    await acceptScrapeCandidate('candidate-no-llm', {
+      getScrapeCandidate: async () => candidate,
+      saveScrapeCandidate: async () => undefined,
+      uploadJobDescription,
+      assistWithLlm,
+    });
+
+    expect(assistWithLlm).not.toHaveBeenCalled();
+    expect(uploadJobDescription).toHaveBeenCalledWith({
+      fileName: 'senior-data-scientist.md',
+      body: validBody,
+    });
+  });
+
+  it('uses injectable LLM assist when explicitly opted in', async () => {
+    const candidate = pendingCandidate({
+      id: 'candidate-llm',
+      title: undefined,
+      source: undefined,
+    });
+    const enrichedBody = `---
+collectedAt: 2026-06-15T10:00:00.000Z
+title: Inferred title
+source: inferred-board
+---
+
+# Senior Data Scientist
+`;
+    const assistWithLlm = vi.fn(async () => ({
+      title: 'Inferred title',
+      source: 'inferred-board',
+      body: enrichedBody,
+    }));
+    const uploadJobDescription = vi.fn(async () => ({
+      status: 'uploaded' as const,
+      s3Key: 'raw/senior-data-scientist.md',
+    }));
+
+    const result = await acceptScrapeCandidate(
+      'candidate-llm',
+      {
+        getScrapeCandidate: async () => candidate,
+        saveScrapeCandidate: async () => undefined,
+        uploadJobDescription,
+        assistWithLlm,
+      },
+      { llmAssist: true },
+    );
+
+    expect(result.status).toBe('accepted');
+    expect(assistWithLlm).toHaveBeenCalledOnce();
+    expect(assistWithLlm).toHaveBeenCalledWith(candidate);
+    expect(uploadJobDescription).toHaveBeenCalledWith({
+      fileName: 'senior-data-scientist.md',
+      body: enrichedBody,
+    });
+  });
+
+  it('accepts without LLM assist when opted in but no adapter is configured', async () => {
+    const candidate = pendingCandidate({ id: 'candidate-llm-no-adapter' });
+    const uploadJobDescription = vi.fn(async () => ({
+      status: 'uploaded' as const,
+      s3Key: 'raw/senior-data-scientist.md',
+    }));
+
+    const result = await acceptScrapeCandidate(
+      'candidate-llm-no-adapter',
+      {
+        getScrapeCandidate: async () => candidate,
+        saveScrapeCandidate: async () => undefined,
+        uploadJobDescription,
+      },
+      { llmAssist: true },
+    );
+
+    expect(result.status).toBe('accepted');
+    expect(uploadJobDescription).toHaveBeenCalledWith({
+      fileName: 'senior-data-scientist.md',
+      body: validBody,
+    });
+  });
 });
 
 describe('rejectScrapeCandidate', () => {

--- a/src/lib/scrape-candidates.ts
+++ b/src/lib/scrape-candidates.ts
@@ -47,6 +47,19 @@ export type AcceptScrapeCandidateDeps = ScrapeCandidateStoreDeps & {
     input: { fileName: string; body: string },
     deps?: UploadJobDescriptionDeps,
   ) => Promise<UploadJobDescriptionResult>;
+  assistWithLlm?: AssistWithLlm;
+};
+
+export type ScrapeCandidateLlmEnrichment = Partial<
+  Pick<ScrapeCandidateRecord, 'title' | 'source' | 'collectedAt' | 'body'>
+>;
+
+export type AssistWithLlm = (
+  candidate: ScrapeCandidateRecord,
+) => Promise<ScrapeCandidateLlmEnrichment>;
+
+export type AcceptScrapeCandidateOptions = {
+  llmAssist?: boolean;
 };
 
 export type AcceptScrapeCandidateResult =
@@ -106,6 +119,51 @@ function metadataFromBody(body: string): Pick<
   };
 }
 
+function applyLlmEnrichment(
+  existing: ScrapeCandidateRecord,
+  enrichment: ScrapeCandidateLlmEnrichment,
+): Pick<ScrapeCandidateRecord, 'body' | 'title' | 'source' | 'collectedAt'> {
+  const title = existing.title ?? enrichment.title;
+  const source = existing.source ?? enrichment.source;
+  const collectedAt = existing.collectedAt ?? enrichment.collectedAt;
+
+  if (enrichment.body) {
+    return {
+      body: enrichment.body,
+      title,
+      source,
+      collectedAt,
+    };
+  }
+
+  const parsed = matter(existing.body);
+  const nextData = { ...(parsed.data as Record<string, unknown>) };
+
+  if (title !== undefined && existing.title === undefined) {
+    nextData.title = title;
+  }
+  if (source !== undefined && existing.source === undefined) {
+    nextData.source = source;
+  }
+  if (collectedAt !== undefined && existing.collectedAt === undefined) {
+    nextData.collectedAt = collectedAt;
+  }
+
+  const body =
+    title !== existing.title ||
+    source !== existing.source ||
+    collectedAt !== existing.collectedAt
+      ? matter.stringify(parsed.content, nextData)
+      : existing.body;
+
+  return {
+    body,
+    title,
+    source,
+    collectedAt,
+  };
+}
+
 export async function listPendingScrapeCandidates(
   deps: ListScrapeCandidatesDeps,
 ): Promise<ScrapeCandidateRecord[]> {
@@ -159,6 +217,7 @@ export async function enqueueScrapeCandidate(
 export async function acceptScrapeCandidate(
   id: string,
   deps: AcceptScrapeCandidateDeps,
+  options: AcceptScrapeCandidateOptions = {},
 ): Promise<AcceptScrapeCandidateResult> {
   const existing = await deps.getScrapeCandidate(id);
   if (!existing) {
@@ -169,9 +228,28 @@ export async function acceptScrapeCandidate(
     return { status: 'not_pending' };
   }
 
+  const llmAssist = options.llmAssist ?? false;
+  let acceptBody = existing.body;
+  let enrichedFields: Pick<ScrapeCandidateRecord, 'title' | 'source' | 'collectedAt'> = {
+    title: existing.title,
+    source: existing.source,
+    collectedAt: existing.collectedAt,
+  };
+
+  if (llmAssist && deps.assistWithLlm) {
+    const enrichment = await deps.assistWithLlm(existing);
+    const applied = applyLlmEnrichment(existing, enrichment);
+    acceptBody = applied.body;
+    enrichedFields = {
+      title: applied.title,
+      source: applied.source,
+      collectedAt: applied.collectedAt,
+    };
+  }
+
   const uploadResult = await deps.uploadJobDescription({
     fileName: existing.fileName,
-    body: existing.body,
+    body: acceptBody,
   });
 
   if (uploadResult.status === 'rejected') {
@@ -180,6 +258,8 @@ export async function acceptScrapeCandidate(
 
   const candidate: ScrapeCandidateRecord = {
     ...existing,
+    ...enrichedFields,
+    body: acceptBody,
     status: 'accepted',
   };
   await deps.saveScrapeCandidate(candidate);


### PR DESCRIPTION
## Summary
- Extend `acceptScrapeCandidate` with an opt-in `llmAssist` flag (default false) and an injectable `assistWithLlm` seam that fills missing structured fields before promotion to `raw/`.
- Add an owner checkbox on the HITL queue panel with British English copy; accept still works without assist.
- Ship a gated `defaultAssistWithLlm` stub (TODO for Bedrock) and Vitest coverage confirming assist is off by default and the recompute path is untouched.

Closes #76

## Test plan
- [x] `npm test` (224 tests)
- [x] Facade tests: assist off by default; opt-in uses injectable adapter; accept succeeds without adapter
- [x] UI tests: checkbox passes `llmAssist: true` on accept
- [x] Isolation tests: recompute client and orchestrator do not reference LLM assist