### PR TITLE
Owner pay and prestige analytics

### DIFF
--- a/src/components/sections/labs/job-market-lab-console-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.test.tsx
@@ -115,6 +115,9 @@ describe('JobMarketLabConsoleSection', () => {
       screen.getByRole('heading', { name: jobMarketLab.metadataAdmin.heading }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: jobMarketLab.payPrestigeAnalytics.heading }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
     ).toBeInTheDocument();
     expect(

--- a/src/components/sections/labs/job-market-lab-console-section.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.tsx
@@ -8,6 +8,7 @@ import { JobMarketLabCvPanel } from '@/components/sections/labs/job-market-lab-c
 import { JobMarketLabEmployerAdmin } from '@/components/sections/labs/job-market-lab-employer-admin';
 import { JobMarketLabHitlQueuePanel } from '@/components/sections/labs/job-market-lab-hitl-queue-panel';
 import { JobMarketLabMetadataAdmin } from '@/components/sections/labs/job-market-lab-metadata-admin';
+import { JobMarketLabPayPrestigeAnalyticsPanel } from '@/components/sections/labs/job-market-lab-pay-prestige-analytics-panel';
 import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
 import { JobMarketLabThemeLabelsPanel } from '@/components/sections/labs/job-market-lab-theme-labels-panel';
 import { JobMarketLabUploadPanel } from '@/components/sections/labs/job-market-lab-upload-panel';
@@ -79,6 +80,7 @@ export function JobMarketLabConsoleSection({
         <JobMarketLabHitlQueuePanel />
         <JobMarketLabEmployerAdmin />
         <JobMarketLabMetadataAdmin corpus={corpus} />
+        <JobMarketLabPayPrestigeAnalyticsPanel />
         <JobMarketLabCorpusAdmin corpus={corpus} />
         <JobMarketLabThemeLabelsPanel />
         <JobMarketLabRunsPanel analysisRuns={analysisRuns} />

--- a/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobMarketLabPayPrestigeAnalyticsPanel } from '@/components/sections/labs/job-market-lab-pay-prestige-analytics-panel';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+import type { GetOwnerPayPrestigeAnalyticsDeps } from '@/lib/job-market-lab';
+import type { JobDescriptionCorpusRecord } from '@/lib/job-market-corpus';
+import type { EmployerRecord } from '@/lib/job-market-employers';
+
+afterEach(() => {
+  cleanup();
+});
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    title: 'Data scientist',
+    ...overrides,
+  };
+}
+
+function createMemoryAnalyticsDeps(): GetOwnerPayPrestigeAnalyticsDeps {
+  const employers: EmployerRecord[] = [
+    { id: 'emp-1', name: 'Alpha Bank', sizeTier: 'enterprise', prestigeTier: 'elite' },
+  ];
+
+  return {
+    listJobDescriptions: async () => [
+      doc({
+        id: 'jd-1',
+        employerId: 'emp-1',
+        compensationCurrency: 'GBP',
+        compensationMin: 90000,
+        compensationMax: 110000,
+        compensationPeriod: 'year',
+      }),
+      doc({ id: 'jd-2' }),
+    ],
+    listEmployers: async () => employers,
+  };
+}
+
+function renderPanel(
+  auth = createMemorySiteAuth(),
+  analytics = createMemoryAnalyticsDeps(),
+) {
+  return render(
+    <SiteAuthProvider auth={auth}>
+      <JobMarketLabPayPrestigeAnalyticsPanel analytics={analytics} />
+    </SiteAuthProvider>,
+  );
+}
+
+const ownerAuth = () =>
+  createMemorySiteAuth({ status: 'authenticated', email: 'owner@example.com' });
+
+describe('JobMarketLabPayPrestigeAnalyticsPanel', () => {
+  it('shows no analytics controls to guests', async () => {
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking session/i)).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('heading', {
+        name: jobMarketLab.payPrestigeAnalytics.heading,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders compensation and tier analytics for authenticated owners', async () => {
+    renderPanel(ownerAuth());
+
+    expect(
+      await screen.findByRole('heading', {
+        name: jobMarketLab.payPrestigeAnalytics.heading,
+      }),
+    ).toBeInTheDocument();
+
+    expect(await screen.findByText('2')).toBeInTheDocument();
+    expect(
+      screen.getByText(jobMarketLab.payPrestigeAnalytics.missingDataHeading),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(jobMarketLab.payPrestigeAnalytics.missingFieldLabels.employerLink),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(jobMarketLab.payPrestigeAnalytics.prestigeHeading),
+    ).toBeInTheDocument();
+    expect(screen.getByText('elite')).toBeInTheDocument();
+    expect(
+      screen.getByText(jobMarketLab.payPrestigeAnalytics.compensationHeading),
+    ).toBeInTheDocument();
+    expect(screen.getByText('GBP')).toBeInTheDocument();
+    expect(screen.getByText(/£90,000/)).toBeInTheDocument();
+  });
+
+  it('shows an error when analytics loading fails', async () => {
+    renderPanel(ownerAuth(), {
+      listJobDescriptions: async () => {
+        throw new Error('network');
+      },
+      listEmployers: async () => [],
+    });
+
+    expect(
+      await screen.findByText(jobMarketLab.payPrestigeAnalytics.errorLabel),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Heading, SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
+import {
+  getOwnerPayPrestigeAnalytics,
+  type GetOwnerPayPrestigeAnalyticsDeps,
+  type OwnerPayPrestigeAnalytics,
+  type TierBucket,
+} from '@/lib/job-market-lab';
+import { createDefaultAmplifyPayPrestigeAnalyticsDeps } from '@/lib/job-market-pay-prestige-analytics-amplify';
+import { cn } from '@/lib/utils';
+
+export type JobMarketLabPayPrestigeAnalyticsPanelProps = {
+  analytics?: GetOwnerPayPrestigeAnalyticsDeps;
+};
+
+function formatPercent(rate: number): string {
+  return new Intl.NumberFormat('en-GB', {
+    style: 'percent',
+    maximumFractionDigits: 0,
+  }).format(rate);
+}
+
+function formatCurrency(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount.toLocaleString('en-GB')}`;
+  }
+}
+
+function TierBars({ items, labelledBy }: { items: TierBucket[]; labelledBy: string }) {
+  const max = Math.max(...items.map((item) => item.count), 1);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  return (
+    <ul className="space-y-3" aria-labelledby={labelledBy}>
+      {items.map((item) => (
+        <li
+          key={item.tier}
+          className="grid grid-cols-[minmax(0,7rem)_1fr_auto] items-center gap-3"
+        >
+          <Text size="sm" className="truncate">
+            {item.tier}
+          </Text>
+          <div
+            className="h-2 overflow-hidden rounded-sm bg-[color-mix(in_oklab,var(--foreground)_12%,transparent)]"
+            role="presentation"
+          >
+            <div
+              className={cn(
+                'h-full rounded-sm bg-[var(--foreground)]',
+                !prefersReducedMotion && 'transition-[width] duration-500 ease-out',
+              )}
+              style={{ width: `${(item.count / max) * 100}%` }}
+            />
+          </div>
+          <Text size="sm" variant="muted" className="tabular-nums">
+            {item.count}
+          </Text>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function AnalyticsDashboard({ analytics }: { analytics: OwnerPayPrestigeAnalytics }) {
+  const copy = jobMarketLab.payPrestigeAnalytics;
+  const missingDataId = 'job-market-missing-data-heading';
+  const prestigeId = 'job-market-prestige-heading';
+  const sizeId = 'job-market-size-heading';
+  const compensationId = 'job-market-compensation-heading';
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-1">
+        <Text size="sm" variant="muted">
+          {copy.activeDocumentsLabel}
+        </Text>
+        <Text className="text-3xl font-semibold tabular-nums tracking-tight">
+          {analytics.activeDocumentCount}
+        </Text>
+      </div>
+
+      <section className="space-y-4" aria-labelledby={missingDataId}>
+        <Heading id={missingDataId} as="h3" size="sm">
+          {copy.missingDataHeading}
+        </Heading>
+        <ul className="space-y-3">
+          {analytics.missingDataRates.map((rate) => (
+            <li
+              key={rate.field}
+              className="grid gap-2 border border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] p-4 sm:grid-cols-[minmax(0,12rem)_1fr]"
+            >
+              <Text size="sm">{copy.missingFieldLabels[rate.field]}</Text>
+              <div className="space-y-1">
+                <Text size="sm" variant="muted">
+                  {copy.presentLabel}: {rate.present} · {copy.missingLabel}: {rate.missing} (
+                  {formatPercent(rate.missingRate)} {copy.missingLabel.toLowerCase()})
+                </Text>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-4" aria-labelledby={prestigeId}>
+        <Heading id={prestigeId} as="h3" size="sm">
+          {copy.prestigeHeading}
+        </Heading>
+        <TierBars items={analytics.prestigeTierBreakdown} labelledBy={prestigeId} />
+      </section>
+
+      <section className="space-y-4" aria-labelledby={sizeId}>
+        <Heading id={sizeId} as="h3" size="sm">
+          {copy.sizeHeading}
+        </Heading>
+        <TierBars items={analytics.sizeTierBreakdown} labelledBy={sizeId} />
+      </section>
+
+      <section className="space-y-4" aria-labelledby={compensationId}>
+        <Heading id={compensationId} as="h3" size="sm">
+          {copy.compensationHeading}
+        </Heading>
+        {analytics.compensationByCurrency.length === 0 ? (
+          <Text variant="muted">{copy.compensationEmpty}</Text>
+        ) : (
+          <ul className="space-y-4">
+            {analytics.compensationByCurrency.map((summary) => (
+              <li
+                key={summary.currency}
+                className="space-y-2 border border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] p-4"
+              >
+                <Text className="font-medium">{summary.currency}</Text>
+                <Text size="sm" variant="muted">
+                  {copy.documentCountLabel}: {summary.count}
+                </Text>
+                {summary.medianMin != null ? (
+                  <Text size="sm">
+                    {copy.medianMinLabel}: {formatCurrency(summary.medianMin, summary.currency)}
+                  </Text>
+                ) : null}
+                {summary.medianMax != null ? (
+                  <Text size="sm">
+                    {copy.medianMaxLabel}: {formatCurrency(summary.medianMax, summary.currency)}
+                  </Text>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export function JobMarketLabPayPrestigeAnalyticsPanel({
+  analytics: analyticsDepsProp,
+}: JobMarketLabPayPrestigeAnalyticsPanelProps) {
+  const { session, isLoading } = useSiteAuth();
+  const [analytics, setAnalytics] = useState<OwnerPayPrestigeAnalytics | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (isLoading || session?.status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const deps = analyticsDepsProp ?? createDefaultAmplifyPayPrestigeAnalyticsDeps();
+        const next = await getOwnerPayPrestigeAnalytics(deps);
+        if (!cancelled) {
+          setAnalytics(next);
+          setError(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setAnalytics(null);
+          setError(true);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [analyticsDepsProp, isLoading, session?.status]);
+
+  if (isLoading || session === null || session.status !== 'authenticated') {
+    return null;
+  }
+
+  const copy = jobMarketLab.payPrestigeAnalytics;
+
+  return (
+    <div className="mt-16 max-w-2xl space-y-6 border-t border-[var(--border)] pt-12">
+      <div className="space-y-3">
+        <SectionHeader as="h2" size="md" animated={false} showLeftAccent={false}>
+          {copy.heading}
+        </SectionHeader>
+        <Text variant="muted">{copy.description}</Text>
+      </div>
+
+      {error ? (
+        <p role="alert" className="font-body text-base text-[var(--foreground)]">
+          {copy.errorLabel}
+        </p>
+      ) : null}
+
+      {!error && analytics === null ? (
+        <Text variant="muted">{copy.loadingLabel}</Text>
+      ) : null}
+
+      {!error && analytics !== null ? <AnalyticsDashboard analytics={analytics} /> : null}
+    </div>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -80,6 +80,11 @@ describe('JobMarketLabSection', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText(jobMarketLab.corpusAdmin.heading)).not.toBeInTheDocument();
     expect(
+      screen.queryByRole('heading', {
+        name: jobMarketLab.payPrestigeAnalytics.heading,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole('link', { name: jobMarketLab.console.openConsoleLabel }),
     ).not.toBeInTheDocument();
   });
@@ -101,6 +106,11 @@ describe('JobMarketLabSection', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: jobMarketLab.corpusAdmin.heading }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {
+        name: jobMarketLab.payPrestigeAnalytics.heading,
+      }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -134,5 +134,30 @@
     "loadingLabel": "Loading job descriptionsÔÇª",
     "errorLabel": "Metadata editing is temporarily unavailable.",
     "emptyList": "No job descriptions to edit."
+  },
+  "payPrestigeAnalytics": {
+    "heading": "Compensation and prestige analytics",
+    "description": "Owner-only aggregates from structured metadata. Missing-data rates show how much of the active corpus still lacks employer links or compensation fields.",
+    "loadingLabel": "Loading analytics…",
+    "errorLabel": "Pay and prestige analytics are temporarily unavailable.",
+    "activeDocumentsLabel": "Active documents in analytics scope",
+    "missingDataHeading": "Missing-data rates",
+    "prestigeHeading": "Prestige tier breakdown",
+    "sizeHeading": "Size tier breakdown",
+    "compensationHeading": "Compensation by currency",
+    "compensationEmpty": "No structured compensation recorded on active documents.",
+    "presentLabel": "Present",
+    "missingLabel": "Missing",
+    "medianMinLabel": "Median minimum",
+    "medianMaxLabel": "Median maximum",
+    "documentCountLabel": "Documents",
+    "missingFieldLabels": {
+      "employerLink": "Employer linked",
+      "compensationCurrency": "Currency",
+      "compensationMin": "Minimum",
+      "compensationMax": "Maximum",
+      "compensationPeriod": "Period",
+      "completeCompensation": "Complete compensation record"
+    }
   }
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -273,6 +273,32 @@ export interface JobMarketLabConsoleCopy {
   themeLabelSizeLabel: string;
 }
 
+export interface JobMarketLabPayPrestigeAnalyticsCopy {
+  heading: string;
+  description: string;
+  loadingLabel: string;
+  errorLabel: string;
+  activeDocumentsLabel: string;
+  missingDataHeading: string;
+  prestigeHeading: string;
+  sizeHeading: string;
+  compensationHeading: string;
+  compensationEmpty: string;
+  presentLabel: string;
+  missingLabel: string;
+  medianMinLabel: string;
+  medianMaxLabel: string;
+  documentCountLabel: string;
+  missingFieldLabels: {
+    employerLink: string;
+    compensationCurrency: string;
+    compensationMin: string;
+    compensationMax: string;
+    compensationPeriod: string;
+    completeCompensation: string;
+  };
+}
+
 export interface JobMarketLabPageData {
   heading: string;
   description: string;
@@ -292,6 +318,7 @@ export interface JobMarketLabPageData {
   hitlQueue: JobMarketLabHitlQueueCopy;
   employerAdmin: JobMarketLabEmployerAdminCopy;
   metadataAdmin: JobMarketLabMetadataAdminCopy;
+  payPrestigeAnalytics: JobMarketLabPayPrestigeAnalyticsCopy;
   console: JobMarketLabConsoleCopy;
 }
 

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -219,6 +219,75 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(metadataAdmin, 'loadingLabel', 'jobMarketLab.metadataAdmin');
   requireString(metadataAdmin, 'errorLabel', 'jobMarketLab.metadataAdmin');
   requireString(metadataAdmin, 'emptyList', 'jobMarketLab.metadataAdmin');
+  const payPrestigeAnalytics = requireRecord(
+    page.payPrestigeAnalytics,
+    'jobMarketLab.payPrestigeAnalytics',
+  );
+  requireString(payPrestigeAnalytics, 'heading', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'description', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'loadingLabel', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'errorLabel', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(
+    payPrestigeAnalytics,
+    'activeDocumentsLabel',
+    'jobMarketLab.payPrestigeAnalytics',
+  );
+  requireString(
+    payPrestigeAnalytics,
+    'missingDataHeading',
+    'jobMarketLab.payPrestigeAnalytics',
+  );
+  requireString(payPrestigeAnalytics, 'prestigeHeading', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'sizeHeading', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(
+    payPrestigeAnalytics,
+    'compensationHeading',
+    'jobMarketLab.payPrestigeAnalytics',
+  );
+  requireString(payPrestigeAnalytics, 'compensationEmpty', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'presentLabel', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'missingLabel', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'medianMinLabel', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(payPrestigeAnalytics, 'medianMaxLabel', 'jobMarketLab.payPrestigeAnalytics');
+  requireString(
+    payPrestigeAnalytics,
+    'documentCountLabel',
+    'jobMarketLab.payPrestigeAnalytics',
+  );
+  const missingFieldLabels = requireRecord(
+    payPrestigeAnalytics.missingFieldLabels,
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'employerLink',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'compensationCurrency',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'compensationMin',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'compensationMax',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'compensationPeriod',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'completeCompensation',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
   const consoleCopy = requireRecord(page.console, 'jobMarketLab.console');
   requireString(consoleCopy, 'heading', 'jobMarketLab.console');
   requireString(consoleCopy, 'description', 'jobMarketLab.console');

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -230,3 +230,18 @@ export {
   type AmplifyEmployerDeps,
 } from './job-market-employers-amplify';
 
+export {
+  getOwnerPayPrestigeAnalytics,
+  type OwnerPayPrestigeAnalytics,
+  type GetOwnerPayPrestigeAnalyticsDeps,
+  type MissingDataRate,
+  type TierBucket,
+  type CompensationCurrencySummary,
+} from './job-market-pay-prestige-analytics';
+
+export {
+  createAmplifyPayPrestigeAnalyticsDeps,
+  createDefaultAmplifyPayPrestigeAnalyticsDeps,
+  type AmplifyPayPrestigeAnalyticsDeps,
+} from './job-market-pay-prestige-analytics-amplify';
+

--- a/src/lib/job-market-pay-prestige-analytics-amplify.test.ts
+++ b/src/lib/job-market-pay-prestige-analytics-amplify.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { JobDescriptionCorpusRecord } from './job-market-corpus';
+import type { EmployerRecord } from './job-market-employers';
+import { createAmplifyPayPrestigeAnalyticsDeps } from './job-market-pay-prestige-analytics-amplify';
+import { getOwnerPayPrestigeAnalytics } from './job-market-pay-prestige-analytics';
+
+describe('createAmplifyPayPrestigeAnalyticsDeps', () => {
+  it('wires corpus and employer list seams into owner analytics', async () => {
+    const corpus: JobDescriptionCorpusRecord[] = [
+      {
+        id: 'jd-1',
+        collectedAt: '2026-01-15T00:00:00.000Z',
+        status: 'active',
+        employerId: 'emp-1',
+        compensationCurrency: 'GBP',
+        compensationMin: 90000,
+        compensationPeriod: 'year',
+      },
+    ];
+    const employers: EmployerRecord[] = [
+      {
+        id: 'emp-1',
+        name: 'Alpha Bank',
+        sizeTier: 'enterprise',
+        prestigeTier: 'high',
+      },
+    ];
+
+    const deps = createAmplifyPayPrestigeAnalyticsDeps(
+      {
+        listJobDescriptions: async () => corpus,
+      },
+      {
+        listEmployers: async () => employers,
+      },
+    );
+
+    const result = await getOwnerPayPrestigeAnalytics(deps);
+
+    expect(result.activeDocumentCount).toBe(1);
+    expect(result.prestigeTierBreakdown).toContainEqual({ tier: 'high', count: 1 });
+    expect(result.compensationByCurrency).toEqual([
+      {
+        currency: 'GBP',
+        count: 1,
+        medianMin: 90000,
+        medianMax: undefined,
+      },
+    ]);
+  });
+});

--- a/src/lib/job-market-pay-prestige-analytics-amplify.ts
+++ b/src/lib/job-market-pay-prestige-analytics-amplify.ts
@@ -1,0 +1,21 @@
+import type { GetOwnerPayPrestigeAnalyticsDeps } from './job-market-pay-prestige-analytics';
+import { createDefaultAmplifyCorpusDeps } from './job-market-corpus-amplify';
+import { createDefaultAmplifyEmployerDeps } from './job-market-employers-amplify';
+
+export type AmplifyPayPrestigeAnalyticsDeps = GetOwnerPayPrestigeAnalyticsDeps;
+
+export function createAmplifyPayPrestigeAnalyticsDeps(
+  corpusDeps: Pick<GetOwnerPayPrestigeAnalyticsDeps, 'listJobDescriptions'>,
+  employerDeps: Pick<GetOwnerPayPrestigeAnalyticsDeps, 'listEmployers'>,
+): AmplifyPayPrestigeAnalyticsDeps {
+  return {
+    listJobDescriptions: corpusDeps.listJobDescriptions,
+    listEmployers: employerDeps.listEmployers,
+  };
+}
+
+export function createDefaultAmplifyPayPrestigeAnalyticsDeps(): AmplifyPayPrestigeAnalyticsDeps {
+  const corpusDeps = createDefaultAmplifyCorpusDeps();
+  const employerDeps = createDefaultAmplifyEmployerDeps();
+  return createAmplifyPayPrestigeAnalyticsDeps(corpusDeps, employerDeps);
+}

--- a/src/lib/job-market-pay-prestige-analytics.test.ts
+++ b/src/lib/job-market-pay-prestige-analytics.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import type { JobDescriptionCorpusRecord } from './job-market-corpus';
+import type { EmployerRecord } from './job-market-employers';
+import { getOwnerPayPrestigeAnalytics } from './job-market-pay-prestige-analytics';
+
+function doc(
+  overrides: Partial<JobDescriptionCorpusRecord> & Pick<JobDescriptionCorpusRecord, 'id'>,
+): JobDescriptionCorpusRecord {
+  return {
+    collectedAt: '2026-01-15T00:00:00.000Z',
+    status: 'active',
+    title: 'Data scientist',
+    ...overrides,
+  };
+}
+
+function employer(
+  overrides: Partial<EmployerRecord> & Pick<EmployerRecord, 'id'>,
+): EmployerRecord {
+  return {
+    name: 'Acme Bank',
+    sizeTier: 'enterprise',
+    prestigeTier: 'high',
+    ...overrides,
+  };
+}
+
+describe('getOwnerPayPrestigeAnalytics', () => {
+  it('aggregates compensation and tier breakdowns from active corpus records', async () => {
+    const result = await getOwnerPayPrestigeAnalytics({
+      listJobDescriptions: async () => [
+        doc({
+          id: 'jd-1',
+          employerId: 'emp-1',
+          compensationCurrency: 'GBP',
+          compensationMin: 80000,
+          compensationMax: 100000,
+          compensationPeriod: 'year',
+        }),
+        doc({
+          id: 'jd-2',
+          employerId: 'emp-2',
+          compensationCurrency: 'GBP',
+          compensationMin: 60000,
+          compensationMax: 70000,
+          compensationPeriod: 'year',
+        }),
+        doc({
+          id: 'jd-3',
+          status: 'archived',
+          employerId: 'emp-1',
+          compensationCurrency: 'GBP',
+          compensationMin: 50000,
+          compensationPeriod: 'year',
+        }),
+        doc({ id: 'jd-4' }),
+      ],
+      listEmployers: async () => [
+        employer({ id: 'emp-1', sizeTier: 'enterprise', prestigeTier: 'elite' }),
+        employer({ id: 'emp-2', sizeTier: 'scaleup', prestigeTier: 'mid' }),
+      ],
+    });
+
+    expect(result.activeDocumentCount).toBe(3);
+    expect(result.missingDataRates).toEqual([
+      { field: 'employerLink', present: 2, missing: 1, missingRate: 1 / 3 },
+      {
+        field: 'compensationCurrency',
+        present: 2,
+        missing: 1,
+        missingRate: 1 / 3,
+      },
+      { field: 'compensationMin', present: 2, missing: 1, missingRate: 1 / 3 },
+      { field: 'compensationMax', present: 2, missing: 1, missingRate: 1 / 3 },
+      {
+        field: 'compensationPeriod',
+        present: 2,
+        missing: 1,
+        missingRate: 1 / 3,
+      },
+      {
+        field: 'completeCompensation',
+        present: 2,
+        missing: 1,
+        missingRate: 1 / 3,
+      },
+    ]);
+    expect(result.prestigeTierBreakdown).toEqual([
+      { tier: 'low', count: 0 },
+      { tier: 'mid', count: 1 },
+      { tier: 'high', count: 0 },
+      { tier: 'elite', count: 1 },
+    ]);
+    expect(result.sizeTierBreakdown).toEqual([
+      { tier: 'startup', count: 0 },
+      { tier: 'scaleup', count: 1 },
+      { tier: 'enterprise', count: 1 },
+      { tier: 'big4', count: 0 },
+      { tier: 'other', count: 0 },
+    ]);
+    expect(result.compensationByCurrency).toEqual([
+      {
+        currency: 'GBP',
+        count: 2,
+        medianMin: 70000,
+        medianMax: 85000,
+      },
+    ]);
+  });
+
+  it('reports honest missing-data rates when the active corpus is empty', async () => {
+    const result = await getOwnerPayPrestigeAnalytics({
+      listJobDescriptions: async () => [
+        doc({ id: 'jd-archived', status: 'archived', employerId: 'emp-1' }),
+      ],
+      listEmployers: async () => [employer({ id: 'emp-1' })],
+    });
+
+    expect(result.activeDocumentCount).toBe(0);
+    expect(result.missingDataRates).toEqual([
+      { field: 'employerLink', present: 0, missing: 0, missingRate: 0 },
+      { field: 'compensationCurrency', present: 0, missing: 0, missingRate: 0 },
+      { field: 'compensationMin', present: 0, missing: 0, missingRate: 0 },
+      { field: 'compensationMax', present: 0, missing: 0, missingRate: 0 },
+      { field: 'compensationPeriod', present: 0, missing: 0, missingRate: 0 },
+      { field: 'completeCompensation', present: 0, missing: 0, missingRate: 0 },
+    ]);
+    expect(result.prestigeTierBreakdown).toEqual([
+      { tier: 'low', count: 0 },
+      { tier: 'mid', count: 0 },
+      { tier: 'high', count: 0 },
+      { tier: 'elite', count: 0 },
+    ]);
+    expect(result.sizeTierBreakdown).toEqual([
+      { tier: 'startup', count: 0 },
+      { tier: 'scaleup', count: 0 },
+      { tier: 'enterprise', count: 0 },
+      { tier: 'big4', count: 0 },
+      { tier: 'other', count: 0 },
+    ]);
+    expect(result.compensationByCurrency).toEqual([]);
+  });
+
+  it('ignores employer links that do not resolve in the registry for tier counts', async () => {
+    const result = await getOwnerPayPrestigeAnalytics({
+      listJobDescriptions: async () => [
+        doc({ id: 'jd-1', employerId: 'missing-employer' }),
+        doc({ id: 'jd-2', employerId: 'emp-1' }),
+      ],
+      listEmployers: async () => [
+        employer({ id: 'emp-1', sizeTier: 'big4', prestigeTier: 'high' }),
+      ],
+    });
+
+    expect(result.missingDataRates).toContainEqual({
+      field: 'employerLink',
+      present: 2,
+      missing: 0,
+      missingRate: 0,
+    });
+    expect(result.prestigeTierBreakdown).toEqual([
+      { tier: 'low', count: 0 },
+      { tier: 'mid', count: 0 },
+      { tier: 'high', count: 1 },
+      { tier: 'elite', count: 0 },
+    ]);
+    expect(result.sizeTierBreakdown).toEqual([
+      { tier: 'startup', count: 0 },
+      { tier: 'scaleup', count: 0 },
+      { tier: 'enterprise', count: 0 },
+      { tier: 'big4', count: 1 },
+      { tier: 'other', count: 0 },
+    ]);
+  });
+});

--- a/src/lib/job-market-pay-prestige-analytics.ts
+++ b/src/lib/job-market-pay-prestige-analytics.ts
@@ -1,0 +1,223 @@
+import { selectActiveCorpus, type JobDescriptionCorpusRecord } from './job-market-corpus';
+import {
+  EMPLOYER_PRESTIGE_TIERS,
+  EMPLOYER_SIZE_TIERS,
+  type EmployerRecord,
+} from './job-market-employers';
+
+export type MissingDataRate = {
+  field:
+    | 'employerLink'
+    | 'compensationCurrency'
+    | 'compensationMin'
+    | 'compensationMax'
+    | 'compensationPeriod'
+    | 'completeCompensation';
+  present: number;
+  missing: number;
+  missingRate: number;
+};
+
+export type TierBucket = {
+  tier: string;
+  count: number;
+};
+
+export type CompensationCurrencySummary = {
+  currency: string;
+  count: number;
+  medianMin?: number;
+  medianMax?: number;
+};
+
+export type OwnerPayPrestigeAnalytics = {
+  activeDocumentCount: number;
+  missingDataRates: MissingDataRate[];
+  prestigeTierBreakdown: TierBucket[];
+  sizeTierBreakdown: TierBucket[];
+  compensationByCurrency: CompensationCurrencySummary[];
+};
+
+export type GetOwnerPayPrestigeAnalyticsDeps = {
+  listJobDescriptions: () => Promise<JobDescriptionCorpusRecord[]>;
+  listEmployers: () => Promise<EmployerRecord[]>;
+};
+
+const MISSING_DATA_FIELDS = [
+  'employerLink',
+  'compensationCurrency',
+  'compensationMin',
+  'compensationMax',
+  'compensationPeriod',
+  'completeCompensation',
+] as const satisfies ReadonlyArray<MissingDataRate['field']>;
+
+function median(values: number[]): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const mid = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+
+  return sorted[mid];
+}
+
+function hasEmployerLink(record: JobDescriptionCorpusRecord): boolean {
+  return Boolean(record.employerId?.trim());
+}
+
+function hasCompensationCurrency(record: JobDescriptionCorpusRecord): boolean {
+  return Boolean(record.compensationCurrency?.trim());
+}
+
+function hasCompensationMin(record: JobDescriptionCorpusRecord): boolean {
+  return record.compensationMin != null;
+}
+
+function hasCompensationMax(record: JobDescriptionCorpusRecord): boolean {
+  return record.compensationMax != null;
+}
+
+function hasCompensationPeriod(record: JobDescriptionCorpusRecord): boolean {
+  return record.compensationPeriod != null;
+}
+
+function hasCompleteCompensation(record: JobDescriptionCorpusRecord): boolean {
+  return (
+    hasCompensationCurrency(record) &&
+    hasCompensationPeriod(record) &&
+    (hasCompensationMin(record) || hasCompensationMax(record))
+  );
+}
+
+function fieldPresent(
+  field: MissingDataRate['field'],
+  record: JobDescriptionCorpusRecord,
+): boolean {
+  switch (field) {
+    case 'employerLink':
+      return hasEmployerLink(record);
+    case 'compensationCurrency':
+      return hasCompensationCurrency(record);
+    case 'compensationMin':
+      return hasCompensationMin(record);
+    case 'compensationMax':
+      return hasCompensationMax(record);
+    case 'compensationPeriod':
+      return hasCompensationPeriod(record);
+    case 'completeCompensation':
+      return hasCompleteCompensation(record);
+  }
+}
+
+function buildMissingDataRates(
+  records: JobDescriptionCorpusRecord[],
+): MissingDataRate[] {
+  const total = records.length;
+
+  return MISSING_DATA_FIELDS.map((field) => {
+    const present = records.filter((record) => fieldPresent(field, record)).length;
+    const missing = total - present;
+
+    return {
+      field,
+      present,
+      missing,
+      missingRate: total === 0 ? 0 : missing / total,
+    };
+  });
+}
+
+function buildTierBreakdown<T extends string>(
+  tiers: readonly T[],
+  counts: Map<T, number>,
+): TierBucket[] {
+  return tiers.map((tier) => ({
+    tier,
+    count: counts.get(tier) ?? 0,
+  }));
+}
+
+function buildCompensationByCurrency(
+  records: JobDescriptionCorpusRecord[],
+): CompensationCurrencySummary[] {
+  const byCurrency = new Map<string, { mins: number[]; maxes: number[] }>();
+
+  for (const record of records) {
+    if (!hasCompensationCurrency(record)) {
+      continue;
+    }
+
+    if (!hasCompensationMin(record) && !hasCompensationMax(record)) {
+      continue;
+    }
+
+    const currency = record.compensationCurrency!.trim().toUpperCase();
+    const bucket = byCurrency.get(currency) ?? { mins: [], maxes: [] };
+
+    if (hasCompensationMin(record)) {
+      bucket.mins.push(record.compensationMin!);
+    }
+    if (hasCompensationMax(record)) {
+      bucket.maxes.push(record.compensationMax!);
+    }
+
+    byCurrency.set(currency, bucket);
+  }
+
+  return [...byCurrency.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([currency, values]) => ({
+      currency,
+      count: Math.max(values.mins.length, values.maxes.length),
+      medianMin: median(values.mins),
+      medianMax: median(values.maxes),
+    }));
+}
+
+export async function getOwnerPayPrestigeAnalytics(
+  deps: GetOwnerPayPrestigeAnalyticsDeps,
+): Promise<OwnerPayPrestigeAnalytics> {
+  const [records, employers] = await Promise.all([
+    deps.listJobDescriptions(),
+    deps.listEmployers(),
+  ]);
+
+  const activeRecords = selectActiveCorpus(records);
+  const employersById = new Map(employers.map((entry) => [entry.id, entry]));
+  const prestigeCounts = new Map<string, number>();
+  const sizeCounts = new Map<string, number>();
+
+  for (const record of activeRecords) {
+    if (!record.employerId) {
+      continue;
+    }
+
+    const linkedEmployer = employersById.get(record.employerId);
+    if (!linkedEmployer) {
+      continue;
+    }
+
+    prestigeCounts.set(
+      linkedEmployer.prestigeTier,
+      (prestigeCounts.get(linkedEmployer.prestigeTier) ?? 0) + 1,
+    );
+    sizeCounts.set(
+      linkedEmployer.sizeTier,
+      (sizeCounts.get(linkedEmployer.sizeTier) ?? 0) + 1,
+    );
+  }
+
+  return {
+    activeDocumentCount: activeRecords.length,
+    missingDataRates: buildMissingDataRates(activeRecords),
+    prestigeTierBreakdown: buildTierBreakdown(EMPLOYER_PRESTIGE_TIERS, prestigeCounts),
+    sizeTierBreakdown: buildTierBreakdown(EMPLOYER_SIZE_TIERS, sizeCounts),
+    compensationByCurrency: buildCompensationByCurrency(activeRecords),
+  };
+}


### PR DESCRIPTION
## Summary
- Add `getOwnerPayPrestigeAnalytics` facade with compensation summaries, honest missing-data rates, and prestige/size tier breakdowns from the employer registry and structured JD metadata.
- Add an authenticated owner-console analytics panel with British English data-layer copy; guests and the public lab remain excluded via existing snapshot sanitisation.
- Cover aggregate shaping with Vitest seams for the facade, Amplify adapter, console panel, and public lab regression checks.

## Test plan
- [x] `npx vitest run` — 223 tests passed
- [ ] Owner console: confirm compensation, missing-data rates, and tier breakdowns render for authenticated owners
- [ ] Public lab: confirm pay/prestige analytics headings never appear for guests or signed-in owners
- [ ] Guest snapshot path: confirm published aggregates still exclude compensation and employer fields

Closes #72

Made with [Cursor](https://cursor.com)