### PR TITLE
Theme and technology filters for job market pulse

### DIFF
--- a/amplify/functions/job-market-analyse/analyse.test.ts
+++ b/amplify/functions/job-market-analyse/analyse.test.ts
@@ -15,6 +15,7 @@ const docs: AnalyzableDocument[] = [
   {
     id: 'jd-1',
     contentHash: 'hash-1',
+    collectedAt: '2026-06-01T00:00:00.000Z',
     markdown:
       'We need Python, SQL, and teamwork. Senior data scientist role with modelling.',
     seniority: 'senior',
@@ -23,6 +24,7 @@ const docs: AnalyzableDocument[] = [
   {
     id: 'jd-2',
     contentHash: 'hash-2',
+    collectedAt: '2026-05-01T00:00:00.000Z',
     markdown: 'Looking for Python, Tableau, and communication skills.',
     seniority: 'mid',
     roleFamily: 'analytics',
@@ -30,6 +32,7 @@ const docs: AnalyzableDocument[] = [
   {
     id: 'jd-3',
     contentHash: 'hash-1',
+    collectedAt: '2026-04-01T00:00:00.000Z',
     markdown:
       'We need Python, SQL, and teamwork. Senior data scientist role with modelling.',
     seniority: 'senior',
@@ -107,11 +110,13 @@ describe('analyseCorpus cluster labels', () => {
       {
         id: 'jd-a',
         contentHash: 'hash-a',
+        collectedAt: '2026-06-01T00:00:00.000Z',
         markdown: 'Python, SQL, and modelling experience.',
       },
       {
         id: 'jd-b',
         contentHash: 'hash-b',
+        collectedAt: '2026-05-01T00:00:00.000Z',
         markdown: 'Tableau, communication, and stakeholder management.',
       },
     ];
@@ -135,16 +140,55 @@ describe('analyseCorpus cluster labels', () => {
     expect(result.snapshot.clusters.map((cluster) => cluster.label)).not.toContain('Theme 1');
   });
 
+  it('publishes per-document corpusMeta for downstream pulse filters', async () => {
+    const clusterDocs: AnalyzableDocument[] = [
+      {
+        id: 'jd-a',
+        contentHash: 'hash-a',
+        collectedAt: '2026-06-01T00:00:00.000Z',
+        markdown: 'Python, SQL, and modelling experience.',
+        seniority: 'senior',
+        roleFamily: 'data-science',
+        employerSizeTier: 'enterprise',
+        employerPrestigeTier: 'elite',
+      },
+    ];
+
+    const result = await analyseCorpus(clusterDocs, {
+      embed: async () => ({
+        vector: [0.9, 0.1, 0.2, 0.3],
+        inputTokens: 4,
+        estimatedCostUsd: 0.0001,
+      }),
+      getCachedEmbedding: async () => null,
+      putCachedEmbedding: async () => undefined,
+      now: new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    expect(result.snapshot.corpusMeta?.documents[0]).toMatchObject({
+      id: 'jd-a',
+      collectedAt: '2026-06-01T00:00:00.000Z',
+      seniority: 'senior',
+      roleFamily: 'data-science',
+      employerSizeTier: 'enterprise',
+      employerPrestigeTier: 'elite',
+      technologies: ['python', 'sql'],
+      clusterId: 0,
+    });
+  });
+
   it('applies owner theme label overrides when publishing clusters', async () => {
     const clusterDocs: AnalyzableDocument[] = [
       {
         id: 'jd-a',
         contentHash: 'hash-a',
+        collectedAt: '2026-06-01T00:00:00.000Z',
         markdown: 'Python, SQL, and modelling experience.',
       },
       {
         id: 'jd-b',
         contentHash: 'hash-b',
+        collectedAt: '2026-05-01T00:00:00.000Z',
         markdown: 'Tableau, communication, and stakeholder management.',
       },
     ];

--- a/amplify/functions/job-market-analyse/analyse.ts
+++ b/amplify/functions/job-market-analyse/analyse.ts
@@ -11,9 +11,25 @@ export type AnalyzableDocument = {
   id: string;
   contentHash: string;
   markdown: string;
+  collectedAt: string;
   seniority?: string;
   roleFamily?: string;
   title?: string;
+  employerSizeTier?: string;
+  employerPrestigeTier?: string;
+};
+
+export type DocumentPulseMeta = {
+  id: string;
+  collectedAt: string;
+  seniority?: string;
+  roleFamily?: string;
+  employerSizeTier?: string;
+  employerPrestigeTier?: string;
+  technologies: string[];
+  clusterId: number;
+  projectionX?: number;
+  projectionY?: number;
 };
 
 export type SkillFrequency = TechnologyFrequency;
@@ -44,6 +60,9 @@ export type CorpusSnapshotPayload = {
   roleFamily: TaxonomyBucket[];
   clusters: ClusterSummary[];
   projection: ProjectionPoint[];
+  corpusMeta?: {
+    documents: DocumentPulseMeta[];
+  };
 };
 
 export type AnalysisMetrics = {
@@ -282,6 +301,22 @@ export async function analyseCorpus(
     maxTechnologies: maxSkills,
   });
 
+  const corpusMetaDocuments: DocumentPulseMeta[] = documents.map((document, index) => {
+    const matched = matchTechnologiesInDocuments([document], { maxTechnologies: maxSkills });
+    return {
+      id: document.id,
+      collectedAt: document.collectedAt,
+      seniority: document.seniority,
+      roleFamily: document.roleFamily,
+      employerSizeTier: document.employerSizeTier,
+      employerPrestigeTier: document.employerPrestigeTier,
+      technologies: matched.map((technology) => technology.name),
+      clusterId: assignments[index] ?? 0,
+      projectionX: vectors[index]?.[0],
+      projectionY: vectors[index]?.[1],
+    };
+  });
+
   return {
     snapshot: {
       documentCount: documents.length,
@@ -292,6 +327,7 @@ export async function analyseCorpus(
       roleFamily: taxonomyBreakdown(documents, 'roleFamily'),
       clusters,
       projection,
+      corpusMeta: { documents: corpusMetaDocuments },
     },
     metrics: {
       docsConsidered: documents.length,

--- a/amplify/functions/job-market-analyse/corpus.ts
+++ b/amplify/functions/job-market-analyse/corpus.ts
@@ -12,6 +12,7 @@ export type JobDescriptionCorpusRecord = {
   source?: string;
   s3Key?: string;
   contentHash?: string;
+  employerId?: string;
 };
 
 export const DEFAULT_MAX_AGE_MONTHS = 18;

--- a/amplify/functions/job-market-analyse/handler.ts
+++ b/amplify/functions/job-market-analyse/handler.ts
@@ -43,7 +43,21 @@ async function listJobDescriptions(): Promise<JobDescriptionCorpusRecord[]> {
     seniority: record.seniority ?? undefined,
     roleFamily: record.roleFamily ?? undefined,
     source: record.source ?? undefined,
+    employerId: record.employerId ?? undefined,
   }));
+}
+
+async function getEmployerTiers(
+  employerId: string,
+): Promise<{ sizeTier?: string; prestigeTier?: string } | null> {
+  const { data, errors } = await client.models.Employer.get({ id: employerId });
+  if (errors?.length || !data) {
+    return null;
+  }
+  return {
+    sizeTier: data.sizeTier ?? undefined,
+    prestigeTier: data.prestigeTier ?? undefined,
+  };
 }
 
 async function saveJobDescription(
@@ -232,6 +246,7 @@ export const handler: Handler<AnalyseEvent> = async (event) => {
     updatePublication,
     getPublication,
     listThemeLabelOverrides,
+    getEmployerTiers,
   });
 
   if (result.status === 'failed') {

--- a/amplify/functions/job-market-analyse/run.ts
+++ b/amplify/functions/job-market-analyse/run.ts
@@ -29,6 +29,9 @@ export type ExecuteAnalysisRunDeps = {
   getCachedEmbedding: AnalyseCorpusDeps['getCachedEmbedding'];
   putCachedEmbedding: AnalyseCorpusDeps['putCachedEmbedding'];
   listThemeLabelOverrides?: () => Promise<Record<string, string>>;
+  getEmployerTiers?: (
+    employerId: string,
+  ) => Promise<{ sizeTier?: string; prestigeTier?: string } | null>;
   saveSnapshot: (snapshot: StoredCorpusSnapshot) => Promise<StoredCorpusSnapshot>;
   updateRun: (run: AnalysisRunRecord) => Promise<AnalysisRunRecord>;
   updatePublication: (publication: LabPublicationPointer) => Promise<void>;
@@ -65,20 +68,33 @@ export async function executeAnalysisRun(
       id: string;
       contentHash: string;
       markdown: string;
+      collectedAt: string;
       seniority?: string;
       roleFamily?: string;
       title?: string;
+      employerSizeTier?: string;
+      employerPrestigeTier?: string;
     }> = [];
     for (const record of active) {
       const s3Key = record.s3Key ?? record.id;
       const markdown = await deps.loadMarkdown(s3Key);
+      let employerSizeTier: string | undefined;
+      let employerPrestigeTier: string | undefined;
+      if (record.employerId && deps.getEmployerTiers) {
+        const tiers = await deps.getEmployerTiers(record.employerId);
+        employerSizeTier = tiers?.sizeTier;
+        employerPrestigeTier = tiers?.prestigeTier;
+      }
       analyzable.push({
         id: record.id,
         contentHash: record.contentHash ?? record.id,
         markdown,
+        collectedAt: record.collectedAt,
         seniority: record.seniority,
         roleFamily: record.roleFamily,
         title: record.title,
+        employerSizeTier,
+        employerPrestigeTier,
       });
     }
 

--- a/amplify/functions/job-market-publication/handler.ts
+++ b/amplify/functions/job-market-publication/handler.ts
@@ -4,6 +4,7 @@ import { generateClient } from 'aws-amplify/data';
 import { env } from '$amplify/env/job-market-publication';
 import type { Schema } from '../../data/resource';
 import type { CorpusSnapshotPayload } from '../job-market-analyse/analyse';
+import { sanitiseSnapshotPayloadForGuests } from './sanitize';
 
 const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(env);
 
@@ -30,11 +31,12 @@ export const handler: Schema['getPublishedJobMarketSnapshot']['functionHandler']
 
     if (typeof rawPayload === 'string') {
       try {
-        return JSON.parse(rawPayload) as CorpusSnapshotPayload;
+        const parsed = JSON.parse(rawPayload) as CorpusSnapshotPayload;
+        return sanitiseSnapshotPayloadForGuests(parsed);
       } catch {
         return null;
       }
     }
 
-    return rawPayload as CorpusSnapshotPayload;
+    return sanitiseSnapshotPayloadForGuests(rawPayload as CorpusSnapshotPayload);
   };

--- a/amplify/functions/job-market-publication/sanitize.test.ts
+++ b/amplify/functions/job-market-publication/sanitize.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { sanitiseSnapshotPayloadForGuests } from './sanitize';
+
+describe('sanitiseSnapshotPayloadForGuests', () => {
+  it('strips employer tiers and taxonomy fields from corpusMeta', () => {
+    const result = sanitiseSnapshotPayloadForGuests({
+      documentCount: 1,
+      publishedAt: '2026-07-14T12:00:00.000Z',
+      technologies: [{ name: 'python', count: 1 }],
+      skills: [{ name: 'python', count: 1 }],
+      seniority: [],
+      roleFamily: [],
+      clusters: [],
+      projection: [],
+      corpusMeta: {
+        documents: [
+          {
+            id: 'jd-1',
+            collectedAt: '2026-06-01T00:00:00.000Z',
+            seniority: 'senior',
+            roleFamily: 'data-science',
+            employerSizeTier: 'enterprise',
+            employerPrestigeTier: 'elite',
+            technologies: ['python'],
+            clusterId: 0,
+            projectionX: 0.1,
+            projectionY: 0.2,
+          },
+        ],
+      },
+    });
+
+    expect(result.corpusMeta).toEqual({
+      documents: [
+        {
+          id: 'jd-1',
+          collectedAt: '2026-06-01T00:00:00.000Z',
+          technologies: ['python'],
+          clusterId: 0,
+          projectionX: 0.1,
+          projectionY: 0.2,
+        },
+      ],
+    });
+  });
+});

--- a/amplify/functions/job-market-publication/sanitize.ts
+++ b/amplify/functions/job-market-publication/sanitize.ts
@@ -1,0 +1,40 @@
+import type { CorpusSnapshotPayload } from '../job-market-analyse/analyse';
+
+type OwnerDocumentPulseMeta = {
+  id: string;
+  collectedAt: string;
+  seniority?: string;
+  roleFamily?: string;
+  employerSizeTier?: string;
+  employerPrestigeTier?: string;
+  technologies: string[];
+  clusterId: number;
+  projectionX?: number;
+  projectionY?: number;
+};
+
+/** Strips owner-only corpusMeta fields before guest publication. */
+export function sanitiseSnapshotPayloadForGuests(
+  payload: CorpusSnapshotPayload,
+): CorpusSnapshotPayload {
+  const { corpusMeta, ...rest } = payload;
+  if (!corpusMeta) {
+    return rest;
+  }
+
+  return {
+    ...rest,
+    corpusMeta: {
+      documents: (corpusMeta.documents as OwnerDocumentPulseMeta[]).map(
+        ({ id, collectedAt, technologies, clusterId, projectionX, projectionY }) => ({
+          id,
+          collectedAt,
+          technologies,
+          clusterId,
+          projectionX,
+          projectionY,
+        }),
+      ),
+    },
+  };
+}

--- a/src/components/sections/labs/job-market-lab-console-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.test.tsx
@@ -130,6 +130,9 @@ describe('JobMarketLabConsoleSection', () => {
       screen.getByRole('heading', { name: jobMarketLab.console.themeLabelsHeading }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: jobMarketLab.console.pulseFiltersHeading }),
+    ).toBeInTheDocument();
+    expect(
       await screen.findByRole('heading', { name: jobMarketLab.console.runsHeading }),
     ).toBeInTheDocument();
     expect(await screen.findByText('run-fail')).toBeInTheDocument();

--- a/src/components/sections/labs/job-market-lab-console-section.tsx
+++ b/src/components/sections/labs/job-market-lab-console-section.tsx
@@ -12,6 +12,7 @@ import { JobMarketLabMetadataAdmin } from '@/components/sections/labs/job-market
 import { JobMarketLabPayPrestigeAnalyticsPanel } from '@/components/sections/labs/job-market-lab-pay-prestige-analytics-panel';
 import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
 import { JobMarketLabThemeLabelsPanel } from '@/components/sections/labs/job-market-lab-theme-labels-panel';
+import { JobMarketLabPulseFiltersPanel } from '@/components/sections/labs/job-market-lab-pulse-filters-panel';
 import { JobMarketLabUploadPanel } from '@/components/sections/labs/job-market-lab-upload-panel';
 import { jobMarketLab } from '@/data';
 import { useSiteAuth } from '@/hooks/use-site-auth';
@@ -85,6 +86,7 @@ export function JobMarketLabConsoleSection({
         <JobMarketLabPayPrestigeAnalyticsPanel />
         <JobMarketLabCorpusAdmin corpus={corpus} />
         <JobMarketLabThemeLabelsPanel />
+        <JobMarketLabPulseFiltersPanel />
         <JobMarketLabRunsPanel analysisRuns={analysisRuns} />
       </Container>
     </Section>

--- a/src/components/sections/labs/job-market-lab-pulse-filters-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-pulse-filters-panel.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobMarketLabPulseFiltersPanel } from '@/components/sections/labs/job-market-lab-pulse-filters-panel';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('JobMarketLabPulseFiltersPanel', () => {
+  it('renders owner filter controls and filtered pulse summary when corpus metadata is available', async () => {
+    render(
+      <SiteAuthProvider
+        auth={createMemorySiteAuth({
+          status: 'authenticated',
+          email: 'owner@example.com',
+        })}
+      >
+        <JobMarketLabPulseFiltersPanel
+          ownerPulse={{
+            fetchOwnerPayload: async () => ({
+              snapshot: {
+                documentCount: 2,
+                publishedAt: '2026-07-14T12:00:00.000Z',
+                technologies: [
+                  { name: 'python', count: 2 },
+                  { name: 'sql', count: 1 },
+                ],
+                skills: [
+                  { name: 'python', count: 2 },
+                  { name: 'sql', count: 1 },
+                ],
+                seniority: [{ name: 'senior', count: 2 }],
+                roleFamily: [{ name: 'data-science', count: 2 }],
+                clusters: [{ id: 0, size: 2, label: 'Python stack' }],
+                projection: [],
+              },
+              corpusMeta: {
+                documents: [
+                  {
+                    id: 'jd-1',
+                    collectedAt: '2026-06-01T00:00:00.000Z',
+                    seniority: 'senior',
+                    roleFamily: 'data-science',
+                    employerSizeTier: 'enterprise',
+                    employerPrestigeTier: 'elite',
+                    technologies: ['python', 'sql'],
+                    clusterId: 0,
+                  },
+                  {
+                    id: 'jd-2',
+                    collectedAt: '2026-01-01T00:00:00.000Z',
+                    seniority: 'mid',
+                    roleFamily: 'analytics',
+                    employerSizeTier: 'startup',
+                    employerPrestigeTier: 'low',
+                    technologies: ['python'],
+                    clusterId: 0,
+                  },
+                ],
+              },
+            }),
+          }}
+        />
+      </SiteAuthProvider>,
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: jobMarketLab.console.pulseFiltersHeading,
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByLabelText(jobMarketLab.employerAdmin.prestigeTierLabel),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('python')).toBeInTheDocument();
+    expect(await screen.findByText('Python stack')).toBeInTheDocument();
+  });
+
+  it('does not render for guests', () => {
+    render(
+      <SiteAuthProvider auth={createMemorySiteAuth()}>
+        <JobMarketLabPulseFiltersPanel />
+      </SiteAuthProvider>,
+    );
+
+    expect(
+      screen.queryByRole('heading', {
+        name: jobMarketLab.console.pulseFiltersHeading,
+      }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/job-market-lab-pulse-filters-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-pulse-filters-panel.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { SectionHeader, Text } from '@/components/ui';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import {
+  EMPLOYER_PRESTIGE_TIERS,
+  EMPLOYER_SIZE_TIERS,
+  JOB_DESCRIPTION_ROLE_FAMILIES,
+  JOB_DESCRIPTION_SENIORITIES,
+  filterJobMarketPulse,
+  fetchOwnerJobMarketPulseSource,
+  type FetchOwnerJobMarketPulseSourceDeps,
+  type FilteredJobMarketPulse,
+  type JobMarketPulseFilterSelection,
+  type JobMarketPulseTimeWindow,
+  type OwnerJobMarketPulseSource,
+} from '@/lib/job-market-lab';
+
+export type JobMarketLabPulseFiltersPanelProps = {
+  ownerPulse?: FetchOwnerJobMarketPulseSourceDeps;
+};
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'empty' }
+  | { status: 'ready' }
+  | { status: 'error' };
+
+const TIME_WINDOWS: JobMarketPulseTimeWindow[] = ['all', '3m', '6m', '12m', '18m'];
+
+const fieldClassName =
+  'w-full rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent px-3 py-2 font-body text-base text-[var(--foreground)]';
+
+function FrequencySummary({ pulse }: { pulse: FilteredJobMarketPulse }) {
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      <div className="space-y-3">
+        <Text size="sm" variant="muted">
+          {jobMarketLab.console.pulseFiltersTechnologiesLabel}
+        </Text>
+        <ul className="space-y-2">
+          {pulse.technologies.slice(0, 8).map((item) => (
+            <li key={item.name} className="flex justify-between gap-4">
+              <Text size="sm">{item.name}</Text>
+              <Text size="sm" variant="muted" className="tabular-nums">
+                {item.count}
+              </Text>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="space-y-3">
+        <Text size="sm" variant="muted">
+          {jobMarketLab.console.pulseFiltersThemesLabel}
+        </Text>
+        <ul className="space-y-2">
+          {pulse.clusters
+            .filter((cluster) => cluster.size > 0)
+            .map((cluster) => (
+              <li key={cluster.id} className="flex justify-between gap-4">
+                <Text size="sm">{cluster.label}</Text>
+                <Text size="sm" variant="muted" className="tabular-nums">
+                  {cluster.size}
+                </Text>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export function JobMarketLabPulseFiltersPanel({
+  ownerPulse,
+}: JobMarketLabPulseFiltersPanelProps) {
+  const { session, isLoading } = useSiteAuth();
+  const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
+  const [pulseSource, setPulseSource] = useState<OwnerJobMarketPulseSource | null>(null);
+  const [selection, setSelection] = useState<JobMarketPulseFilterSelection>({
+    timeWindow: 'all',
+    seniority: 'all',
+    roleFamily: 'all',
+    employerSizeTier: 'all',
+    employerPrestigeTier: 'all',
+  });
+
+  const loadSource = useCallback(async () => {
+    return fetchOwnerJobMarketPulseSource(ownerPulse);
+  }, [ownerPulse]);
+
+  useEffect(() => {
+    if (isLoading || session?.status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      setLoadState({ status: 'loading' });
+      try {
+        const source = await loadSource();
+        if (cancelled) {
+          return;
+        }
+        if (!source) {
+          setLoadState({ status: 'empty' });
+          setPulseSource(null);
+          return;
+        }
+        setPulseSource(source);
+        setLoadState({ status: 'ready' });
+      } catch {
+        if (!cancelled) {
+          setLoadState({ status: 'error' });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, session, loadSource]);
+
+  const filteredPulse = useMemo(() => {
+    if (!pulseSource) {
+      return null;
+    }
+    return filterJobMarketPulse(pulseSource, selection, { audience: 'owner' });
+  }, [pulseSource, selection]);
+
+  if (isLoading || session?.status !== 'authenticated') {
+    return null;
+  }
+
+  return (
+    <section className="mt-16 space-y-6" aria-labelledby="job-market-pulse-filters-heading">
+      <div className="space-y-2">
+        <SectionHeader
+          id="job-market-pulse-filters-heading"
+          as="h2"
+          size="md"
+          animated={false}
+          showLeftAccent={false}
+        >
+          {jobMarketLab.console.pulseFiltersHeading}
+        </SectionHeader>
+        <Text variant="muted">{jobMarketLab.console.pulseFiltersDescription}</Text>
+      </div>
+
+      {loadState.status === 'loading' || loadState.status === 'idle' ? (
+        <Text variant="muted">{jobMarketLab.console.pulseFiltersLoading}</Text>
+      ) : null}
+
+      {loadState.status === 'error' ? (
+        <p role="alert" className="font-body text-lg leading-relaxed text-[var(--foreground)]">
+          {jobMarketLab.console.pulseFiltersError}
+        </p>
+      ) : null}
+
+      {loadState.status === 'empty' ? (
+        <Text>{jobMarketLab.console.pulseFiltersEmpty}</Text>
+      ) : null}
+
+      {loadState.status === 'ready' && filteredPulse ? (
+        <div className="space-y-8">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <label className="block space-y-2">
+              <Text size="sm" variant="muted">
+                {jobMarketLab.console.pulseFiltersTimeLabel}
+              </Text>
+              <select
+                className={fieldClassName}
+                value={selection.timeWindow ?? 'all'}
+                onChange={(event) => {
+                  setSelection((current) => ({
+                    ...current,
+                    timeWindow: event.target.value as JobMarketPulseTimeWindow,
+                  }));
+                }}
+              >
+                {TIME_WINDOWS.map((window) => (
+                  <option key={window} value={window}>
+                    {jobMarketLab.console.pulseFilterTimeOptions[window]}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block space-y-2">
+              <Text size="sm" variant="muted">
+                {jobMarketLab.seniorityLabel}
+              </Text>
+              <select
+                className={fieldClassName}
+                value={selection.seniority ?? 'all'}
+                onChange={(event) => {
+                  setSelection((current) => ({
+                    ...current,
+                    seniority: event.target.value as JobMarketPulseFilterSelection['seniority'],
+                  }));
+                }}
+              >
+                <option value="all">{jobMarketLab.console.pulseFiltersAllOption}</option>
+                {JOB_DESCRIPTION_SENIORITIES.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block space-y-2">
+              <Text size="sm" variant="muted">
+                {jobMarketLab.roleFamilyLabel}
+              </Text>
+              <select
+                className={fieldClassName}
+                value={selection.roleFamily ?? 'all'}
+                onChange={(event) => {
+                  setSelection((current) => ({
+                    ...current,
+                    roleFamily: event.target.value as JobMarketPulseFilterSelection['roleFamily'],
+                  }));
+                }}
+              >
+                <option value="all">{jobMarketLab.console.pulseFiltersAllOption}</option>
+                {JOB_DESCRIPTION_ROLE_FAMILIES.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block space-y-2">
+              <Text size="sm" variant="muted">
+                {jobMarketLab.employerAdmin.sizeTierLabel}
+              </Text>
+              <select
+                className={fieldClassName}
+                value={selection.employerSizeTier ?? 'all'}
+                onChange={(event) => {
+                  setSelection((current) => ({
+                    ...current,
+                    employerSizeTier:
+                      event.target.value as JobMarketPulseFilterSelection['employerSizeTier'],
+                  }));
+                }}
+              >
+                <option value="all">{jobMarketLab.console.pulseFiltersAllOption}</option>
+                {EMPLOYER_SIZE_TIERS.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block space-y-2">
+              <Text size="sm" variant="muted">
+                {jobMarketLab.employerAdmin.prestigeTierLabel}
+              </Text>
+              <select
+                aria-label={jobMarketLab.employerAdmin.prestigeTierLabel}
+                className={fieldClassName}
+                value={selection.employerPrestigeTier ?? 'all'}
+                onChange={(event) => {
+                  setSelection((current) => ({
+                    ...current,
+                    employerPrestigeTier:
+                      event.target.value as JobMarketPulseFilterSelection['employerPrestigeTier'],
+                  }));
+                }}
+              >
+                <option value="all">{jobMarketLab.console.pulseFiltersAllOption}</option>
+                {EMPLOYER_PRESTIGE_TIERS.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <Text size="sm" variant="muted">
+            {jobMarketLab.console.pulseFiltersDocumentCountLabel.replace(
+              '{count}',
+              String(filteredPulse.documentCount),
+            )}
+          </Text>
+
+          <FrequencySummary pulse={filteredPulse} />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useMemo, useState } from 'react';
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
 import { jobMarketLab } from '@/data';
 import type {
@@ -9,6 +10,10 @@ import type {
   SkillFrequency,
   TaxonomyBucket,
 } from '@/lib/job-market-lab';
+import {
+  filterJobMarketPulse,
+  type JobMarketPulseTimeWindow,
+} from '@/lib/job-market-pulse-filters';
 import { useSiteAuth } from '@/hooks/use-site-auth';
 import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 import { cn } from '@/lib/utils';
@@ -127,13 +132,57 @@ function ClusterProjection({ snapshot }: { snapshot: JobMarketSnapshot }) {
 }
 
 function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
+  const [timeWindow, setTimeWindow] = useState<JobMarketPulseTimeWindow>('all');
+  const filtered = useMemo(
+    () =>
+      filterJobMarketPulse(
+        { snapshot, corpusMeta: snapshot.corpusMeta },
+        { timeWindow },
+        { audience: 'public' },
+      ),
+    [snapshot, timeWindow],
+  );
+
+  const displaySnapshot: JobMarketSnapshot = {
+    ...snapshot,
+    documentCount: filtered.documentCount,
+    technologies: filtered.technologies,
+    skills: filtered.skills,
+    seniority: filtered.seniority,
+    roleFamily: filtered.roleFamily,
+    clusters: filtered.clusters,
+    projection: filtered.projection,
+  };
+
   const technologiesId = 'job-market-technologies-heading';
   const taxonomyId = 'job-market-taxonomy-heading';
   const clustersId = 'job-market-clusters-heading';
-  const technologyPulse = snapshot.technologies ?? snapshot.skills;
+  const technologyPulse = displaySnapshot.technologies ?? displaySnapshot.skills;
+  const showTimeFilter = snapshot.corpusMeta != null;
 
   return (
     <div className="space-y-14">
+      {showTimeFilter ? (
+        <section className="max-w-md space-y-2" aria-labelledby="job-market-time-filter-label">
+          <Text id="job-market-time-filter-label" size="sm" variant="muted">
+            {jobMarketLab.pulseFiltersTimeLabel}
+          </Text>
+          <select
+            className="w-full rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent px-3 py-2 font-body text-base text-[var(--foreground)]"
+            value={timeWindow}
+            onChange={(event) => {
+              setTimeWindow(event.target.value as JobMarketPulseTimeWindow);
+            }}
+          >
+            {(['all', '3m', '6m', '12m', '18m'] as const).map((window) => (
+              <option key={window} value={window}>
+                {jobMarketLab.pulseFilterTimeOptions[window]}
+              </option>
+            ))}
+          </select>
+        </section>
+      ) : null}
+
       <section className="space-y-4" aria-labelledby="job-market-metrics-heading">
         <SectionHeader id="job-market-metrics-heading" as="h2" size="md" animated={false} showLeftAccent={false}>
           {jobMarketLab.metricsHeading}
@@ -144,7 +193,7 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
               {jobMarketLab.documentCountLabel}
             </Text>
             <Text className="text-3xl font-semibold tabular-nums tracking-tight">
-              {snapshot.documentCount}
+              {displaySnapshot.documentCount}
             </Text>
           </div>
           <div className="space-y-1">
@@ -152,7 +201,7 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
               {jobMarketLab.publishedAtLabel}
             </Text>
             <Text className="text-xl font-medium tracking-tight">
-              {formatPublishedAt(snapshot.publishedAt)}
+              {formatPublishedAt(displaySnapshot.publishedAt)}
             </Text>
           </div>
         </div>
@@ -175,7 +224,7 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
               {jobMarketLab.seniorityLabel}
             </Text>
             <FrequencyBars
-              items={snapshot.seniority}
+              items={displaySnapshot.seniority}
               labelledBy={taxonomyId}
             />
           </div>
@@ -184,7 +233,7 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
               {jobMarketLab.roleFamilyLabel}
             </Text>
             <FrequencyBars
-              items={snapshot.roleFamily}
+              items={displaySnapshot.roleFamily}
               labelledBy={taxonomyId}
             />
           </div>
@@ -195,7 +244,7 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
         <SectionHeader id={clustersId} as="h2" size="md" animated={false} showLeftAccent={false}>
           {jobMarketLab.clustersHeading}
         </SectionHeader>
-        <ClusterProjection snapshot={snapshot} />
+        <ClusterProjection snapshot={displaySnapshot} />
       </section>
     </div>
   );

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -11,6 +11,14 @@
   "seniorityLabel": "Seniority",
   "roleFamilyLabel": "Role family",
   "clustersHeading": "Requirement themes",
+  "pulseFiltersTimeLabel": "Time window",
+  "pulseFilterTimeOptions": {
+    "all": "All published documents",
+    "3m": "Last 3 months",
+    "6m": "Last 6 months",
+    "12m": "Last 12 months",
+    "18m": "Last 18 months"
+  },
   "admin": {
     "heading": "Corpus recompute",
     "description": "Start an analysis run against the active corpus. Only one run may be queued or in progress at a time.",
@@ -122,7 +130,24 @@
     "themeLabelSaveLabel": "Save override",
     "themeLabelSavingLabel": "SavingÔÇª",
     "themeLabelSavedMessage": "Override saved for theme {clusterKey}. It will appear after the next recompute.",
-    "themeLabelSizeLabel": "Documents"
+    "themeLabelSizeLabel": "Documents",
+    "pulseFiltersHeading": "Themes and technology filters",
+    "pulseFiltersDescription": "Slice the published pulse by time, seniority, role family, and employer tier. Filters use corpus metadata and never expose raw job descriptions or compensation.",
+    "pulseFiltersLoading": "Loading filterable pulse…",
+    "pulseFiltersEmpty": "No filterable corpus metadata yet. Start a recompute after the corpus has active documents.",
+    "pulseFiltersError": "Pulse filters are temporarily unavailable.",
+    "pulseFiltersTimeLabel": "Time window",
+    "pulseFiltersAllOption": "All",
+    "pulseFiltersDocumentCountLabel": "Matching documents: {count}",
+    "pulseFiltersTechnologiesLabel": "Filtered technologies",
+    "pulseFiltersThemesLabel": "Filtered themes",
+    "pulseFilterTimeOptions": {
+      "all": "All published documents",
+      "3m": "Last 3 months",
+      "6m": "Last 6 months",
+      "12m": "Last 12 months",
+      "18m": "Last 18 months"
+    }
   },
   "employerAdmin": {
     "heading": "Employer registry",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -270,6 +270,14 @@ export interface JobMarketLabMetadataAdminCopy {
   emptyList: string;
 }
 
+export interface JobMarketPulseFilterTimeOptions {
+  all: string;
+  '3m': string;
+  '6m': string;
+  '12m': string;
+  '18m': string;
+}
+
 export interface JobMarketLabConsoleCopy {
   heading: string;
   description: string;
@@ -299,6 +307,17 @@ export interface JobMarketLabConsoleCopy {
   themeLabelSavingLabel: string;
   themeLabelSavedMessage: string;
   themeLabelSizeLabel: string;
+  pulseFiltersHeading: string;
+  pulseFiltersDescription: string;
+  pulseFiltersLoading: string;
+  pulseFiltersEmpty: string;
+  pulseFiltersError: string;
+  pulseFiltersTimeLabel: string;
+  pulseFiltersAllOption: string;
+  pulseFiltersDocumentCountLabel: string;
+  pulseFiltersTechnologiesLabel: string;
+  pulseFiltersThemesLabel: string;
+  pulseFilterTimeOptions: JobMarketPulseFilterTimeOptions;
 }
 
 export interface JobMarketLabPayPrestigeAnalyticsCopy {
@@ -340,6 +359,8 @@ export interface JobMarketLabPageData {
   seniorityLabel: string;
   roleFamilyLabel: string;
   clustersHeading: string;
+  pulseFiltersTimeLabel: string;
+  pulseFilterTimeOptions: JobMarketPulseFilterTimeOptions;
   admin: JobMarketLabAdminCopy;
   corpusAdmin: JobMarketLabCorpusAdminData;
   upload: JobMarketLabUploadCopy;

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -143,6 +143,16 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(page, 'seniorityLabel', 'jobMarketLab');
   requireString(page, 'roleFamilyLabel', 'jobMarketLab');
   requireString(page, 'clustersHeading', 'jobMarketLab');
+  requireString(page, 'pulseFiltersTimeLabel', 'jobMarketLab');
+  const pulseFilterTimeOptions = requireRecord(
+    page.pulseFilterTimeOptions,
+    'jobMarketLab.pulseFilterTimeOptions',
+  );
+  requireString(pulseFilterTimeOptions, 'all', 'jobMarketLab.pulseFilterTimeOptions');
+  requireString(pulseFilterTimeOptions, '3m', 'jobMarketLab.pulseFilterTimeOptions');
+  requireString(pulseFilterTimeOptions, '6m', 'jobMarketLab.pulseFilterTimeOptions');
+  requireString(pulseFilterTimeOptions, '12m', 'jobMarketLab.pulseFilterTimeOptions');
+  requireString(pulseFilterTimeOptions, '18m', 'jobMarketLab.pulseFilterTimeOptions');
   const admin = requireRecord(page.admin, 'jobMarketLab.admin');
   requireString(admin, 'heading', 'jobMarketLab.admin');
   requireString(admin, 'description', 'jobMarketLab.admin');
@@ -353,6 +363,25 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(consoleCopy, 'themeLabelSavingLabel', 'jobMarketLab.console');
   requireString(consoleCopy, 'themeLabelSavedMessage', 'jobMarketLab.console');
   requireString(consoleCopy, 'themeLabelSizeLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersHeading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersDescription', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersLoading', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersEmpty', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersError', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersTimeLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersAllOption', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersDocumentCountLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersTechnologiesLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'pulseFiltersThemesLabel', 'jobMarketLab.console');
+  const consolePulseFilterTimeOptions = requireRecord(
+    consoleCopy.pulseFilterTimeOptions,
+    'jobMarketLab.console.pulseFilterTimeOptions',
+  );
+  requireString(consolePulseFilterTimeOptions, 'all', 'jobMarketLab.console.pulseFilterTimeOptions');
+  requireString(consolePulseFilterTimeOptions, '3m', 'jobMarketLab.console.pulseFilterTimeOptions');
+  requireString(consolePulseFilterTimeOptions, '6m', 'jobMarketLab.console.pulseFilterTimeOptions');
+  requireString(consolePulseFilterTimeOptions, '12m', 'jobMarketLab.console.pulseFilterTimeOptions');
+  requireString(consolePulseFilterTimeOptions, '18m', 'jobMarketLab.console.pulseFilterTimeOptions');
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/lib/fetch-owner-job-market-pulse.test.ts
+++ b/src/lib/fetch-owner-job-market-pulse.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fetchOwnerJobMarketPulseSource,
+  ownerPulseSourceFromPayload,
+} from './fetch-owner-job-market-pulse';
+
+describe('ownerPulseSourceFromPayload', () => {
+  it('parses owner corpusMeta with employer tiers from stored snapshot payload', () => {
+    const source = ownerPulseSourceFromPayload({
+      documentCount: 1,
+      publishedAt: '2026-07-14T12:00:00.000Z',
+      technologies: [{ name: 'python', count: 1 }],
+      skills: [{ name: 'python', count: 1 }],
+      seniority: [{ name: 'senior', count: 1 }],
+      roleFamily: [{ name: 'data-science', count: 1 }],
+      clusters: [{ id: 0, size: 1, label: 'Python stack' }],
+      projection: [{ x: 0.1, y: 0.2, clusterId: 0 }],
+      corpusMeta: {
+        documents: [
+          {
+            id: 'jd-1',
+            collectedAt: '2026-06-01T00:00:00.000Z',
+            seniority: 'senior',
+            roleFamily: 'data-science',
+            employerSizeTier: 'enterprise',
+            employerPrestigeTier: 'elite',
+            technologies: ['python'],
+            clusterId: 0,
+            projectionX: 0.1,
+            projectionY: 0.2,
+          },
+        ],
+      },
+    });
+
+    expect(source?.corpusMeta.documents[0]).toMatchObject({
+      employerSizeTier: 'enterprise',
+      employerPrestigeTier: 'elite',
+    });
+  });
+
+  it('returns null when corpusMeta is absent', () => {
+    expect(
+      ownerPulseSourceFromPayload({
+        documentCount: 1,
+        publishedAt: '2026-07-14T12:00:00.000Z',
+        technologies: [],
+        skills: [],
+        seniority: [],
+        roleFamily: [],
+        clusters: [],
+        projection: [],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('fetchOwnerJobMarketPulseSource', () => {
+  it('uses injected fetchOwnerPayload seam', async () => {
+    const source = await fetchOwnerJobMarketPulseSource({
+      fetchOwnerPayload: async () => ({
+        snapshot: {
+          documentCount: 1,
+          publishedAt: '2026-07-14T12:00:00.000Z',
+          skills: [],
+          seniority: [],
+          roleFamily: [],
+          clusters: [],
+          projection: [],
+        },
+        corpusMeta: {
+          documents: [
+            {
+              id: 'jd-1',
+              collectedAt: '2026-06-01T00:00:00.000Z',
+              technologies: [],
+              clusterId: 0,
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(source?.corpusMeta.documents).toHaveLength(1);
+  });
+});

--- a/src/lib/fetch-owner-job-market-pulse.ts
+++ b/src/lib/fetch-owner-job-market-pulse.ts
@@ -1,0 +1,189 @@
+import type { JobMarketSnapshot } from './job-market-lab';
+import type { JobMarketCorpusMeta, JobMarketPulseInput } from './job-market-pulse-filters';
+
+export type OwnerJobMarketPulseSource = JobMarketPulseInput & {
+  corpusMeta: JobMarketCorpusMeta;
+};
+
+export type OwnerSnapshotPayloadClient = {
+  getPublication: () => Promise<{ currentSnapshotId: string | null }>;
+  getSnapshotPayload: (id: string) => Promise<unknown>;
+};
+
+export type FetchOwnerJobMarketPulseSourceDeps = {
+  fetchOwnerPayload?: () => Promise<OwnerJobMarketPulseSource | null>;
+};
+
+export type FetchOwnerJobMarketPulseSource = (
+  deps?: FetchOwnerJobMarketPulseSourceDeps,
+) => Promise<OwnerJobMarketPulseSource | null>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+function parsePayload(raw: unknown): Record<string, unknown> | null {
+  if (isRecord(raw)) {
+    return raw;
+  }
+  if (typeof raw === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function toSnapshot(payload: Record<string, unknown>): JobMarketSnapshot {
+  const technologies = Array.isArray(payload.technologies)
+    ? (payload.technologies as JobMarketSnapshot['technologies'])
+    : Array.isArray(payload.skills)
+      ? (payload.skills as JobMarketSnapshot['skills'])
+      : [];
+
+  return {
+    documentCount: typeof payload.documentCount === 'number' ? payload.documentCount : 0,
+    publishedAt:
+      typeof payload.publishedAt === 'string' ? payload.publishedAt : new Date(0).toISOString(),
+    technologies,
+    skills: technologies ?? [],
+    seniority: Array.isArray(payload.seniority)
+      ? (payload.seniority as JobMarketSnapshot['seniority'])
+      : [],
+    roleFamily: Array.isArray(payload.roleFamily)
+      ? (payload.roleFamily as JobMarketSnapshot['roleFamily'])
+      : [],
+    clusters: Array.isArray(payload.clusters)
+      ? (payload.clusters as JobMarketSnapshot['clusters'])
+      : [],
+    projection: Array.isArray(payload.projection)
+      ? (payload.projection as JobMarketSnapshot['projection'])
+      : [],
+  };
+}
+
+function toCorpusMeta(payload: Record<string, unknown>): JobMarketCorpusMeta | null {
+  const rawMeta = payload.corpusMeta;
+  if (!isRecord(rawMeta) || !Array.isArray(rawMeta.documents)) {
+    return null;
+  }
+
+  const documents = rawMeta.documents
+    .map((item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+      if (typeof item.id !== 'string' || typeof item.collectedAt !== 'string') {
+        return null;
+      }
+      if (typeof item.clusterId !== 'number' || !Array.isArray(item.technologies)) {
+        return null;
+      }
+
+      return {
+        id: item.id,
+        collectedAt: item.collectedAt,
+        seniority:
+          typeof item.seniority === 'string'
+            ? (item.seniority as JobMarketCorpusMeta['documents'][number]['seniority'])
+            : undefined,
+        roleFamily:
+          typeof item.roleFamily === 'string'
+            ? (item.roleFamily as JobMarketCorpusMeta['documents'][number]['roleFamily'])
+            : undefined,
+        employerSizeTier:
+          typeof item.employerSizeTier === 'string'
+            ? (item.employerSizeTier as JobMarketCorpusMeta['documents'][number]['employerSizeTier'])
+            : undefined,
+        employerPrestigeTier:
+          typeof item.employerPrestigeTier === 'string'
+            ? (item.employerPrestigeTier as JobMarketCorpusMeta['documents'][number]['employerPrestigeTier'])
+            : undefined,
+        technologies: item.technologies.filter((tech): tech is string => typeof tech === 'string'),
+        clusterId: item.clusterId,
+        projectionX: typeof item.projectionX === 'number' ? item.projectionX : undefined,
+        projectionY: typeof item.projectionY === 'number' ? item.projectionY : undefined,
+      };
+    })
+    .filter((item): item is NonNullable<typeof item> => item != null);
+
+  return documents.length > 0 ? { documents } : null;
+}
+
+export function ownerPulseSourceFromPayload(
+  raw: unknown,
+): OwnerJobMarketPulseSource | null {
+  const payload = parsePayload(raw);
+  if (!payload) {
+    return null;
+  }
+
+  const corpusMeta = toCorpusMeta(payload);
+  if (!corpusMeta) {
+    return null;
+  }
+
+  return {
+    snapshot: toSnapshot(payload),
+    corpusMeta,
+  };
+}
+
+export function ownerSnapshotClientFromAmplify(client: {
+  models: {
+    LabPublication: {
+      get: (input: { id: string }) => Promise<{
+        data: { currentSnapshotId?: string | null } | null;
+        errors?: Array<{ message: string }> | null;
+      }>;
+    };
+    CorpusSnapshot: {
+      get: (input: { id: string }) => Promise<{
+        data: { payload?: unknown } | null;
+        errors?: Array<{ message: string }> | null;
+      }>;
+    };
+  };
+}): OwnerSnapshotPayloadClient {
+  return {
+    async getPublication() {
+      const { data, errors } = await client.models.LabPublication.get({ id: 'current' });
+      if (errors?.length) {
+        throw new Error(errors.map((error) => error.message).join('; '));
+      }
+      return { currentSnapshotId: data?.currentSnapshotId ?? null };
+    },
+    async getSnapshotPayload(id) {
+      const { data, errors } = await client.models.CorpusSnapshot.get({ id });
+      if (errors?.length) {
+        throw new Error(errors.map((error) => error.message).join('; '));
+      }
+      return data?.payload ?? null;
+    },
+  };
+}
+
+export async function fetchOwnerJobMarketPulseSourceViaClient(
+  client: OwnerSnapshotPayloadClient,
+): Promise<OwnerJobMarketPulseSource | null> {
+  const publication = await client.getPublication();
+  if (!publication.currentSnapshotId) {
+    return null;
+  }
+
+  const payload = await client.getSnapshotPayload(publication.currentSnapshotId);
+  return ownerPulseSourceFromPayload(payload);
+}
+
+export async function fetchOwnerJobMarketPulseSource(
+  deps: FetchOwnerJobMarketPulseSourceDeps = {},
+): Promise<OwnerJobMarketPulseSource | null> {
+  if (deps.fetchOwnerPayload) {
+    return deps.fetchOwnerPayload();
+  }
+
+  return null;
+}

--- a/src/lib/job-market-lab.test.ts
+++ b/src/lib/job-market-lab.test.ts
@@ -97,6 +97,63 @@ describe('getPublishedJobMarketSnapshot', () => {
     });
   });
 
+  it('keeps public-safe corpusMeta but strips employer tiers from guest snapshots', async () => {
+    const result = await getPublishedJobMarketSnapshot({
+      fetchPublished: async () =>
+        ({
+          documentCount: 1,
+          publishedAt: '2026-07-01T00:00:00.000Z',
+          skills: [{ name: 'python', count: 1 }],
+          seniority: [],
+          roleFamily: [],
+          clusters: [],
+          projection: [],
+          corpusMeta: {
+            documents: [
+              {
+                id: 'jd-1',
+                collectedAt: '2026-06-01T00:00:00.000Z',
+                seniority: 'senior',
+                roleFamily: 'data-science',
+                employerSizeTier: 'enterprise',
+                employerPrestigeTier: 'elite',
+                technologies: ['python'],
+                clusterId: 0,
+                projectionX: 0.1,
+                projectionY: 0.2,
+              },
+            ],
+          },
+        }) as never,
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      snapshot: {
+        documentCount: 1,
+        publishedAt: '2026-07-01T00:00:00.000Z',
+        technologies: [{ name: 'python', count: 1 }],
+        skills: [{ name: 'python', count: 1 }],
+        seniority: [],
+        roleFamily: [],
+        clusters: [],
+        projection: [],
+        corpusMeta: {
+          documents: [
+            {
+              id: 'jd-1',
+              collectedAt: '2026-06-01T00:00:00.000Z',
+              technologies: ['python'],
+              clusterId: 0,
+              projectionX: 0.1,
+              projectionY: 0.2,
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('does not expose raw job description or employer identity fields', async () => {
     const result = await getPublishedJobMarketSnapshot({
       fetchPublished: async () =>

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -8,6 +8,7 @@ import {
 } from './fetch-published-job-market-snapshot';
 import { readAmplifyOutputs } from './read-amplify-outputs';
 import { defaultStartJobMarketRecompute } from './start-job-market-recompute-client';
+import type { JobMarketPublicCorpusMeta } from './job-market-pulse-filters';
 
 export type SkillFrequency = {
   name: string;
@@ -40,6 +41,7 @@ export type JobMarketSnapshot = {
   roleFamily: TaxonomyBucket[];
   clusters: ClusterSummary[];
   projection: ProjectionPoint[];
+  corpusMeta?: JobMarketPublicCorpusMeta;
 };
 
 export type PublishedJobMarketResult =
@@ -93,7 +95,43 @@ export {
   type AmplifyAnalysisRunModelClient,
 } from './job-market-analysis-runs-amplify';
 
-function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
+function sanitisePublicCorpusMeta(value: unknown): JobMarketPublicCorpusMeta | undefined {
+  if (typeof value !== 'object' || value == null || !('documents' in value)) {
+    return undefined;
+  }
+
+  const record = value as { documents?: unknown };
+  if (!Array.isArray(record.documents)) {
+    return undefined;
+  }
+
+  const documents = record.documents
+    .map((item) => {
+      if (typeof item !== 'object' || item == null) {
+        return null;
+      }
+      const doc = item as Record<string, unknown>;
+      if (typeof doc.id !== 'string' || typeof doc.collectedAt !== 'string') {
+        return null;
+      }
+      if (typeof doc.clusterId !== 'number' || !Array.isArray(doc.technologies)) {
+        return null;
+      }
+      return {
+        id: doc.id,
+        collectedAt: doc.collectedAt,
+        technologies: doc.technologies.filter((tech): tech is string => typeof tech === 'string'),
+        clusterId: doc.clusterId,
+        projectionX: typeof doc.projectionX === 'number' ? doc.projectionX : undefined,
+        projectionY: typeof doc.projectionY === 'number' ? doc.projectionY : undefined,
+      };
+    })
+    .filter((item): item is NonNullable<typeof item> => item != null);
+
+  return documents.length > 0 ? { documents } : undefined;
+}
+
+function sanitiseSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
   const technologies = snapshot.technologies ?? snapshot.skills ?? [];
   const sanitised: JobMarketSnapshot = {
     documentCount: snapshot.documentCount,
@@ -105,6 +143,11 @@ function sanitizeSnapshot(snapshot: JobMarketSnapshot): JobMarketSnapshot {
     clusters: snapshot.clusters ?? [],
     projection: snapshot.projection ?? [],
   };
+
+  const corpusMeta = sanitisePublicCorpusMeta(snapshot.corpusMeta);
+  if (corpusMeta) {
+    sanitised.corpusMeta = corpusMeta;
+  }
 
   return sanitised;
 }
@@ -147,7 +190,7 @@ export async function getPublishedJobMarketSnapshot(
 
   return {
     status: 'published',
-    snapshot: sanitizeSnapshot(snapshot),
+    snapshot: sanitiseSnapshot(snapshot),
   };
 }
 
@@ -268,4 +311,27 @@ export {
   createDefaultAmplifyPayPrestigeAnalyticsDeps,
   type AmplifyPayPrestigeAnalyticsDeps,
 } from './job-market-pay-prestige-analytics-amplify';
+
+export {
+  filterJobMarketPulse,
+  sanitiseFilterSelection,
+  toPublicCorpusMeta,
+  OWNER_PULSE_FILTER_DIMENSIONS,
+  PUBLIC_PULSE_FILTER_DIMENSIONS,
+  type FilteredJobMarketPulse,
+  type FilterJobMarketPulseOptions,
+  type JobMarketCorpusMeta,
+  type JobMarketDocumentPulseMeta,
+  type JobMarketPublicCorpusMeta,
+  type JobMarketPulseFilterSelection,
+  type JobMarketPulseInput,
+  type JobMarketPulseTimeWindow,
+} from './job-market-pulse-filters';
+
+export {
+  fetchOwnerJobMarketPulseSource,
+  type FetchOwnerJobMarketPulseSource,
+  type FetchOwnerJobMarketPulseSourceDeps,
+  type OwnerJobMarketPulseSource,
+} from './fetch-owner-job-market-pulse';
 

--- a/src/lib/job-market-pulse-filters.test.ts
+++ b/src/lib/job-market-pulse-filters.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import type { JobMarketSnapshot } from './job-market-lab';
+import {
+  filterJobMarketPulse,
+  OWNER_PULSE_FILTER_DIMENSIONS,
+  PUBLIC_PULSE_FILTER_DIMENSIONS,
+  sanitiseFilterSelection,
+  type JobMarketCorpusMeta,
+  type JobMarketPulseFilterSelection,
+} from './job-market-pulse-filters';
+
+const snapshot: JobMarketSnapshot = {
+  documentCount: 4,
+  publishedAt: '2026-07-14T12:00:00.000Z',
+  technologies: [
+    { name: 'python', count: 3 },
+    { name: 'sql', count: 2 },
+  ],
+  skills: [
+    { name: 'python', count: 3 },
+    { name: 'sql', count: 2 },
+  ],
+  seniority: [
+    { name: 'senior', count: 2 },
+    { name: 'mid', count: 2 },
+  ],
+  roleFamily: [
+    { name: 'data-science', count: 3 },
+    { name: 'analytics', count: 1 },
+  ],
+  clusters: [
+    { id: 0, size: 2, label: 'Python stack' },
+    { id: 1, size: 2, label: 'SQL analytics' },
+  ],
+  projection: [
+    { x: 0.1, y: 0.2, clusterId: 0 },
+    { x: 0.3, y: 0.4, clusterId: 1 },
+    { x: 0.5, y: 0.6, clusterId: 0 },
+    { x: 0.7, y: 0.8, clusterId: 1 },
+  ],
+};
+
+const corpusMeta: JobMarketCorpusMeta = {
+  documents: [
+    {
+      id: 'jd-1',
+      collectedAt: '2026-06-01T00:00:00.000Z',
+      seniority: 'senior',
+      roleFamily: 'data-science',
+      employerSizeTier: 'enterprise',
+      employerPrestigeTier: 'elite',
+      technologies: ['python', 'sql'],
+      clusterId: 0,
+      projectionX: 0.1,
+      projectionY: 0.2,
+    },
+    {
+      id: 'jd-2',
+      collectedAt: '2026-01-15T00:00:00.000Z',
+      seniority: 'mid',
+      roleFamily: 'analytics',
+      employerSizeTier: 'scaleup',
+      employerPrestigeTier: 'mid',
+      technologies: ['python'],
+      clusterId: 1,
+      projectionX: 0.3,
+      projectionY: 0.4,
+    },
+    {
+      id: 'jd-3',
+      collectedAt: '2025-06-01T00:00:00.000Z',
+      seniority: 'senior',
+      roleFamily: 'data-science',
+      employerSizeTier: 'enterprise',
+      employerPrestigeTier: 'high',
+      technologies: ['python'],
+      clusterId: 0,
+      projectionX: 0.5,
+      projectionY: 0.6,
+    },
+    {
+      id: 'jd-4',
+      collectedAt: '2024-01-01T00:00:00.000Z',
+      seniority: 'mid',
+      roleFamily: 'data-science',
+      employerSizeTier: 'startup',
+      employerPrestigeTier: 'low',
+      technologies: ['sql'],
+      clusterId: 1,
+      projectionX: 0.7,
+      projectionY: 0.8,
+    },
+  ],
+};
+
+const now = new Date('2026-07-14T12:00:00.000Z');
+
+describe('filterJobMarketPulse', () => {
+  it('returns snapshot aggregates unchanged when corpusMeta is absent', () => {
+    const result = filterJobMarketPulse(
+      { snapshot },
+      {},
+      { audience: 'owner', now },
+    );
+
+    expect(result.documentCount).toBe(4);
+    expect(result.technologies).toEqual(snapshot.technologies);
+    expect(result.clusters).toEqual(snapshot.clusters);
+  });
+
+  it('filters technologies and themes by seniority for owner audience', () => {
+    const selection: JobMarketPulseFilterSelection = { seniority: 'senior' };
+
+    const result = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      selection,
+      { audience: 'owner', now },
+    );
+
+    expect(result.documentCount).toBe(2);
+    expect(result.technologies).toEqual([
+      { name: 'python', count: 2 },
+      { name: 'sql', count: 1 },
+    ]);
+    expect(result.clusters).toEqual([
+      { id: 0, size: 2, label: 'Python stack' },
+      { id: 1, size: 0, label: 'SQL analytics' },
+    ]);
+    expect(result.seniority).toEqual([{ name: 'senior', count: 2 }]);
+  });
+
+  it('filters by role family and employer prestige tier', () => {
+    const result = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { roleFamily: 'data-science', employerPrestigeTier: 'elite' },
+      { audience: 'owner', now },
+    );
+
+    expect(result.documentCount).toBe(1);
+    expect(result.technologies).toEqual([{ name: 'python', count: 1 }, { name: 'sql', count: 1 }]);
+  });
+
+  it('filters by employer size tier', () => {
+    const result = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { employerSizeTier: 'scaleup' },
+      { audience: 'owner', now },
+    );
+
+    expect(result.documentCount).toBe(1);
+    expect(result.roleFamily).toEqual([{ name: 'analytics', count: 1 }]);
+  });
+
+  it('filters by time window using collectedAt', () => {
+    const result = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { timeWindow: '6m' },
+      { audience: 'owner', now },
+    );
+
+    expect(result.documentCount).toBe(2);
+    expect(result.technologies).toEqual([
+      { name: 'python', count: 2 },
+      { name: 'sql', count: 1 },
+    ]);
+  });
+
+  it('rebuilds projection points from filtered corpusMeta', () => {
+    const result = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { seniority: 'mid' },
+      { audience: 'owner', now },
+    );
+
+    expect(result.projection).toEqual([
+      { x: 0.3, y: 0.4, clusterId: 1 },
+      { x: 0.7, y: 0.8, clusterId: 1 },
+    ]);
+  });
+
+  it('ignores employer tier filters for public audience', () => {
+    const ownerOnly = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { employerPrestigeTier: 'elite' },
+      { audience: 'owner', now },
+    );
+    const publicAttempt = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { employerPrestigeTier: 'elite' },
+      { audience: 'public', now },
+    );
+
+    expect(ownerOnly.documentCount).toBe(1);
+    expect(publicAttempt.documentCount).toBe(4);
+  });
+
+  it('allows public time window filtering only', () => {
+    const result = filterJobMarketPulse(
+      { snapshot, corpusMeta },
+      { timeWindow: '12m' },
+      { audience: 'public', now },
+    );
+
+    expect(result.documentCount).toBe(2);
+  });
+});
+
+describe('sanitiseFilterSelection', () => {
+  it('exposes owner and public dimension sets', () => {
+    expect(OWNER_PULSE_FILTER_DIMENSIONS).toContain('employerPrestigeTier');
+    expect(PUBLIC_PULSE_FILTER_DIMENSIONS).toEqual(['timeWindow']);
+  });
+
+  it('strips sensitive dimensions for public audience', () => {
+    expect(
+      sanitiseFilterSelection(
+        {
+          timeWindow: '6m',
+          seniority: 'senior',
+          employerPrestigeTier: 'elite',
+        },
+        'public',
+      ),
+    ).toEqual({ timeWindow: '6m' });
+  });
+});

--- a/src/lib/job-market-pulse-filters.ts
+++ b/src/lib/job-market-pulse-filters.ts
@@ -1,0 +1,289 @@
+import type {
+  ClusterSummary,
+  JobMarketSnapshot,
+  ProjectionPoint,
+  SkillFrequency,
+  TaxonomyBucket,
+} from './job-market-lab';
+import type {
+  EmployerPrestigeTier,
+  EmployerSizeTier,
+  JobDescriptionRoleFamily,
+  JobDescriptionSeniority,
+} from './job-market-employers';
+
+export const OWNER_PULSE_FILTER_DIMENSIONS = [
+  'timeWindow',
+  'seniority',
+  'roleFamily',
+  'employerSizeTier',
+  'employerPrestigeTier',
+] as const;
+
+export const PUBLIC_PULSE_FILTER_DIMENSIONS = ['timeWindow'] as const;
+
+export type JobMarketPulseTimeWindow = 'all' | '3m' | '6m' | '12m' | '18m';
+
+export type JobMarketPulseFilterSelection = {
+  timeWindow?: JobMarketPulseTimeWindow;
+  seniority?: JobDescriptionSeniority | 'all';
+  roleFamily?: JobDescriptionRoleFamily | 'all';
+  employerSizeTier?: EmployerSizeTier | 'all';
+  employerPrestigeTier?: EmployerPrestigeTier | 'all';
+};
+
+export type JobMarketDocumentPulseMeta = {
+  id: string;
+  collectedAt: string;
+  seniority?: JobDescriptionSeniority;
+  roleFamily?: JobDescriptionRoleFamily;
+  employerSizeTier?: EmployerSizeTier;
+  employerPrestigeTier?: EmployerPrestigeTier;
+  technologies: string[];
+  clusterId: number;
+  projectionX?: number;
+  projectionY?: number;
+};
+
+export type JobMarketPublicDocumentPulseMeta = Pick<
+  JobMarketDocumentPulseMeta,
+  'id' | 'collectedAt' | 'technologies' | 'clusterId' | 'projectionX' | 'projectionY'
+>;
+
+export type JobMarketCorpusMeta = {
+  documents: JobMarketDocumentPulseMeta[];
+};
+
+export type JobMarketPublicCorpusMeta = {
+  documents: JobMarketPublicDocumentPulseMeta[];
+};
+
+export type JobMarketPulseInput = {
+  snapshot: JobMarketSnapshot;
+  corpusMeta?: JobMarketCorpusMeta | JobMarketPublicCorpusMeta;
+};
+
+export type FilteredJobMarketPulse = {
+  documentCount: number;
+  technologies: SkillFrequency[];
+  skills: SkillFrequency[];
+  seniority: TaxonomyBucket[];
+  roleFamily: TaxonomyBucket[];
+  clusters: ClusterSummary[];
+  projection: ProjectionPoint[];
+};
+
+export type FilterJobMarketPulseOptions = {
+  audience: 'owner' | 'public';
+  now?: Date;
+};
+
+const TIME_WINDOW_MONTHS: Record<Exclude<JobMarketPulseTimeWindow, 'all'>, number> = {
+  '3m': 3,
+  '6m': 6,
+  '12m': 12,
+  '18m': 18,
+};
+
+function isWithinTimeWindow(
+  collectedAt: string,
+  timeWindow: JobMarketPulseTimeWindow,
+  now: Date,
+): boolean {
+  if (timeWindow === 'all') {
+    return true;
+  }
+
+  const collected = new Date(collectedAt);
+  if (Number.isNaN(collected.getTime())) {
+    return false;
+  }
+
+  const months = TIME_WINDOW_MONTHS[timeWindow];
+  const cutoff = new Date(now);
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - months);
+  return collected.getTime() >= cutoff.getTime();
+}
+
+function matchesSelection(
+  document: JobMarketDocumentPulseMeta,
+  selection: JobMarketPulseFilterSelection,
+  now: Date,
+): boolean {
+  const timeWindow = selection.timeWindow ?? 'all';
+  if (!isWithinTimeWindow(document.collectedAt, timeWindow, now)) {
+    return false;
+  }
+
+  if (selection.seniority && selection.seniority !== 'all') {
+    if (document.seniority !== selection.seniority) {
+      return false;
+    }
+  }
+
+  if (selection.roleFamily && selection.roleFamily !== 'all') {
+    if (document.roleFamily !== selection.roleFamily) {
+      return false;
+    }
+  }
+
+  if (selection.employerSizeTier && selection.employerSizeTier !== 'all') {
+    if (document.employerSizeTier !== selection.employerSizeTier) {
+      return false;
+    }
+  }
+
+  if (selection.employerPrestigeTier && selection.employerPrestigeTier !== 'all') {
+    if (document.employerPrestigeTier !== selection.employerPrestigeTier) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function countByField<T extends string>(
+  documents: JobMarketDocumentPulseMeta[],
+  field: 'seniority' | 'roleFamily',
+): TaxonomyBucket[] {
+  const counts = new Map<string, number>();
+  for (const document of documents) {
+    const value = document[field];
+    if (!value) {
+      continue;
+    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function aggregateTechnologies(documents: JobMarketDocumentPulseMeta[]): SkillFrequency[] {
+  const counts = new Map<string, number>();
+  for (const document of documents) {
+    for (const technology of document.technologies) {
+      counts.set(technology, (counts.get(technology) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function aggregateClusters(
+  documents: JobMarketDocumentPulseMeta[],
+  clusterLabels: Map<number, string>,
+): ClusterSummary[] {
+  const sizes = new Map<number, number>();
+  for (const document of documents) {
+    sizes.set(document.clusterId, (sizes.get(document.clusterId) ?? 0) + 1);
+  }
+
+  const clusterIds = [...new Set([...clusterLabels.keys(), ...sizes.keys()])].sort(
+    (a, b) => a - b,
+  );
+
+  return clusterIds.map((id) => ({
+    id,
+    size: sizes.get(id) ?? 0,
+    label: clusterLabels.get(id) ?? `Requirement theme ${id + 1}`,
+  }));
+}
+
+function buildProjection(documents: JobMarketDocumentPulseMeta[]): ProjectionPoint[] {
+  return documents
+    .filter(
+      (document) =>
+        document.projectionX != null &&
+        document.projectionY != null &&
+        Number.isFinite(document.projectionX) &&
+        Number.isFinite(document.projectionY),
+    )
+    .map((document) => ({
+      x: document.projectionX!,
+      y: document.projectionY!,
+      clusterId: document.clusterId,
+    }));
+}
+
+function snapshotToPulse(snapshot: JobMarketSnapshot): FilteredJobMarketPulse {
+  const technologies = snapshot.technologies ?? snapshot.skills ?? [];
+  return {
+    documentCount: snapshot.documentCount,
+    technologies,
+    skills: technologies,
+    seniority: snapshot.seniority ?? [],
+    roleFamily: snapshot.roleFamily ?? [],
+    clusters: snapshot.clusters ?? [],
+    projection: snapshot.projection ?? [],
+  };
+}
+
+export function sanitiseFilterSelection(
+  selection: JobMarketPulseFilterSelection,
+  audience: 'owner' | 'public',
+): JobMarketPulseFilterSelection {
+  if (audience === 'owner') {
+    return selection;
+  }
+
+  const timeWindow = selection.timeWindow;
+  return timeWindow && timeWindow !== 'all' ? { timeWindow } : {};
+}
+
+export function toPublicCorpusMeta(
+  corpusMeta: JobMarketCorpusMeta,
+): JobMarketPublicCorpusMeta {
+  return {
+    documents: corpusMeta.documents.map(
+      ({ id, collectedAt, technologies, clusterId, projectionX, projectionY }) => ({
+        id,
+        collectedAt,
+        technologies,
+        clusterId,
+        projectionX,
+        projectionY,
+      }),
+    ),
+  };
+}
+
+export function filterJobMarketPulse(
+  input: JobMarketPulseInput,
+  selection: JobMarketPulseFilterSelection,
+  options: FilterJobMarketPulseOptions,
+): FilteredJobMarketPulse {
+  const effectiveSelection = sanitiseFilterSelection(selection, options.audience);
+  const now = options.now ?? new Date();
+  const { snapshot, corpusMeta } = input;
+
+  if (!corpusMeta || corpusMeta.documents.length === 0) {
+    return snapshotToPulse(snapshot);
+  }
+
+  const filtered = corpusMeta.documents.filter((document) =>
+    matchesSelection(document, effectiveSelection, now),
+  );
+
+  if (filtered.length === corpusMeta.documents.length && Object.keys(effectiveSelection).length === 0) {
+    return snapshotToPulse(snapshot);
+  }
+
+  const clusterLabels = new Map(
+    (snapshot.clusters ?? []).map((cluster) => [cluster.id, cluster.label]),
+  );
+  const technologies = aggregateTechnologies(filtered);
+
+  return {
+    documentCount: filtered.length,
+    technologies,
+    skills: technologies,
+    seniority: countByField(filtered, 'seniority'),
+    roleFamily: countByField(filtered, 'roleFamily'),
+    clusters: aggregateClusters(filtered, clusterLabels),
+    projection: buildProjection(filtered),
+  };
+}


### PR DESCRIPTION
## Summary

- Add `filterJobMarketPulse` facade with owner vs public filter dimensions (time, seniority, role family, employer size/prestige tier) and Vitest coverage at the seam.
- Emit per-document `corpusMeta` on recompute; guest publication strips employer tiers and other owner-only fields while keeping a public-safe subset for time filtering.
- Wire owner console pulse filters panel and a minimal public time-window filter on the lab dashboard.

Closes #71

## Test plan

- [x] `npm test` (234 tests)
- [ ] Owner console: open pulse filters, slice by seniority / employer tier, confirm technology and theme counts update
- [ ] Public lab: confirm only time window filter appears when corpusMeta is published
- [ ] Guest snapshot query: confirm employer tiers and compensation never appear in network payload