### PR TITLE
Improve Job Signal Lab: salary disclosure, analytics/fit, and public redesign

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -22,6 +22,7 @@ const schema = a
       'other',
     ]),
     CompensationPeriod: a.enum(['year', 'month', 'day', 'hour']),
+    CompensationDisclosure: a.enum(['range', 'competitive', 'unknown']),
 
     Employer: a
       .model({
@@ -50,6 +51,7 @@ const schema = a
         compensationMin: a.float(),
         compensationMax: a.float(),
         compensationPeriod: a.ref('CompensationPeriod'),
+        compensationDisclosure: a.ref('CompensationDisclosure'),
       })
       .authorization((allow) => [
         allow.authenticated().to(['read', 'create', 'update', 'delete']),

--- a/amplify/functions/job-market-analyse/analyse.test.ts
+++ b/amplify/functions/job-market-analyse/analyse.test.ts
@@ -285,5 +285,18 @@ describe('analyseCorpus', () => {
     expect(result.metrics.estimatedCostUsd).toBeGreaterThan(0);
     expect(embed).toHaveBeenCalledOnce();
     expect(cachePut).toHaveBeenCalledOnce();
+
+    // Projection uses PCA coordinates, not raw first-two embedding dimensions.
+    const firstTwoDims = Array.from({ length: 8 }, (_, index) => index / 10);
+    expect(result.snapshot.projection[0]).not.toMatchObject({
+      x: firstTwoDims[0],
+      y: firstTwoDims[1],
+    });
+    expect(result.snapshot.corpusMeta?.documents[0]?.projectionX).toEqual(
+      result.snapshot.projection[0]?.x,
+    );
+    expect(result.snapshot.corpusMeta?.documents[0]?.projectionY).toEqual(
+      result.snapshot.projection[0]?.y,
+    );
   });
 });

--- a/amplify/functions/job-market-analyse/analyse.ts
+++ b/amplify/functions/job-market-analyse/analyse.ts
@@ -1,3 +1,4 @@
+import { projectEmbeddingsTo2D } from './project-embeddings-2d';
 import {
   matchTechnologiesInDocuments,
   type TechnologyFrequency,
@@ -291,9 +292,10 @@ export async function analyseCorpus(
       ),
     }));
 
-  const projection = documents.slice(0, maxProjectionPoints).map((document, index) => ({
-    x: vectors[index]?.[0] ?? 0,
-    y: vectors[index]?.[1] ?? 0,
+  const projected = projectEmbeddingsTo2D(vectors);
+  const projection = documents.slice(0, maxProjectionPoints).map((_, index) => ({
+    x: projected[index]?.x ?? 0,
+    y: projected[index]?.y ?? 0,
     clusterId: assignments[index] ?? 0,
   }));
 
@@ -312,8 +314,8 @@ export async function analyseCorpus(
       employerPrestigeTier: document.employerPrestigeTier,
       technologies: matched.map((technology) => technology.name),
       clusterId: assignments[index] ?? 0,
-      projectionX: vectors[index]?.[0],
-      projectionY: vectors[index]?.[1],
+      projectionX: projected[index]?.x,
+      projectionY: projected[index]?.y,
     };
   });
 

--- a/amplify/functions/job-market-analyse/project-embeddings-2d.test.ts
+++ b/amplify/functions/job-market-analyse/project-embeddings-2d.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { projectEmbeddingsTo2D } from './project-embeddings-2d';
+
+describe('projectEmbeddingsTo2D', () => {
+  it('returns empty output for empty input', () => {
+    expect(projectEmbeddingsTo2D([])).toEqual([]);
+  });
+
+  it('maps a single vector to the origin', () => {
+    expect(projectEmbeddingsTo2D([[1, 2, 3]])).toEqual([{ x: 0, y: 0 }]);
+  });
+
+  it('separates points that differ along one dominant axis', () => {
+    const points = projectEmbeddingsTo2D([
+      [0, 0, 0],
+      [10, 0, 0],
+      [20, 0, 0],
+      [0, 1, 0],
+      [10, 1, 0],
+      [20, 1, 0],
+    ]);
+
+    expect(points).toHaveLength(6);
+    const xs = points.map((point) => point.x);
+    const spanX = Math.max(...xs) - Math.min(...xs);
+    const ys = points.map((point) => point.y);
+    const spanY = Math.max(...ys) - Math.min(...ys);
+
+    // First PC should capture the large x-spread; second the small y-spread.
+    expect(spanX).toBeGreaterThan(spanY);
+    expect(spanX).toBeGreaterThan(10);
+    expect(spanY).toBeGreaterThan(0.5);
+  });
+
+  it('does not use raw first-two embedding dimensions as coordinates', () => {
+    // Variance lives in dims 2–3; dims 0–1 are constant noise.
+    const vectors = [
+      [0.01, 0.02, 0, 0],
+      [0.01, 0.02, 10, 0],
+      [0.01, 0.02, 0, 8],
+      [0.01, 0.02, 10, 8],
+    ];
+    const points = projectEmbeddingsTo2D(vectors);
+
+    const firstTwoDims = vectors.map((vector) => ({ x: vector[0]!, y: vector[1]! }));
+    expect(points).not.toEqual(firstTwoDims);
+
+    const spanX = Math.max(...points.map((p) => p.x)) - Math.min(...points.map((p) => p.x));
+    const spanY = Math.max(...points.map((p) => p.y)) - Math.min(...points.map((p) => p.y));
+    expect(spanX).toBeGreaterThan(1);
+    expect(spanY).toBeGreaterThan(1);
+  });
+
+  it('collapses identical vectors to the origin', () => {
+    const points = projectEmbeddingsTo2D([
+      [1, 1, 1],
+      [1, 1, 1],
+      [1, 1, 1],
+    ]);
+    for (const point of points) {
+      expect(Math.abs(point.x)).toBeLessThan(1e-9);
+      expect(Math.abs(point.y)).toBeLessThan(1e-9);
+    }
+  });
+});

--- a/amplify/functions/job-market-analyse/project-embeddings-2d.ts
+++ b/amplify/functions/job-market-analyse/project-embeddings-2d.ts
@@ -1,0 +1,138 @@
+/**
+ * Project embedding vectors to 2D via PCA (top two principal components).
+ * Uses the dual (Gram) form so cost scales with document count, not embedding width.
+ */
+
+export type Point2D = { x: number; y: number };
+
+function dot(a: number[], b: number[]): number {
+  let sum = 0;
+  const length = Math.min(a.length, b.length);
+  for (let index = 0; index < length; index += 1) {
+    sum += (a[index] ?? 0) * (b[index] ?? 0);
+  }
+  return sum;
+}
+
+function norm(vector: number[]): number {
+  return Math.sqrt(dot(vector, vector));
+}
+
+function matVec(matrix: number[][], vector: number[]): number[] {
+  return matrix.map((row) => dot(row, vector));
+}
+
+/** Power iteration for the leading eigenvector of a symmetric matrix. */
+function leadingEigenpair(
+  matrix: number[][],
+  exclude?: number[],
+  iterations: number = 64,
+): { value: number; vector: number[] } {
+  const n = matrix.length;
+  if (n === 0) {
+    return { value: 0, vector: [] };
+  }
+
+  let vector = Array.from({ length: n }, (_, index) =>
+    exclude ? (index === 0 ? 1 : 0.01 * index) : Math.sin(index + 1),
+  );
+
+  if (exclude) {
+    const projection = dot(vector, exclude);
+    vector = vector.map((value, index) => value - projection * (exclude[index] ?? 0));
+  }
+
+  let length = norm(vector);
+  if (length < 1e-12) {
+    vector = Array.from({ length: n }, (_, index) => (index === 0 ? 1 : 0));
+    if (exclude) {
+      const projection = dot(vector, exclude);
+      vector = vector.map((value, index) => value - projection * (exclude[index] ?? 0));
+      length = norm(vector);
+      if (length < 1e-12) {
+        return { value: 0, vector: new Array(n).fill(0) };
+      }
+    }
+  }
+  vector = vector.map((value) => value / (length || 1));
+
+  let value = 0;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    let next = matVec(matrix, vector);
+    if (exclude) {
+      const projection = dot(next, exclude);
+      next = next.map((entry, index) => entry - projection * (exclude[index] ?? 0));
+    }
+    const nextNorm = norm(next);
+    if (nextNorm < 1e-12) {
+      return { value: 0, vector };
+    }
+    vector = next.map((entry) => entry / nextNorm);
+    value = dot(vector, matVec(matrix, vector));
+  }
+
+  return { value, vector };
+}
+
+function buildGram(centered: number[][]): number[][] {
+  const n = centered.length;
+  const gram: number[][] = Array.from({ length: n }, () => new Array(n).fill(0));
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i; j < n; j += 1) {
+      const value = dot(centered[i]!, centered[j]!);
+      gram[i]![j] = value;
+      gram[j]![i] = value;
+    }
+  }
+  return gram;
+}
+
+/**
+ * Returns one 2D point per input vector (same order).
+ * Degenerate cases (empty, single point, identical vectors) collapse to the origin / axis.
+ */
+export function projectEmbeddingsTo2D(vectors: number[][]): Point2D[] {
+  const n = vectors.length;
+  if (n === 0) {
+    return [];
+  }
+
+  const dimensions = vectors[0]?.length ?? 0;
+  if (dimensions === 0) {
+    return vectors.map(() => ({ x: 0, y: 0 }));
+  }
+
+  if (n === 1) {
+    return [{ x: 0, y: 0 }];
+  }
+
+  const mean = new Array(dimensions).fill(0);
+  for (const vector of vectors) {
+    for (let dim = 0; dim < dimensions; dim += 1) {
+      mean[dim] += vector[dim] ?? 0;
+    }
+  }
+  for (let dim = 0; dim < dimensions; dim += 1) {
+    mean[dim] /= n;
+  }
+
+  const centered = vectors.map((vector) =>
+    Array.from({ length: dimensions }, (_, dim) => (vector[dim] ?? 0) - mean[dim]),
+  );
+
+  if (dimensions === 1) {
+    return centered.map((vector) => ({ x: vector[0] ?? 0, y: 0 }));
+  }
+
+  const gram = buildGram(centered);
+  const first = leadingEigenpair(gram);
+  const second = leadingEigenpair(gram, first.vector);
+
+  const scaleX = Math.sqrt(Math.max(first.value, 0));
+  const scaleY = Math.sqrt(Math.max(second.value, 0));
+
+  return Array.from({ length: n }, (_, index) => ({
+    x: scaleX * (first.vector[index] ?? 0),
+    y: scaleY * (second.vector[index] ?? 0),
+  }));
+}

--- a/amplify/functions/job-market-analyse/resource.ts
+++ b/amplify/functions/job-market-analyse/resource.ts
@@ -1,7 +1,8 @@
 import { defineFunction } from '@aws-amplify/backend';
 
 /**
- * Analysis worker: Bedrock embeddings (contentHash cache), descriptive stats, k-means.
+ * Analysis worker: Bedrock embeddings (contentHash cache), descriptive stats,
+ * k-means clusters, and PCA 2D projection for the published theme map.
  * Invoked asynchronously by the recompute orchestrator — not guest-callable.
  */
 export const jobMarketAnalyse = defineFunction({

--- a/amplify/functions/job-market-ingest/handler.ts
+++ b/amplify/functions/job-market-ingest/handler.ts
@@ -36,6 +36,7 @@ async function upsertJobDescription(
     compensationMin: record.compensationMin,
     compensationMax: record.compensationMax,
     compensationPeriod: record.compensationPeriod,
+    compensationDisclosure: record.compensationDisclosure,
   };
 
   const existing = await client.models.JobDescription.get({ id: record.id });

--- a/amplify/functions/job-market-ingest/ingest.test.ts
+++ b/amplify/functions/job-market-ingest/ingest.test.ts
@@ -30,6 +30,7 @@ describe('ingestJobDescription', () => {
         seniority: 'senior',
         roleFamily: 'data_science',
         source: 'confidential-board',
+        compensationDisclosure: 'unknown',
       },
     });
     expect(result.status).toBe('ingested');

--- a/amplify/functions/job-market-ingest/ingest.ts
+++ b/amplify/functions/job-market-ingest/ingest.ts
@@ -22,6 +22,12 @@ export const JOB_DESCRIPTION_ROLE_FAMILIES = [
 
 export const COMPENSATION_PERIODS = ['year', 'month', 'day', 'hour'] as const;
 
+export const COMPENSATION_DISCLOSURES = [
+  'range',
+  'competitive',
+  'unknown',
+] as const;
+
 export type JobDescriptionSeniority =
   (typeof JOB_DESCRIPTION_SENIORITIES)[number];
 
@@ -29,6 +35,9 @@ export type JobDescriptionRoleFamily =
   (typeof JOB_DESCRIPTION_ROLE_FAMILIES)[number];
 
 export type CompensationPeriod = (typeof COMPENSATION_PERIODS)[number];
+
+export type CompensationDisclosure =
+  (typeof COMPENSATION_DISCLOSURES)[number];
 
 /** Frontmatter may still use kebab-case; map to GraphQL-safe enum values. */
 const ROLE_FAMILY_ALIASES: Record<string, JobDescriptionRoleFamily> = {
@@ -55,6 +64,7 @@ export type JobDescriptionRecord = {
   compensationMin: number | null;
   compensationMax: number | null;
   compensationPeriod: CompensationPeriod | null;
+  compensationDisclosure: CompensationDisclosure;
 };
 
 export type IngestResult =
@@ -120,6 +130,23 @@ function formatCollectedAt(value: unknown): string | undefined {
   return undefined;
 }
 
+function resolveDisclosure(input: {
+  compensationDisclosure: CompensationDisclosure | null;
+  compensationMin: number | null;
+  compensationMax: number | null;
+}): CompensationDisclosure {
+  if (input.compensationDisclosure === 'competitive') {
+    return 'competitive';
+  }
+  if (input.compensationMin != null && input.compensationMax != null) {
+    return 'range';
+  }
+  if (input.compensationDisclosure === 'range') {
+    return 'range';
+  }
+  return 'unknown';
+}
+
 export async function ingestJobDescription(
   input: { s3Key: string; body: string },
   deps: IngestJobDescriptionDeps,
@@ -147,8 +174,8 @@ export async function ingestJobDescription(
     };
   }
 
-  const compensationMin = optionalNumber(data.compensationMin);
-  const compensationMax = optionalNumber(data.compensationMax);
+  let compensationMin = optionalNumber(data.compensationMin);
+  let compensationMax = optionalNumber(data.compensationMax);
   if (
     compensationMin !== null &&
     compensationMax !== null &&
@@ -158,6 +185,28 @@ export async function ingestJobDescription(
       status: 'rejected',
       reason: 'compensationMin must be less than or equal to compensationMax',
     };
+  }
+
+  const compensationDisclosure = resolveDisclosure({
+    compensationDisclosure: optionalEnum(
+      data.compensationDisclosure,
+      COMPENSATION_DISCLOSURES,
+    ),
+    compensationMin,
+    compensationMax,
+  });
+
+  let compensationCurrency = optionalString(data.compensationCurrency);
+  let compensationPeriod = optionalEnum(
+    data.compensationPeriod,
+    COMPENSATION_PERIODS,
+  );
+
+  if (compensationDisclosure !== 'range') {
+    compensationCurrency = null;
+    compensationMin = null;
+    compensationMax = null;
+    compensationPeriod = null;
   }
 
   const record: JobDescriptionRecord = {
@@ -171,10 +220,11 @@ export async function ingestJobDescription(
     roleFamily: optionalRoleFamily(data.roleFamily),
     source: optionalString(data.source),
     employerId: optionalString(data.employerId),
-    compensationCurrency: optionalString(data.compensationCurrency),
+    compensationCurrency,
     compensationMin,
     compensationMax,
-    compensationPeriod: optionalEnum(data.compensationPeriod, COMPENSATION_PERIODS),
+    compensationPeriod,
+    compensationDisclosure,
   };
 
   await deps.upsertJobDescription(record);

--- a/amplify/functions/job-market-parse-listing/assemble-markdown.ts
+++ b/amplify/functions/job-market-parse-listing/assemble-markdown.ts
@@ -15,17 +15,35 @@ export const JOB_DESCRIPTION_ROLE_FAMILIES = [
   'other',
 ] as const;
 
+export const COMPENSATION_PERIODS = ['year', 'month', 'day', 'hour'] as const;
+
+export const COMPENSATION_DISCLOSURES = [
+  'range',
+  'competitive',
+  'unknown',
+] as const;
+
 export type JobDescriptionSeniority =
   (typeof JOB_DESCRIPTION_SENIORITIES)[number];
 
 export type JobDescriptionRoleFamily =
   (typeof JOB_DESCRIPTION_ROLE_FAMILIES)[number];
 
+export type CompensationPeriod = (typeof COMPENSATION_PERIODS)[number];
+
+export type CompensationDisclosure =
+  (typeof COMPENSATION_DISCLOSURES)[number];
+
 export type ExtractedJobDescription = {
   title: string;
   seniority?: JobDescriptionSeniority;
   roleFamily?: JobDescriptionRoleFamily;
   body: string;
+  compensationDisclosure?: CompensationDisclosure;
+  compensationCurrency?: string;
+  compensationMin?: number;
+  compensationMax?: number;
+  compensationPeriod?: CompensationPeriod;
 };
 
 export type AssembleMarkdownInput = ExtractedJobDescription & {
@@ -55,6 +73,40 @@ function optionalEnum<T extends string>(
     : undefined;
 }
 
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function resolveDisclosure(input: {
+  compensationDisclosure?: CompensationDisclosure;
+  compensationMin?: number;
+  compensationMax?: number;
+}): CompensationDisclosure {
+  if (input.compensationDisclosure === 'competitive') {
+    return 'competitive';
+  }
+  if (input.compensationMin != null && input.compensationMax != null) {
+    return 'range';
+  }
+  if (input.compensationDisclosure === 'range') {
+    return 'range';
+  }
+  return 'unknown';
+}
+
 export function normaliseExtraction(raw: unknown): ExtractedJobDescription | null {
   if (!raw || typeof raw !== 'object') {
     return null;
@@ -66,16 +118,41 @@ export function normaliseExtraction(raw: unknown): ExtractedJobDescription | nul
     return null;
   }
 
-  return {
+  const compensationMin = optionalNumber(record.compensationMin);
+  const compensationMax = optionalNumber(record.compensationMax);
+  const compensationDisclosure = resolveDisclosure({
+    compensationDisclosure: optionalEnum(
+      record.compensationDisclosure,
+      COMPENSATION_DISCLOSURES,
+    ),
+    compensationMin,
+    compensationMax,
+  });
+
+  const extraction: ExtractedJobDescription = {
     title,
     body,
     seniority: optionalEnum(record.seniority, JOB_DESCRIPTION_SENIORITIES),
     roleFamily: optionalEnum(record.roleFamily, JOB_DESCRIPTION_ROLE_FAMILIES),
+    compensationDisclosure,
   };
+
+  if (compensationDisclosure === 'range') {
+    extraction.compensationCurrency = optionalString(record.compensationCurrency);
+    extraction.compensationMin = compensationMin;
+    extraction.compensationMax = compensationMax;
+    extraction.compensationPeriod = optionalEnum(
+      record.compensationPeriod,
+      COMPENSATION_PERIODS,
+    );
+  }
+
+  return extraction;
 }
 
 /** Assemble YAML frontmatter + body. Omits source for owner HITL tagging. */
 export function assembleJobDescriptionMarkdown(input: AssembleMarkdownInput): string {
+  const disclosure = resolveDisclosure(input);
   const lines = [
     '---',
     `collectedAt: ${input.collectedAt}`,
@@ -86,6 +163,23 @@ export function assembleJobDescriptionMarkdown(input: AssembleMarkdownInput): st
   }
   if (input.roleFamily) {
     lines.push(`roleFamily: ${input.roleFamily}`);
+  }
+  lines.push(`compensationDisclosure: ${disclosure}`);
+  if (disclosure === 'range') {
+    if (input.compensationCurrency) {
+      lines.push(
+        `compensationCurrency: ${yamlString(input.compensationCurrency)}`,
+      );
+    }
+    if (input.compensationMin !== undefined) {
+      lines.push(`compensationMin: ${input.compensationMin}`);
+    }
+    if (input.compensationMax !== undefined) {
+      lines.push(`compensationMax: ${input.compensationMax}`);
+    }
+    if (input.compensationPeriod) {
+      lines.push(`compensationPeriod: ${input.compensationPeriod}`);
+    }
   }
   lines.push('---', '', input.body.trim(), '');
   return lines.join('\n');

--- a/amplify/functions/job-market-parse-listing/bedrock-extract.ts
+++ b/amplify/functions/job-market-parse-listing/bedrock-extract.ts
@@ -2,6 +2,8 @@ import type { ToolConfiguration } from '@aws-sdk/client-bedrock-runtime';
 import type { DocumentType } from '@smithy/types';
 import type { ExtractedJobDescription } from './assemble-markdown';
 import {
+  COMPENSATION_DISCLOSURES,
+  COMPENSATION_PERIODS,
   JOB_DESCRIPTION_ROLE_FAMILIES,
   JOB_DESCRIPTION_SENIORITIES,
   normaliseExtraction,
@@ -16,6 +18,11 @@ export const EXTRACT_TOOL_NAME = 'extract_job_description';
 export const SYSTEM_PROMPT = [
   'Extract a structured job description from career-page plain text.',
   'Map seniority and roleFamily only to the allowed enums; omit them when unsure.',
+  'For compensationDisclosure: use range when a numeric salary or day-rate band is stated;',
+  'use competitive for phrases such as competitive, DOE, negotiable, or attractive package;',
+  'use unknown when pay is not mentioned.',
+  'When disclosure is range, also extract currency (ISO-like code), min, max, and period when present;',
+  'omit numeric pay fields for competitive or unknown.',
   'Do not invent employer marketing fluff; keep the body faithful to the listing.',
   'Leave source unset — the owner will tag it later.',
   'Call the extract_job_description tool exactly once.',
@@ -94,12 +101,34 @@ export function buildExtractToolSchema(): DocumentType {
         type: 'string',
         enum: [...JOB_DESCRIPTION_ROLE_FAMILIES],
       },
+      compensationDisclosure: {
+        type: 'string',
+        enum: [...COMPENSATION_DISCLOSURES],
+        description:
+          'range for numeric bands; competitive for DOE/negotiable/attractive package; unknown when pay is absent',
+      },
+      compensationCurrency: {
+        type: 'string',
+        description: 'ISO-like currency code when disclosure is range (e.g. GBP, USD)',
+      },
+      compensationMin: {
+        type: 'number',
+        description: 'Lower bound of the stated pay band when disclosure is range',
+      },
+      compensationMax: {
+        type: 'number',
+        description: 'Upper bound of the stated pay band when disclosure is range',
+      },
+      compensationPeriod: {
+        type: 'string',
+        enum: [...COMPENSATION_PERIODS],
+      },
       body: {
         type: 'string',
         description: 'Cleaned markdown-friendly job description body',
       },
     },
-    required: ['title', 'body'],
+    required: ['title', 'body', 'compensationDisclosure'],
     additionalProperties: false,
   };
 }

--- a/amplify/functions/job-market-parse-listing/parse-listing.test.ts
+++ b/amplify/functions/job-market-parse-listing/parse-listing.test.ts
@@ -20,8 +20,36 @@ describe('assembleJobDescriptionMarkdown', () => {
     expect(markdown).toContain('title: Senior Data Scientist');
     expect(markdown).toContain('seniority: senior');
     expect(markdown).toContain('roleFamily: data_science');
+    expect(markdown).toContain('compensationDisclosure: unknown');
     expect(markdown).not.toContain('source:');
     expect(markdown).toContain('Lead modelling across credit risk.');
+  });
+
+  it('emits range fields and strips them for competitive disclosure', () => {
+    expect(
+      assembleJobDescriptionMarkdown({
+        title: 'Analyst',
+        body: 'Do analysis.',
+        collectedAt: '2026-07-18T10:00:00.000Z',
+        compensationDisclosure: 'range',
+        compensationCurrency: 'GBP',
+        compensationMin: 50000,
+        compensationMax: 60000,
+        compensationPeriod: 'year',
+      }),
+    ).toContain('compensationMin: 50000');
+
+    const competitive = assembleJobDescriptionMarkdown({
+      title: 'Analyst',
+      body: 'Do analysis.',
+      collectedAt: '2026-07-18T10:00:00.000Z',
+      compensationDisclosure: 'competitive',
+      compensationCurrency: 'GBP',
+      compensationMin: 50000,
+      compensationMax: 60000,
+    });
+    expect(competitive).toContain('compensationDisclosure: competitive');
+    expect(competitive).not.toContain('compensationMin:');
   });
 
   it('drops invalid enum values from model output', () => {
@@ -37,6 +65,42 @@ describe('assembleJobDescriptionMarkdown', () => {
       body: 'Do analysis.',
       seniority: undefined,
       roleFamily: 'data_science',
+      compensationDisclosure: 'unknown',
+    });
+  });
+
+  it('maps competitive and range extractions pay', () => {
+    expect(
+      normaliseExtraction({
+        title: 'Analyst',
+        body: 'Do analysis.',
+        compensationDisclosure: 'competitive',
+        compensationMin: 1,
+        compensationMax: 2,
+      }),
+    ).toEqual({
+      title: 'Analyst',
+      body: 'Do analysis.',
+      seniority: undefined,
+      roleFamily: undefined,
+      compensationDisclosure: 'competitive',
+    });
+
+    expect(
+      normaliseExtraction({
+        title: 'Analyst',
+        body: 'Do analysis.',
+        compensationMin: 80000,
+        compensationMax: 90000,
+        compensationCurrency: 'GBP',
+        compensationPeriod: 'year',
+      }),
+    ).toMatchObject({
+      compensationDisclosure: 'range',
+      compensationMin: 80000,
+      compensationMax: 90000,
+      compensationCurrency: 'GBP',
+      compensationPeriod: 'year',
     });
   });
 });

--- a/docs/labs/job-market-console.md
+++ b/docs/labs/job-market-console.md
@@ -2,6 +2,8 @@
 
 Owner-authenticated surface at `/labs/job-market/console`. Routes use a dedicated layout shell (not the public `SitePage` chrome).
 
+The **public** lab at `/labs/job-market` is the published results surface (app-like pulse layout; themes use PCA projection). See [job-market-lab.md](./job-market-lab.md).
+
 ## Layout and appearance
 
 - Full-width authenticated shell with in-console navigation (overview, corpus, Intake, runs, fit, analytics).
@@ -13,6 +15,17 @@ Owner-authenticated surface at `/labs/job-market/console`. Routes use a dedicate
 - New listings enter via the Intake tab; corpus is for review, metadata, employers, and table health.
 - Supporting helpers live in `src/lib/job-market-corpus-table.ts`.
 
-## Compensation currency
+## Compensation disclosure
 
-- Currency is an optional free-text field (`compensationCurrency`). Prefer ISO-like codes (e.g. `GBP`, `USD`); do not treat the field as a closed enum in the UI.
+- Every job description has a `compensationDisclosure` enum: `range` | `competitive` | `unknown`.
+- **`range`:** a numeric pay band is stated. Currency is optional free text (`compensationCurrency`); prefer ISO-like codes (e.g. `GBP`, `USD`). Also store `compensationMin`, `compensationMax`, and `compensationPeriod` when known. Do not treat currency as a closed enum in the UI.
+- **`competitive`:** one bucket for competitive / DOE / negotiable / attractive package phrasing. Numeric band fields are cleared.
+- **`unknown`:** pay was not disclosed (including legacy rows with no disclosure field and no valid numerics).
+- Readers resolve unset legacy rows as `range` when both min and max are present, otherwise `unknown`. Prefer writing an explicit disclosure on save or parse.
+- Analytics treat `competitive` as disclosed (not missing compensation). Only `unknown` counts as missing / not disclosed.
+- Intake may defer disclosure; the corpus detail and metadata editors must set it. Bedrock listing parse maps bands → `range`, competitive phrases → `competitive`, and absent pay → `unknown`.
+
+## Analytics and runs
+
+- **Analytics** is the insights dashboard (coverage summary, pay/prestige metrics, theme labels, pulse filters) and the primary place to start a recompute.
+- **Runs** is the audit/history view of analysis runs, with a secondary recompute control for power users.

--- a/docs/labs/job-market-lab.md
+++ b/docs/labs/job-market-lab.md
@@ -1,0 +1,23 @@
+# Job market lab (public)
+
+Public results surface at `/labs/job-market`: **Hasha Dar's Job Signal Lab**.
+
+The `/labs` index is a flagship stage for this lab (hero “Labs” word, purpose line, CTA), not a multi-lab catalogue. Live pulse data stays on the lab page.
+
+## Layout
+
+- Uses `SitePage` (site header + footer) so brand stays lightly present.
+- The lab section itself is a denser, near-app shell: edge-to-edge pulse within the content width, time filter + freshness in the first viewport, then a secondary **How this is produced** band (numbered pipeline stages with plain-language + under-the-hood copy), not a collapsible note and not a marketing essay stack.
+- Owner tooling lives under `/labs/job-market/console` (see [job-market-console.md](./job-market-console.md)).
+
+## What the page shows
+
+- **Technologies** and **requirement themes** from the published snapshot (time-window filter only), each with a short plain-language caption.
+- Theme **ranked sizes** plus a **2D theme map**. Map coordinates are PCA of embedding vectors, computed in the analyse worker and published with the snapshot (not raw first-two embedding dimensions).
+- Compact seniority / role-family band (secondary to tech and themes).
+- Methodology stages (accessible titles): collect listings → tag context → match technologies → fingerprint requirements into themes → lay out map → publish counts/themes/map. Sensitive fields are redacted in publication.
+- No pay, prestige, employers, raw JDs, CV fit, runs, or costs.
+
+## Recompute note
+
+Projection improvements ship with the analyse Lambda. Existing published snapshots keep their prior coordinates until the next successful recompute and publish.

--- a/src/app/labs/job-market/page.tsx
+++ b/src/app/labs/job-market/page.tsx
@@ -21,12 +21,17 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Public results surface. Keeps SitePage (header + footer) so site brand stays
+ * lightly present, while JobMarketLabSection uses a denser full-bleed lab shell
+ * instead of the marketing Section essay stack.
+ */
 export default async function JobMarketLabPage() {
   ensureSiteAmplifyFromOutputs();
   const publication = await getPublishedJobMarketSnapshot();
 
   return (
-    <SitePage mainClassName="min-h-screen pt-20">
+    <SitePage mainClassName="min-h-screen pt-16 md:pt-20">
       <JobMarketLabSection publication={publication} />
     </SitePage>
   );

--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 export default function LabsPage() {
   return (
-    <SitePage mainClassName="min-h-screen pt-20">
+    <SitePage mainClassName="min-h-screen pt-16 md:pt-20">
       <LabsIndexSection />
     </SitePage>
   );

--- a/src/components/sections/labs/console/analytics/job-market-analytics-workspace.tsx
+++ b/src/components/sections/labs/console/analytics/job-market-analytics-workspace.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { Button, Heading, SectionHeader, Text } from '@/components/ui';
+import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
+import { JobMarketLabPayPrestigeAnalyticsPanel } from '@/components/sections/labs/job-market-lab-pay-prestige-analytics-panel';
+import { JobMarketLabPulseFiltersPanel } from '@/components/sections/labs/job-market-lab-pulse-filters-panel';
+import { JobMarketLabThemeLabelsPanel } from '@/components/sections/labs/job-market-lab-theme-labels-panel';
+import { jobMarketLab } from '@/data';
+import { useSiteAuth } from '@/hooks/use-site-auth';
+import {
+  getOwnerPayPrestigeAnalytics,
+  type GetOwnerPayPrestigeAnalyticsDeps,
+  type OwnerPayPrestigeAnalytics,
+  type StartJobMarketRecompute,
+} from '@/lib/job-market-lab';
+import { createDefaultAmplifyPayPrestigeAnalyticsDeps } from '@/lib/job-market-pay-prestige-analytics-amplify';
+
+export type JobMarketAnalyticsWorkspaceProps = {
+  analytics?: GetOwnerPayPrestigeAnalyticsDeps;
+  startRecompute?: StartJobMarketRecompute;
+};
+
+function rateFor(
+  analytics: OwnerPayPrestigeAnalytics,
+  field: OwnerPayPrestigeAnalytics['missingDataRates'][number]['field'],
+) {
+  return analytics.missingDataRates.find((entry) => entry.field === field);
+}
+
+function formatPercent(rate: number): string {
+  return new Intl.NumberFormat('en-GB', {
+    style: 'percent',
+    maximumFractionDigits: 0,
+  }).format(rate);
+}
+
+export function JobMarketAnalyticsWorkspace({
+  analytics: analyticsDepsProp,
+  startRecompute,
+}: JobMarketAnalyticsWorkspaceProps) {
+  const copy = jobMarketLab.console.analyticsWorkspace;
+  const { session, isLoading } = useSiteAuth();
+  const [analytics, setAnalytics] = useState<OwnerPayPrestigeAnalytics | null>(
+    null,
+  );
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (isLoading || session?.status !== 'authenticated') {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const deps =
+          analyticsDepsProp ?? createDefaultAmplifyPayPrestigeAnalyticsDeps();
+        const next = await getOwnerPayPrestigeAnalytics(deps);
+        if (!cancelled) {
+          setAnalytics(next);
+          setError(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setAnalytics(null);
+          setError(true);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [analyticsDepsProp, isLoading, session?.status]);
+
+  if (isLoading || session === null || session.status !== 'authenticated') {
+    return null;
+  }
+
+  const disclosed = analytics ? rateFor(analytics, 'compensationDisclosed') : null;
+  const employer = analytics ? rateFor(analytics, 'employerLink') : null;
+  const complete = analytics ? rateFor(analytics, 'completeCompensation') : null;
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-3">
+        <SectionHeader as="h2" size="md" animated={false} showLeftAccent>
+          {copy.heading}
+        </SectionHeader>
+        <Text variant="muted">{copy.description}</Text>
+      </div>
+
+      <section className="space-y-4" aria-labelledby="analytics-summary-heading">
+        <Heading id="analytics-summary-heading" as="h3" size="sm">
+          {copy.summaryHeading}
+        </Heading>
+        {error ? (
+          <p role="alert" className="font-body text-sm text-[var(--foreground)]">
+            {jobMarketLab.payPrestigeAnalytics.errorLabel}
+          </p>
+        ) : null}
+        {!error && analytics === null ? (
+          <Text variant="muted">{jobMarketLab.payPrestigeAnalytics.loadingLabel}</Text>
+        ) : null}
+        {!error && analytics !== null ? (
+          <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            <div className="border-l-2 border-l-[var(--primary)] pl-3">
+              <dt>
+                <Text size="sm" variant="muted">
+                  {copy.activeDocumentsLabel}
+                </Text>
+              </dt>
+              <dd>
+                <Text className="text-2xl font-semibold tabular-nums tracking-tight">
+                  {analytics.activeDocumentCount}
+                </Text>
+              </dd>
+            </div>
+            <div className="border-l-2 border-[var(--border)] pl-3">
+              <dt>
+                <Text size="sm" variant="muted">
+                  {copy.payDisclosedLabel}
+                </Text>
+              </dt>
+              <dd>
+                <Text className="tabular-nums">
+                  {disclosed?.present ?? 0}
+                  {disclosed ? (
+                    <Text as="span" size="sm" variant="muted" className="ml-1">
+                      ({formatPercent(1 - disclosed.missingRate)})
+                    </Text>
+                  ) : null}
+                </Text>
+              </dd>
+            </div>
+            <div className="border-l-2 border-[var(--border)] pl-3">
+              <dt>
+                <Text size="sm" variant="muted">
+                  {copy.payUndisclosedLabel}
+                </Text>
+              </dt>
+              <dd>
+                <Text className="tabular-nums">{disclosed?.missing ?? 0}</Text>
+              </dd>
+            </div>
+            <div className="border-l-2 border-[var(--border)] pl-3">
+              <dt>
+                <Text size="sm" variant="muted">
+                  {copy.employerLinkedLabel}
+                </Text>
+              </dt>
+              <dd>
+                <Text className="tabular-nums">
+                  {employer?.present ?? 0}
+                  {employer ? (
+                    <Text as="span" size="sm" variant="muted" className="ml-1">
+                      ({formatPercent(1 - employer.missingRate)})
+                    </Text>
+                  ) : null}
+                </Text>
+              </dd>
+            </div>
+            <div className="border-l-2 border-[var(--border)] pl-3">
+              <dt>
+                <Text size="sm" variant="muted">
+                  {copy.completeCompensationLabel}
+                </Text>
+              </dt>
+              <dd>
+                <Text className="tabular-nums">{complete?.present ?? 0}</Text>
+              </dd>
+            </div>
+          </dl>
+        ) : null}
+      </section>
+
+      <section className="space-y-4 border-t border-[var(--border)] pt-8">
+        <div className="space-y-2">
+          <Heading as="h3" size="sm">
+            {copy.startRecomputeHeading}
+          </Heading>
+          <Text size="sm" variant="muted">
+            {copy.startRecomputeDescription}
+          </Text>
+        </div>
+        <JobMarketLabAdminSection
+          startRecompute={startRecompute}
+          variant="primary"
+        />
+        <Link
+          href="/labs/job-market/console/runs"
+          className="inline-flex font-body text-sm text-[var(--foreground)] underline underline-offset-4"
+        >
+          {copy.viewRunsLabel}
+        </Link>
+      </section>
+
+      <JobMarketLabPayPrestigeAnalyticsPanel
+        analytics={analyticsDepsProp}
+        embedded
+      />
+
+      <section className="space-y-6 border-t border-[var(--border)] pt-8">
+        <div className="space-y-2">
+          <Heading as="h3" size="sm">
+            {copy.secondaryToolsHeading}
+          </Heading>
+          <Text size="sm" variant="muted">
+            {copy.secondaryToolsDescription}
+          </Text>
+        </div>
+        <JobMarketLabThemeLabelsPanel embedded />
+        <JobMarketLabPulseFiltersPanel embedded />
+      </section>
+    </div>
+  );
+}

--- a/src/components/sections/labs/console/corpus/job-market-corpus-jd-detail.tsx
+++ b/src/components/sections/labs/console/corpus/job-market-corpus-jd-detail.tsx
@@ -7,10 +7,13 @@ import { jobMarketLab } from '@/data';
 import { displayTitle } from '@/lib/job-market-corpus-table';
 import type { JobDescriptionCorpusRecord } from '@/lib/job-market-corpus';
 import {
+  COMPENSATION_DISCLOSURES,
   COMPENSATION_PERIODS,
   JOB_DESCRIPTION_ROLE_FAMILIES,
   JOB_DESCRIPTION_SENIORITIES,
+  resolveCompensationDisclosure,
   updateJobDescriptionStructuredFields,
+  type CompensationDisclosure,
   type CompensationPeriod,
   type EmployerRecord,
   type JobDescriptionRoleFamily,
@@ -46,6 +49,7 @@ type MetadataDraft = {
   employerId: string;
   seniority: string;
   roleFamily: string;
+  compensationDisclosure: CompensationDisclosure;
   compensationCurrency: string;
   compensationMin: string;
   compensationMax: string;
@@ -57,6 +61,7 @@ function toMetadataDraft(record: JobDescriptionCorpusRecord): MetadataDraft {
     employerId: record.employerId ?? '',
     seniority: record.seniority ?? '',
     roleFamily: record.roleFamily ?? '',
+    compensationDisclosure: resolveCompensationDisclosure(record),
     compensationCurrency: record.compensationCurrency ?? '',
     compensationMin:
       record.compensationMin != null ? String(record.compensationMin) : '',
@@ -129,6 +134,7 @@ export function JobMarketCorpusJdDetail({
           employerId: record.employerId,
           seniority: record.seniority,
           roleFamily: record.roleFamily,
+          compensationDisclosure: record.compensationDisclosure,
           compensationCurrency: record.compensationCurrency,
           compensationMin: record.compensationMin,
           compensationMax: record.compensationMax,
@@ -182,9 +188,12 @@ export function JobMarketCorpusJdDetail({
     setSavingMetadata(true);
     setMessage(null);
     setError(null);
-    const min = parseOptionalNumber(draft.compensationMin);
-    const max = parseOptionalNumber(draft.compensationMax);
-    if (min === undefined || max === undefined) {
+
+    const disclosure = draft.compensationDisclosure;
+    const isRange = disclosure === 'range';
+    const min = isRange ? parseOptionalNumber(draft.compensationMin) : null;
+    const max = isRange ? parseOptionalNumber(draft.compensationMax) : null;
+    if (isRange && (min === undefined || max === undefined)) {
       setError(copy.metadataSaveError);
       setSavingMetadata(false);
       return;
@@ -194,11 +203,15 @@ export function JobMarketCorpusJdDetail({
       employerId: draft.employerId || null,
       seniority: (draft.seniority || null) as JobDescriptionSeniority | null,
       roleFamily: (draft.roleFamily || null) as JobDescriptionRoleFamily | null,
-      compensationCurrency: draft.compensationCurrency.trim() || null,
-      compensationMin: min,
-      compensationMax: max,
-      compensationPeriod: (draft.compensationPeriod ||
-        null) as CompensationPeriod | null,
+      compensationDisclosure: disclosure,
+      compensationCurrency: isRange
+        ? draft.compensationCurrency.trim() || null
+        : null,
+      compensationMin: min ?? null,
+      compensationMax: max ?? null,
+      compensationPeriod: isRange
+        ? ((draft.compensationPeriod || null) as CompensationPeriod | null)
+        : null,
     };
 
     try {
@@ -360,67 +373,91 @@ export function JobMarketCorpusJdDetail({
             </label>
           </div>
           <div className="grid grid-cols-2 gap-2">
-            <label className="block min-w-0 space-y-1">
-              <Text size="sm">{copy.compensationCurrencyLabel}</Text>
-              <input
-                className={corpusFieldClassName}
-                value={draft.compensationCurrency}
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    compensationCurrency: event.target.value,
-                  }))
-                }
-              />
-            </label>
-            <label className="block min-w-0 space-y-1">
-              <Text size="sm">{copy.compensationPeriodLabel}</Text>
+            <label className="block min-w-0 space-y-1 col-span-2">
+              <Text size="sm">{copy.compensationDisclosureLabel}</Text>
               <select
                 className={corpusFieldClassName}
-                value={draft.compensationPeriod}
+                value={draft.compensationDisclosure}
                 onChange={(event) =>
                   setDraft((current) => ({
                     ...current,
-                    compensationPeriod: event.target.value,
+                    compensationDisclosure: event.target
+                      .value as CompensationDisclosure,
                   }))
                 }
               >
-                <option value="">{copy.unsetOption}</option>
-                {COMPENSATION_PERIODS.map((value) => (
+                {COMPENSATION_DISCLOSURES.map((value) => (
                   <option key={value} value={value}>
-                    {value}
+                    {copy.compensationDisclosureOptions[value]}
                   </option>
                 ))}
               </select>
             </label>
-            <label className="block min-w-0 space-y-1">
-              <Text size="sm">{copy.compensationMinLabel}</Text>
-              <input
-                className={corpusFieldClassName}
-                inputMode="decimal"
-                value={draft.compensationMin}
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    compensationMin: event.target.value,
-                  }))
-                }
-              />
-            </label>
-            <label className="block min-w-0 space-y-1">
-              <Text size="sm">{copy.compensationMaxLabel}</Text>
-              <input
-                className={corpusFieldClassName}
-                inputMode="decimal"
-                value={draft.compensationMax}
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    compensationMax: event.target.value,
-                  }))
-                }
-              />
-            </label>
+            {draft.compensationDisclosure === 'range' ? (
+              <>
+                <label className="block min-w-0 space-y-1">
+                  <Text size="sm">{copy.compensationCurrencyLabel}</Text>
+                  <input
+                    className={corpusFieldClassName}
+                    value={draft.compensationCurrency}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        compensationCurrency: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+                <label className="block min-w-0 space-y-1">
+                  <Text size="sm">{copy.compensationPeriodLabel}</Text>
+                  <select
+                    className={corpusFieldClassName}
+                    value={draft.compensationPeriod}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        compensationPeriod: event.target.value,
+                      }))
+                    }
+                  >
+                    <option value="">{copy.unsetOption}</option>
+                    {COMPENSATION_PERIODS.map((value) => (
+                      <option key={value} value={value}>
+                        {value}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block min-w-0 space-y-1">
+                  <Text size="sm">{copy.compensationMinLabel}</Text>
+                  <input
+                    className={corpusFieldClassName}
+                    inputMode="decimal"
+                    value={draft.compensationMin}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        compensationMin: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+                <label className="block min-w-0 space-y-1">
+                  <Text size="sm">{copy.compensationMaxLabel}</Text>
+                  <input
+                    className={corpusFieldClassName}
+                    inputMode="decimal"
+                    value={draft.compensationMax}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        compensationMax: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+              </>
+            ) : null}
           </div>
           {record.source ? (
             <Text size="sm" variant="muted" className="break-all">

--- a/src/components/sections/labs/console/fit/job-market-fit-workspace.test.tsx
+++ b/src/components/sections/labs/console/fit/job-market-fit-workspace.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobMarketFitWorkspace } from '@/components/sections/labs/console/fit/job-market-fit-workspace';
+import { SiteAuthProvider } from '@/hooks/use-site-auth';
+import { jobMarketLab } from '@/data';
+import type { CanonicalCvDeps } from '@/lib/canonical-cv';
+import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import { createMemorySiteAuth } from '@/lib/site-auth';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createMemoryCorpus(): AmplifyCorpusDeps {
+  return {
+    getJobDescription: async () => null,
+    listJobDescriptions: async () => [],
+    saveJobDescription: async () => undefined,
+  };
+}
+
+function createMemoryCv(body: string): CanonicalCvDeps {
+  return {
+    async getCanonicalCv() {
+      return {
+        id: 'current',
+        body,
+        updatedAt: '2026-07-14T12:00:00.000Z',
+      };
+    },
+    async saveCanonicalCv(input) {
+      return {
+        id: 'current',
+        body: input.body,
+        updatedAt: input.updatedAt,
+      };
+    },
+  };
+}
+
+describe('JobMarketFitWorkspace', () => {
+  it('renders a persistent CV column and mode tabs for fit actions', async () => {
+    const user = userEvent.setup();
+    render(
+      <SiteAuthProvider
+        auth={createMemorySiteAuth({
+          status: 'authenticated',
+          email: 'owner@example.com',
+        })}
+      >
+        <JobMarketFitWorkspace
+          corpus={createMemoryCorpus()}
+          canonicalCv={createMemoryCv('Python and SQL experience.')}
+        />
+      </SiteAuthProvider>,
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: jobMarketLab.console.fitWorkspace.heading,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: jobMarketLab.console.fitWorkspace.cvColumnHeading,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', {
+        name: jobMarketLab.console.fitWorkspace.modeRoleLabel,
+      }),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(
+      screen.getByRole('tab', {
+        name: jobMarketLab.console.fitWorkspace.modeMarketLabel,
+      }),
+    );
+    expect(
+      screen.getByRole('tab', {
+        name: jobMarketLab.console.fitWorkspace.modeMarketLabel,
+      }),
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/src/components/sections/labs/console/fit/job-market-fit-workspace.tsx
+++ b/src/components/sections/labs/console/fit/job-market-fit-workspace.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { SectionHeader, Text } from '@/components/ui';
+import { JobMarketLabComparePanel } from '@/components/sections/labs/job-market-lab-compare-panel';
+import { JobMarketLabCvPanel } from '@/components/sections/labs/job-market-lab-cv-panel';
+import { JobMarketLabMarketComparePanel } from '@/components/sections/labs/job-market-lab-market-compare-panel';
+import { jobMarketLab } from '@/data';
+import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
+import type { CanonicalCvDeps } from '@/lib/canonical-cv';
+import { cn } from '@/lib/utils';
+
+export type JobMarketFitWorkspaceProps = {
+  corpus?: AmplifyCorpusDeps;
+  canonicalCv?: CanonicalCvDeps;
+};
+
+type FitMode = 'role' | 'market';
+
+export function JobMarketFitWorkspace({
+  corpus,
+  canonicalCv,
+}: JobMarketFitWorkspaceProps) {
+  const copy = jobMarketLab.console.fitWorkspace;
+  const [mode, setMode] = useState<FitMode>('role');
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <SectionHeader as="h2" size="md" animated={false} showLeftAccent>
+          {copy.heading}
+        </SectionHeader>
+        <Text variant="muted">{copy.description}</Text>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(16rem,22rem)_minmax(0,1fr)] lg:items-start lg:gap-8">
+        <aside className="min-w-0 lg:sticky lg:top-24">
+          <JobMarketLabCvPanel canonicalCv={canonicalCv} embedded />
+        </aside>
+
+        <div className="min-w-0 space-y-5">
+          <div
+            role="tablist"
+            aria-label={copy.heading}
+            className="inline-flex flex-wrap gap-1 border-b border-[var(--border)] pb-px"
+          >
+            {(
+              [
+                { id: 'role' as const, label: copy.modeRoleLabel },
+                { id: 'market' as const, label: copy.modeMarketLabel },
+              ] as const
+            ).map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={mode === tab.id}
+                className={cn(
+                  'px-3 py-2 font-body text-sm transition-colors',
+                  mode === tab.id
+                    ? 'border-b-2 border-b-[var(--primary)] text-[var(--foreground)]'
+                    : 'text-[var(--mono-500)] hover:text-[var(--foreground)]',
+                )}
+                onClick={() => setMode(tab.id)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {mode === 'role' ? (
+            <JobMarketLabComparePanel
+              corpus={corpus}
+              canonicalCv={canonicalCv}
+              embedded
+              showHeading={false}
+            />
+          ) : (
+            <JobMarketLabMarketComparePanel
+              canonicalCv={canonicalCv}
+              embedded
+              showHeading={false}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/labs/console/job-market-console-analytics-page.tsx
+++ b/src/components/sections/labs/console/job-market-console-analytics-page.tsx
@@ -1,15 +1,24 @@
 'use client';
 
-import { JobMarketLabPayPrestigeAnalyticsPanel } from '@/components/sections/labs/job-market-lab-pay-prestige-analytics-panel';
-import { JobMarketLabPulseFiltersPanel } from '@/components/sections/labs/job-market-lab-pulse-filters-panel';
-import { JobMarketLabThemeLabelsPanel } from '@/components/sections/labs/job-market-lab-theme-labels-panel';
+import { JobMarketAnalyticsWorkspace } from '@/components/sections/labs/console/analytics/job-market-analytics-workspace';
+import type {
+  GetOwnerPayPrestigeAnalyticsDeps,
+  StartJobMarketRecompute,
+} from '@/lib/job-market-lab';
 
-export function JobMarketConsoleAnalyticsPage() {
+export type JobMarketConsoleAnalyticsPageProps = {
+  analytics?: GetOwnerPayPrestigeAnalyticsDeps;
+  startRecompute?: StartJobMarketRecompute;
+};
+
+export function JobMarketConsoleAnalyticsPage({
+  analytics,
+  startRecompute,
+}: JobMarketConsoleAnalyticsPageProps) {
   return (
-    <>
-      <JobMarketLabThemeLabelsPanel />
-      <JobMarketLabPulseFiltersPanel />
-      <JobMarketLabPayPrestigeAnalyticsPanel />
-    </>
+    <JobMarketAnalyticsWorkspace
+      analytics={analytics}
+      startRecompute={startRecompute}
+    />
   );
 }

--- a/src/components/sections/labs/console/job-market-console-fit-page.tsx
+++ b/src/components/sections/labs/console/job-market-console-fit-page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { JobMarketLabComparePanel } from '@/components/sections/labs/job-market-lab-compare-panel';
-import { JobMarketLabCvPanel } from '@/components/sections/labs/job-market-lab-cv-panel';
-import { JobMarketLabMarketComparePanel } from '@/components/sections/labs/job-market-lab-market-compare-panel';
+import { JobMarketFitWorkspace } from '@/components/sections/labs/console/fit/job-market-fit-workspace';
 import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
 import type { CanonicalCvDeps } from '@/lib/canonical-cv';
 
@@ -15,11 +13,5 @@ export function JobMarketConsoleFitPage({
   corpus,
   canonicalCv,
 }: JobMarketConsoleFitPageProps) {
-  return (
-    <>
-      <JobMarketLabCvPanel canonicalCv={canonicalCv} />
-      <JobMarketLabComparePanel canonicalCv={canonicalCv} corpus={corpus} />
-      <JobMarketLabMarketComparePanel canonicalCv={canonicalCv} />
-    </>
-  );
+  return <JobMarketFitWorkspace corpus={corpus} canonicalCv={canonicalCv} />;
 }

--- a/src/components/sections/labs/console/job-market-console-runs-page.tsx
+++ b/src/components/sections/labs/console/job-market-console-runs-page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
 import { JobMarketLabRunsPanel } from '@/components/sections/labs/job-market-lab-runs-panel';
 import type { ListAnalysisRunsDeps, StartJobMarketRecompute } from '@/lib/job-market-lab';
 
@@ -14,9 +13,9 @@ export function JobMarketConsoleRunsPage({
   startRecompute,
 }: JobMarketConsoleRunsPageProps) {
   return (
-    <>
-      <JobMarketLabAdminSection startRecompute={startRecompute} />
-      <JobMarketLabRunsPanel analysisRuns={analysisRuns} />
-    </>
+    <JobMarketLabRunsPanel
+      analysisRuns={analysisRuns}
+      startRecompute={startRecompute}
+    />
   );
 }

--- a/src/components/sections/labs/job-market-lab-admin-section.tsx
+++ b/src/components/sections/labs/job-market-lab-admin-section.tsx
@@ -17,10 +17,13 @@ import { defaultStartJobMarketRecompute } from '@/lib/start-job-market-recompute
 
 export type JobMarketLabAdminSectionProps = {
   startRecompute?: StartJobMarketRecompute;
+  /** Primary (analytics) uses the runs-hint started message; secondary is denser for Runs audit. */
+  variant?: 'primary' | 'secondary';
 };
 
 export function JobMarketLabAdminSection({
   startRecompute = defaultStartJobMarketRecompute,
+  variant = 'secondary',
 }: JobMarketLabAdminSectionProps) {
   const { session, isLoading } = useSiteAuth();
   const [isStarting, setIsStarting] = useState(false);
@@ -38,14 +41,29 @@ export function JobMarketLabAdminSection({
     setIsStarting(false);
   }
 
+  const startedMessage =
+    variant === 'primary'
+      ? jobMarketLab.admin.startedMessageWithRunsHint
+      : jobMarketLab.admin.startedMessage;
+
   return (
-    <div className="mt-16 max-w-2xl space-y-6 border-t border-[var(--border)] pt-12">
-      <div className="space-y-3">
-        <SectionHeader as="h2" size="md" animated={false} showLeftAccent>
-          {jobMarketLab.admin.heading}
-        </SectionHeader>
-        <Text variant="muted">{jobMarketLab.admin.description}</Text>
-      </div>
+    <div
+      className={
+        variant === 'primary'
+          ? 'space-y-4'
+          : 'space-y-4 border-t border-[var(--border)] pt-6'
+      }
+    >
+      {variant === 'secondary' ? (
+        <div className="space-y-2">
+          <SectionHeader as="h2" size="sm" animated={false} showLeftAccent>
+            {jobMarketLab.admin.heading}
+          </SectionHeader>
+          <Text size="sm" variant="muted">
+            {jobMarketLab.admin.secondaryStartDescription}
+          </Text>
+        </div>
+      ) : null}
 
       <Button
         type="button"
@@ -58,8 +76,8 @@ export function JobMarketLabAdminSection({
       </Button>
 
       {result?.status === 'started' ? (
-        <p role="status" className="font-body text-base leading-relaxed text-[var(--foreground)]">
-          {jobMarketLab.admin.startedMessage.replace('{runId}', result.runId)}
+        <p role="status" className="font-body text-sm leading-relaxed text-[var(--foreground)]">
+          {startedMessage.replace('{runId}', result.runId)}
         </p>
       ) : null}
 
@@ -68,7 +86,7 @@ export function JobMarketLabAdminSection({
           <Heading as="h3" size="sm">
             {jobMarketLab.admin.rejectedHeading}
           </Heading>
-          <Text>{result.reason}</Text>
+          <Text size="sm">{result.reason}</Text>
         </div>
       ) : null}
     </div>

--- a/src/components/sections/labs/job-market-lab-compare-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-compare-panel.tsx
@@ -25,6 +25,9 @@ export type JobMarketLabComparePanelProps = {
   corpus?: AmplifyCorpusDeps;
   canonicalCv?: CanonicalCvDeps;
   markdown?: FetchJobDescriptionMarkdownDeps;
+  embedded?: boolean;
+  /** When false, hide the panel chrome (used by fit workspace mode tabs). */
+  showHeading?: boolean;
 };
 
 type LoadState =
@@ -52,6 +55,8 @@ export function JobMarketLabComparePanel({
   corpus,
   canonicalCv,
   markdown,
+  embedded = false,
+  showHeading = true,
 }: JobMarketLabComparePanelProps) {
   const { session, isLoading } = useSiteAuth();
   const [corpusDeps] = useState(() => corpus ?? createDefaultAmplifyCorpusDeps());
@@ -63,7 +68,9 @@ export function JobMarketLabComparePanel({
     useState<FetchJobDescriptionMarkdownDeps | null>(markdownDeps);
   const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
   const [selectedId, setSelectedId] = useState('');
+  const [jdSearch, setJdSearch] = useState('');
   const [compareState, setCompareState] = useState<CompareState>({ status: 'idle' });
+  const [hasSavedCv, setHasSavedCv] = useState<boolean | null>(null);
 
   const loadRecords = useCallback(async () => {
     const records = await corpusDeps.listJobDescriptions();
@@ -99,9 +106,13 @@ export function JobMarketLabComparePanel({
     void (async () => {
       setLoadState({ status: 'loading' });
       try {
-        const records = await loadRecords();
+        const [records, cvRecord] = await Promise.all([
+          loadRecords(),
+          getCanonicalCv(cvDeps),
+        ]);
         if (!cancelled) {
           setLoadState({ status: 'ready', records });
+          setHasSavedCv(Boolean(cvRecord?.body.trim()));
         }
       } catch {
         if (!cancelled) {
@@ -113,14 +124,24 @@ export function JobMarketLabComparePanel({
     return () => {
       cancelled = true;
     };
-  }, [isLoading, session, loadRecords]);
+  }, [isLoading, session, loadRecords, cvDeps]);
 
   if (isLoading || session?.status !== 'authenticated') {
     return null;
   }
 
   const copy = jobMarketLab.console.compare;
+  const fitCopy = jobMarketLab.console.fitWorkspace;
   const markdownFetcher = markdownDeps ?? resolvedMarkdownDeps;
+  const filteredRecords =
+    loadState.status === 'ready'
+      ? loadState.records.filter((record) => {
+          const query = jdSearch.trim().toLowerCase();
+          if (!query) return true;
+          const title = (record.title ?? '').toLowerCase();
+          return title.includes(query) || record.id.toLowerCase().includes(query);
+        })
+      : [];
 
   async function handleCompare() {
     const compareCopy = jobMarketLab.console.compare;
@@ -190,19 +211,24 @@ export function JobMarketLabComparePanel({
   }
 
   return (
-    <section className="mt-16 space-y-6" aria-labelledby="job-market-compare-heading">
-      <div className="max-w-2xl space-y-4">
-        <SectionHeader
-          id="job-market-compare-heading"
-          as="h2"
-          size="md"
-          animated={false}
-          showLeftAccent
-        >
-          {copy.heading}
-        </SectionHeader>
-        <Text variant="muted">{copy.description}</Text>
-      </div>
+    <section
+      className={embedded ? 'space-y-4' : 'mt-16 space-y-6'}
+      aria-labelledby="job-market-compare-heading"
+    >
+      {showHeading ? (
+        <div className={embedded ? 'space-y-2' : 'max-w-2xl space-y-4'}>
+          <SectionHeader
+            id="job-market-compare-heading"
+            as={embedded ? 'h3' : 'h2'}
+            size={embedded ? 'sm' : 'md'}
+            animated={false}
+            showLeftAccent={!embedded}
+          >
+            {copy.heading}
+          </SectionHeader>
+          {embedded ? null : <Text variant="muted">{copy.description}</Text>}
+        </div>
+      ) : null}
 
       {loadState.status === 'loading' || loadState.status === 'idle' ? (
         <Text variant="muted">{copy.loadingJdsLabel}</Text>
@@ -211,14 +237,31 @@ export function JobMarketLabComparePanel({
       {loadState.status === 'error' ? (
         <p
           role="alert"
-          className="font-body text-lg leading-relaxed text-[var(--foreground)]"
+          className="font-body text-base leading-relaxed text-[var(--foreground)]"
         >
           {copy.errorLabel}
         </p>
       ) : null}
 
       {loadState.status === 'ready' ? (
-        <div className="max-w-2xl space-y-4">
+        <div className={embedded ? 'space-y-3' : 'max-w-2xl space-y-4'}>
+          {embedded && hasSavedCv === false ? (
+            <p role="status" className="font-body text-sm text-[var(--mono-500)]">
+              {fitCopy.saveCvFirstHint}
+            </p>
+          ) : null}
+          {embedded ? (
+            <label className="block space-y-1" htmlFor="job-market-compare-jd-search">
+              <Text size="sm">{fitCopy.jdSearchLabel}</Text>
+              <input
+                id="job-market-compare-jd-search"
+                className="w-full rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent px-2 py-1.5 font-body text-sm text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[color-mix(in_oklab,var(--primary)_35%,transparent)]"
+                value={jdSearch}
+                onChange={(event) => setJdSearch(event.target.value)}
+                placeholder={fitCopy.jdSearchPlaceholder}
+              />
+            </label>
+          ) : null}
           <label className="block space-y-2" htmlFor="job-market-compare-jd">
             <Text size="sm">{copy.selectLabel}</Text>
             <select
@@ -228,10 +271,14 @@ export function JobMarketLabComparePanel({
                 setSelectedId(event.target.value);
                 setCompareState({ status: 'idle' });
               }}
-              className="block w-full rounded border border-[var(--border)] bg-[var(--background)] p-3 font-body text-base text-[var(--foreground)]"
+              className={
+                embedded
+                  ? 'block w-full rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent px-2 py-1.5 font-body text-sm text-[var(--foreground)]'
+                  : 'block w-full rounded border border-[var(--border)] bg-[var(--background)] p-3 font-body text-base text-[var(--foreground)]'
+              }
             >
               <option value="">{copy.noSelectionOption}</option>
-              {loadState.records.map((record) => (
+              {filteredRecords.map((record) => (
                 <option key={record.id} value={record.id}>
                   {record.title?.trim() || jobMarketLab.corpusAdmin.untitledLabel}
                 </option>
@@ -252,76 +299,89 @@ export function JobMarketLabComparePanel({
       {compareState.status === 'error' ? (
         <p
           role="alert"
-          className="font-body text-lg leading-relaxed text-[var(--foreground)]"
+          className="font-body text-base leading-relaxed text-[var(--foreground)]"
         >
           {compareState.message}
         </p>
       ) : null}
 
       {compareState.status === 'ready' ? (
-        <div className="max-w-2xl space-y-8">
-          <div className="space-y-3">
+        <div className={embedded ? 'space-y-5' : 'max-w-2xl space-y-8'}>
+          {embedded ? (
+            <SectionHeader as="h3" size="sm" animated={false} showLeftAccent={false}>
+              {fitCopy.resultsHeading}
+            </SectionHeader>
+          ) : null}
+          <div className="space-y-2">
             <SectionHeader as="h3" size="sm" animated={false} showLeftAccent={false}>
               {copy.matchesHeading}
             </SectionHeader>
             {compareState.result.matches.length === 0 ? (
-              <Text variant="muted">{copy.matchesEmpty}</Text>
+              <Text size="sm" variant="muted">
+                {copy.matchesEmpty}
+              </Text>
             ) : (
-              <ul className="list-disc space-y-1 pl-5">
+              <ul className="list-disc space-y-0.5 pl-5">
                 {compareState.result.matches.map((item) => (
                   <li key={item.name}>
-                    <Text>{item.name}</Text>
+                    <Text size="sm">{item.name}</Text>
                   </li>
                 ))}
               </ul>
             )}
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             <SectionHeader as="h3" size="sm" animated={false} showLeftAccent={false}>
               {copy.gapsHeading}
             </SectionHeader>
             {compareState.result.gaps.length === 0 ? (
-              <Text variant="muted">{copy.gapsEmpty}</Text>
+              <Text size="sm" variant="muted">
+                {copy.gapsEmpty}
+              </Text>
             ) : (
-              <ul className="list-disc space-y-1 pl-5">
+              <ul className="list-disc space-y-0.5 pl-5">
                 {compareState.result.gaps.map((item) => (
                   <li key={item.name}>
-                    <Text>{item.name}</Text>
+                    <Text size="sm">{item.name}</Text>
                   </li>
                 ))}
               </ul>
             )}
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             <SectionHeader as="h3" size="sm" animated={false} showLeftAccent={false}>
               {copy.talkingPointsHeading}
             </SectionHeader>
             {compareState.result.talkingPoints.length === 0 ? (
-              <Text variant="muted">{copy.talkingPointsEmpty}</Text>
+              <Text size="sm" variant="muted">
+                {copy.talkingPointsEmpty}
+              </Text>
             ) : (
-              <ul className="list-disc space-y-1 pl-5">
+              <ul className="list-disc space-y-0.5 pl-5">
                 {compareState.result.talkingPoints.map((point) => (
                   <li key={point}>
-                    <Text>{point}</Text>
+                    <Text size="sm">{point}</Text>
                   </li>
                 ))}
               </ul>
             )}
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             <SectionHeader as="h3" size="sm" animated={false} showLeftAccent={false}>
               {copy.learningTargetsHeading}
             </SectionHeader>
             {compareState.result.learningTargets.length === 0 ? (
-              <Text variant="muted">{copy.learningTargetsEmpty}</Text>
+              <Text size="sm" variant="muted">
+                {copy.learningTargetsEmpty}
+              </Text>
             ) : (
-              <ul className="list-disc space-y-1 pl-5">
+              <ul className="list-disc space-y-0.5 pl-5">
                 {compareState.result.learningTargets.map((target) => (
                   <li key={target}>
-                    <Text>{target}</Text>
+                    <Text size="sm">{target}</Text>
                   </li>
                 ))}
               </ul>

--- a/src/components/sections/labs/job-market-lab-cv-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-cv-panel.tsx
@@ -14,6 +14,7 @@ import { createDefaultAmplifyCanonicalCvDeps } from '@/lib/canonical-cv-amplify'
 
 export type JobMarketLabCvPanelProps = {
   canonicalCv?: CanonicalCvDeps;
+  embedded?: boolean;
 };
 
 type LoadState =
@@ -24,6 +25,7 @@ type LoadState =
 
 export function JobMarketLabCvPanel({
   canonicalCv,
+  embedded = false,
 }: JobMarketLabCvPanelProps) {
   const { session, isLoading } = useSiteAuth();
   const [deps] = useState(() => canonicalCv ?? createDefaultAmplifyCanonicalCvDeps());
@@ -99,18 +101,23 @@ export function JobMarketLabCvPanel({
   }
 
   return (
-    <section className="mt-16 space-y-6" aria-labelledby="job-market-cv-heading">
-      <div className="max-w-2xl space-y-4">
+    <section
+      className={embedded ? 'space-y-4' : 'mt-16 space-y-6'}
+      aria-labelledby="job-market-cv-heading"
+    >
+      <div className={embedded ? 'space-y-2' : 'max-w-2xl space-y-4'}>
         <SectionHeader
           id="job-market-cv-heading"
-          as="h2"
-          size="md"
+          as={embedded ? 'h3' : 'h2'}
+          size={embedded ? 'sm' : 'md'}
           animated={false}
-          showLeftAccent
+          showLeftAccent={!embedded}
         >
-          {cvCopy.heading}
+          {embedded
+            ? jobMarketLab.console.fitWorkspace.cvColumnHeading
+            : cvCopy.heading}
         </SectionHeader>
-        <Text variant="muted">{cvCopy.description}</Text>
+        {embedded ? null : <Text variant="muted">{cvCopy.description}</Text>}
       </div>
 
       {loadState.status === 'loading' ? (
@@ -122,9 +129,11 @@ export function JobMarketLabCvPanel({
       ) : null}
 
       {loadState.status === 'ready' || loadState.status === 'idle' ? (
-        <div className="max-w-2xl space-y-4">
+        <div className={embedded ? 'space-y-3' : 'max-w-2xl space-y-4'}>
           {isEmpty ? (
-            <Text variant="muted">{cvCopy.emptyHint}</Text>
+            <Text size="sm" variant="muted">
+              {cvCopy.emptyHint}
+            </Text>
           ) : null}
 
           <label className="block space-y-2" htmlFor="job-market-cv-body">
@@ -133,8 +142,12 @@ export function JobMarketLabCvPanel({
               id="job-market-cv-body"
               value={draftBody}
               onChange={(event) => setDraftBody(event.target.value)}
-              rows={16}
-              className="block w-full rounded border border-[var(--border)] bg-[var(--background)] p-3 font-body text-base leading-relaxed text-[var(--foreground)]"
+              rows={embedded ? 22 : 16}
+              className={
+                embedded
+                  ? 'block min-h-[18rem] w-full resize-y rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent p-2 font-body text-sm leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[color-mix(in_oklab,var(--primary)_35%,transparent)]'
+                  : 'block w-full rounded border border-[var(--border)] bg-[var(--background)] p-3 font-body text-base leading-relaxed text-[var(--foreground)]'
+              }
             />
           </label>
 

--- a/src/components/sections/labs/job-market-lab-market-compare-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-market-compare-panel.tsx
@@ -17,6 +17,8 @@ import {
 export type JobMarketLabMarketComparePanelProps = {
   canonicalCv?: CanonicalCvDeps;
   ownerPulse?: FetchOwnerJobMarketPulseSourceDeps;
+  embedded?: boolean;
+  showHeading?: boolean;
 };
 
 type LoadState =
@@ -44,6 +46,8 @@ function comparisonTemplates() {
 export function JobMarketLabMarketComparePanel({
   canonicalCv,
   ownerPulse,
+  embedded = false,
+  showHeading = true,
 }: JobMarketLabMarketComparePanelProps) {
   const { session, isLoading } = useSiteAuth();
   const [cvDeps] = useState(() => canonicalCv ?? createDefaultAmplifyCanonicalCvDeps());
@@ -93,6 +97,7 @@ export function JobMarketLabMarketComparePanel({
   }
 
   const copy = jobMarketLab.console.marketCompare;
+  const fitCopy = jobMarketLab.console.fitWorkspace;
 
   async function handleCompare() {
     const compareCopy = jobMarketLab.console.marketCompare;
@@ -157,19 +162,24 @@ export function JobMarketLabMarketComparePanel({
   }
 
   return (
-    <section className="mt-16 space-y-6" aria-labelledby="job-market-market-compare-heading">
-      <div className="max-w-2xl space-y-4">
-        <SectionHeader
-          id="job-market-market-compare-heading"
-          as="h2"
-          size="md"
-          animated={false}
-          showLeftAccent
-        >
-          {copy.heading}
-        </SectionHeader>
-        <Text variant="muted">{copy.description}</Text>
-      </div>
+    <section
+      className={embedded ? 'space-y-4' : 'mt-16 space-y-6'}
+      aria-labelledby="job-market-market-compare-heading"
+    >
+      {showHeading ? (
+        <div className={embedded ? 'space-y-2' : 'max-w-2xl space-y-4'}>
+          <SectionHeader
+            id="job-market-market-compare-heading"
+            as={embedded ? 'h3' : 'h2'}
+            size={embedded ? 'sm' : 'md'}
+            animated={false}
+            showLeftAccent={!embedded}
+          >
+            {copy.heading}
+          </SectionHeader>
+          {embedded ? null : <Text variant="muted">{copy.description}</Text>}
+        </div>
+      ) : null}
 
       {loadState.status === 'loading' || loadState.status === 'idle' ? (
         <Text variant="muted">{copy.loadingPulseLabel}</Text>
@@ -185,7 +195,12 @@ export function JobMarketLabMarketComparePanel({
       ) : null}
 
       {loadState.status === 'ready' || loadState.status === 'empty' ? (
-        <div className="max-w-2xl space-y-4">
+        <div className={embedded ? 'space-y-3' : 'max-w-2xl space-y-4'}>
+          {embedded ? (
+            <p role="status" className="font-body text-sm text-[var(--mono-500)]">
+              {fitCopy.saveCvFirstHint}
+            </p>
+          ) : null}
           <Button
             type="button"
             onClick={() => void handleCompare()}

--- a/src/components/sections/labs/job-market-lab-metadata-admin.test.tsx
+++ b/src/components/sections/labs/job-market-lab-metadata-admin.test.tsx
@@ -146,6 +146,12 @@ describe('JobMarketLabMetadataAdmin', () => {
       screen.getByLabelText(`${jobMarketLab.metadataAdmin.roleFamilyLabel} (jd-1)`),
       'data_science',
     );
+    await user.selectOptions(
+      screen.getByLabelText(
+        `${jobMarketLab.metadataAdmin.compensationDisclosureLabel} (jd-1)`,
+      ),
+      'range',
+    );
     await user.type(
       screen.getByLabelText(`${jobMarketLab.metadataAdmin.compensationCurrencyLabel} (jd-1)`),
       'GBP',
@@ -183,6 +189,7 @@ describe('JobMarketLabMetadataAdmin', () => {
         compensationMin: 80000,
         compensationMax: 95000,
         compensationPeriod: 'year',
+        compensationDisclosure: 'range',
       }),
     );
   });

--- a/src/components/sections/labs/job-market-lab-metadata-admin.tsx
+++ b/src/components/sections/labs/job-market-lab-metadata-admin.tsx
@@ -8,10 +8,13 @@ import type { JobDescriptionCorpusRecord } from '@/lib/job-market-corpus';
 import type { AmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
 import { createDefaultAmplifyCorpusDeps } from '@/lib/job-market-corpus-amplify';
 import {
+  COMPENSATION_DISCLOSURES,
   COMPENSATION_PERIODS,
   JOB_DESCRIPTION_ROLE_FAMILIES,
   JOB_DESCRIPTION_SENIORITIES,
+  resolveCompensationDisclosure,
   updateJobDescriptionStructuredFields,
+  type CompensationDisclosure,
   type CompensationPeriod,
   type EmployerRecord,
   type JobDescriptionRoleFamily,
@@ -46,6 +49,7 @@ type MetadataDraft = {
   employerId: string;
   seniority: string;
   roleFamily: string;
+  compensationDisclosure: CompensationDisclosure;
   compensationCurrency: string;
   compensationMin: string;
   compensationMax: string;
@@ -60,6 +64,7 @@ function toDraft(record: JobDescriptionCorpusRecord): MetadataDraft {
     employerId: record.employerId ?? '',
     seniority: record.seniority ?? '',
     roleFamily: record.roleFamily ?? '',
+    compensationDisclosure: resolveCompensationDisclosure(record),
     compensationCurrency: record.compensationCurrency ?? '',
     compensationMin:
       record.compensationMin != null ? String(record.compensationMin) : '',
@@ -141,6 +146,9 @@ export function JobMarketLabMetadataAdmin({
     const draft = drafts[record.id] ?? toDraft(record);
     setSaveState({ status: 'saving' });
 
+    const disclosure = draft.compensationDisclosure;
+    const isRange = disclosure === 'range';
+
     const result = await updateJobDescriptionStructuredFields(
       record.id,
       {
@@ -151,13 +159,20 @@ export function JobMarketLabMetadataAdmin({
         roleFamily: draft.roleFamily
           ? (draft.roleFamily as JobDescriptionRoleFamily)
           : null,
-        compensationCurrency: draft.compensationCurrency.trim()
-          ? draft.compensationCurrency.trim()
+        compensationDisclosure: disclosure,
+        compensationCurrency: isRange
+          ? draft.compensationCurrency.trim() || null
           : null,
-        compensationMin: parseOptionalNumber(draft.compensationMin),
-        compensationMax: parseOptionalNumber(draft.compensationMax),
-        compensationPeriod: draft.compensationPeriod
-          ? (draft.compensationPeriod as CompensationPeriod)
+        compensationMin: isRange
+          ? parseOptionalNumber(draft.compensationMin)
+          : null,
+        compensationMax: isRange
+          ? parseOptionalNumber(draft.compensationMax)
+          : null,
+        compensationPeriod: isRange
+          ? draft.compensationPeriod
+            ? (draft.compensationPeriod as CompensationPeriod)
+            : null
           : null,
       },
       metadata,
@@ -281,59 +296,106 @@ export function JobMarketLabMetadataAdmin({
                 </label>
 
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <label className="block space-y-2">
-                    <Text size="sm">{jobMarketLab.metadataAdmin.compensationCurrencyLabel}</Text>
-                    <input
-                      className={fieldClassName}
-                      value={draft.compensationCurrency}
-                      onChange={(event) =>
-                        updateDraft(record.id, { compensationCurrency: event.target.value })
-                      }
-                      aria-label={`${jobMarketLab.metadataAdmin.compensationCurrencyLabel} (${record.id})`}
-                    />
-                  </label>
-                  <label className="block space-y-2">
-                    <Text size="sm">{jobMarketLab.metadataAdmin.compensationPeriodLabel}</Text>
+                  <label className="block space-y-2 sm:col-span-2">
+                    <Text size="sm">
+                      {jobMarketLab.metadataAdmin.compensationDisclosureLabel}
+                    </Text>
                     <select
                       className={fieldClassName}
-                      value={draft.compensationPeriod}
+                      value={draft.compensationDisclosure}
                       onChange={(event) =>
-                        updateDraft(record.id, { compensationPeriod: event.target.value })
+                        updateDraft(record.id, {
+                          compensationDisclosure: event.target
+                            .value as CompensationDisclosure,
+                        })
                       }
-                      aria-label={`${jobMarketLab.metadataAdmin.compensationPeriodLabel} (${record.id})`}
+                      aria-label={`${jobMarketLab.metadataAdmin.compensationDisclosureLabel} (${record.id})`}
                     >
-                      <option value="">{jobMarketLab.metadataAdmin.unsetOption}</option>
-                      {COMPENSATION_PERIODS.map((value) => (
+                      {COMPENSATION_DISCLOSURES.map((value) => (
                         <option key={value} value={value}>
-                          {value}
+                          {
+                            jobMarketLab.metadataAdmin
+                              .compensationDisclosureOptions[value]
+                          }
                         </option>
                       ))}
                     </select>
                   </label>
-                  <label className="block space-y-2">
-                    <Text size="sm">{jobMarketLab.metadataAdmin.compensationMinLabel}</Text>
-                    <input
-                      className={fieldClassName}
-                      inputMode="decimal"
-                      value={draft.compensationMin}
-                      onChange={(event) =>
-                        updateDraft(record.id, { compensationMin: event.target.value })
-                      }
-                      aria-label={`${jobMarketLab.metadataAdmin.compensationMinLabel} (${record.id})`}
-                    />
-                  </label>
-                  <label className="block space-y-2">
-                    <Text size="sm">{jobMarketLab.metadataAdmin.compensationMaxLabel}</Text>
-                    <input
-                      className={fieldClassName}
-                      inputMode="decimal"
-                      value={draft.compensationMax}
-                      onChange={(event) =>
-                        updateDraft(record.id, { compensationMax: event.target.value })
-                      }
-                      aria-label={`${jobMarketLab.metadataAdmin.compensationMaxLabel} (${record.id})`}
-                    />
-                  </label>
+                  {draft.compensationDisclosure === 'range' ? (
+                    <>
+                      <label className="block space-y-2">
+                        <Text size="sm">
+                          {jobMarketLab.metadataAdmin.compensationCurrencyLabel}
+                        </Text>
+                        <input
+                          className={fieldClassName}
+                          value={draft.compensationCurrency}
+                          onChange={(event) =>
+                            updateDraft(record.id, {
+                              compensationCurrency: event.target.value,
+                            })
+                          }
+                          aria-label={`${jobMarketLab.metadataAdmin.compensationCurrencyLabel} (${record.id})`}
+                        />
+                      </label>
+                      <label className="block space-y-2">
+                        <Text size="sm">
+                          {jobMarketLab.metadataAdmin.compensationPeriodLabel}
+                        </Text>
+                        <select
+                          className={fieldClassName}
+                          value={draft.compensationPeriod}
+                          onChange={(event) =>
+                            updateDraft(record.id, {
+                              compensationPeriod: event.target.value,
+                            })
+                          }
+                          aria-label={`${jobMarketLab.metadataAdmin.compensationPeriodLabel} (${record.id})`}
+                        >
+                          <option value="">
+                            {jobMarketLab.metadataAdmin.unsetOption}
+                          </option>
+                          {COMPENSATION_PERIODS.map((value) => (
+                            <option key={value} value={value}>
+                              {value}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="block space-y-2">
+                        <Text size="sm">
+                          {jobMarketLab.metadataAdmin.compensationMinLabel}
+                        </Text>
+                        <input
+                          className={fieldClassName}
+                          inputMode="decimal"
+                          value={draft.compensationMin}
+                          onChange={(event) =>
+                            updateDraft(record.id, {
+                              compensationMin: event.target.value,
+                            })
+                          }
+                          aria-label={`${jobMarketLab.metadataAdmin.compensationMinLabel} (${record.id})`}
+                        />
+                      </label>
+                      <label className="block space-y-2">
+                        <Text size="sm">
+                          {jobMarketLab.metadataAdmin.compensationMaxLabel}
+                        </Text>
+                        <input
+                          className={fieldClassName}
+                          inputMode="decimal"
+                          value={draft.compensationMax}
+                          onChange={(event) =>
+                            updateDraft(record.id, {
+                              compensationMax: event.target.value,
+                            })
+                          }
+                          aria-label={`${jobMarketLab.metadataAdmin.compensationMaxLabel} (${record.id})`}
+                        />
+                      </label>
+                    </>
+                  ) : null}
                 </div>
 
                 <Button

--- a/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.test.tsx
+++ b/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.test.tsx
@@ -82,12 +82,15 @@ describe('JobMarketLabPayPrestigeAnalyticsPanel', () => {
       }),
     ).toBeInTheDocument();
 
-    expect(await screen.findByText('2')).toBeInTheDocument();
+    expect(await screen.findByText(jobMarketLab.payPrestigeAnalytics.disclosureHeading)).toBeInTheDocument();
     expect(
       screen.getByText(jobMarketLab.payPrestigeAnalytics.missingDataHeading),
     ).toBeInTheDocument();
     expect(
       screen.getByText(jobMarketLab.payPrestigeAnalytics.missingFieldLabels.employerLink),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(jobMarketLab.payPrestigeAnalytics.disclosureLabels.range),
     ).toBeInTheDocument();
     expect(
       screen.getByText(jobMarketLab.payPrestigeAnalytics.prestigeHeading),

--- a/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-pay-prestige-analytics-panel.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils';
 
 export type JobMarketLabPayPrestigeAnalyticsPanelProps = {
   analytics?: GetOwnerPayPrestigeAnalyticsDeps;
+  embedded?: boolean;
 };
 
 function formatPercent(rate: number): string {
@@ -75,69 +76,82 @@ function TierBars({ items, labelledBy }: { items: TierBucket[]; labelledBy: stri
 function AnalyticsDashboard({ analytics }: { analytics: OwnerPayPrestigeAnalytics }) {
   const copy = jobMarketLab.payPrestigeAnalytics;
   const missingDataId = 'job-market-missing-data-heading';
+  const disclosureId = 'job-market-disclosure-heading';
   const prestigeId = 'job-market-prestige-heading';
   const sizeId = 'job-market-size-heading';
   const compensationId = 'job-market-compensation-heading';
 
   return (
-    <div className="space-y-10">
-      <div className="space-y-1">
-        <Text size="sm" variant="muted">
-          {copy.activeDocumentsLabel}
-        </Text>
-        <Text className="text-3xl font-semibold tabular-nums tracking-tight">
-          {analytics.activeDocumentCount}
-        </Text>
-      </div>
-
-      <section className="space-y-4" aria-labelledby={missingDataId}>
-        <Heading id={missingDataId} as="h3" size="sm">
-          {copy.missingDataHeading}
-        </Heading>
-        <ul className="space-y-3">
-          {analytics.missingDataRates.map((rate) => (
-            <li
-              key={rate.field}
-              className="grid gap-2 border border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] p-4 sm:grid-cols-[minmax(0,12rem)_1fr]"
-            >
-              <Text size="sm">{copy.missingFieldLabels[rate.field]}</Text>
-              <div className="space-y-1">
+    <div className="space-y-8">
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="space-y-3" aria-labelledby={missingDataId}>
+          <Heading id={missingDataId} as="h3" size="sm">
+            {copy.missingDataHeading}
+          </Heading>
+          <ul className="space-y-2">
+            {analytics.missingDataRates.map((rate) => (
+              <li
+                key={rate.field}
+                className="grid gap-1 border-b border-[color-mix(in_oklab,var(--foreground)_10%,transparent)] py-2 sm:grid-cols-[minmax(0,11rem)_1fr]"
+              >
+                <Text size="sm">{copy.missingFieldLabels[rate.field]}</Text>
                 <Text size="sm" variant="muted">
                   {copy.presentLabel}: {rate.present} · {copy.missingLabel}: {rate.missing} (
-                  {formatPercent(rate.missingRate)} {copy.missingLabel.toLowerCase()})
+                  {formatPercent(rate.missingRate)})
                 </Text>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </section>
+              </li>
+            ))}
+          </ul>
+        </section>
 
-      <section className="space-y-4" aria-labelledby={prestigeId}>
-        <Heading id={prestigeId} as="h3" size="sm">
-          {copy.prestigeHeading}
-        </Heading>
-        <TierBars items={analytics.prestigeTierBreakdown} labelledBy={prestigeId} />
-      </section>
+        <section className="space-y-3" aria-labelledby={disclosureId}>
+          <Heading id={disclosureId} as="h3" size="sm">
+            {copy.disclosureHeading}
+          </Heading>
+          <ul className="space-y-2">
+            {analytics.compensationDisclosureBreakdown.map((bucket) => (
+              <li
+                key={bucket.disclosure}
+                className="flex items-baseline justify-between gap-3 border-b border-[color-mix(in_oklab,var(--foreground)_10%,transparent)] py-2"
+              >
+                <Text size="sm">{copy.disclosureLabels[bucket.disclosure]}</Text>
+                <Text size="sm" variant="muted" className="tabular-nums">
+                  {bucket.count}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
 
-      <section className="space-y-4" aria-labelledby={sizeId}>
-        <Heading id={sizeId} as="h3" size="sm">
-          {copy.sizeHeading}
-        </Heading>
-        <TierBars items={analytics.sizeTierBreakdown} labelledBy={sizeId} />
-      </section>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="space-y-3" aria-labelledby={prestigeId}>
+          <Heading id={prestigeId} as="h3" size="sm">
+            {copy.prestigeHeading}
+          </Heading>
+          <TierBars items={analytics.prestigeTierBreakdown} labelledBy={prestigeId} />
+        </section>
 
-      <section className="space-y-4" aria-labelledby={compensationId}>
+        <section className="space-y-3" aria-labelledby={sizeId}>
+          <Heading id={sizeId} as="h3" size="sm">
+            {copy.sizeHeading}
+          </Heading>
+          <TierBars items={analytics.sizeTierBreakdown} labelledBy={sizeId} />
+        </section>
+      </div>
+
+      <section className="space-y-3" aria-labelledby={compensationId}>
         <Heading id={compensationId} as="h3" size="sm">
           {copy.compensationHeading}
         </Heading>
         {analytics.compensationByCurrency.length === 0 ? (
           <Text variant="muted">{copy.compensationEmpty}</Text>
         ) : (
-          <ul className="space-y-4">
+          <ul className="grid gap-3 sm:grid-cols-2">
             {analytics.compensationByCurrency.map((summary) => (
               <li
                 key={summary.currency}
-                className="space-y-2 border border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] p-4"
+                className="space-y-1 border-l-2 border-l-[var(--border)] pl-3"
               >
                 <Text className="font-medium">{summary.currency}</Text>
                 <Text size="sm" variant="muted">
@@ -164,6 +178,7 @@ function AnalyticsDashboard({ analytics }: { analytics: OwnerPayPrestigeAnalytic
 
 export function JobMarketLabPayPrestigeAnalyticsPanel({
   analytics: analyticsDepsProp,
+  embedded = false,
 }: JobMarketLabPayPrestigeAnalyticsPanelProps) {
   const { session, isLoading } = useSiteAuth();
   const [analytics, setAnalytics] = useState<OwnerPayPrestigeAnalytics | null>(null);
@@ -205,7 +220,14 @@ export function JobMarketLabPayPrestigeAnalyticsPanel({
   const copy = jobMarketLab.payPrestigeAnalytics;
 
   return (
-    <div className="mt-16 max-w-2xl space-y-6 border-t border-[var(--border)] pt-12">
+    <div
+      className={cn(
+        'space-y-6',
+        embedded
+          ? 'border-t border-[var(--border)] pt-8'
+          : 'mt-16 max-w-2xl border-t border-[var(--border)] pt-12',
+      )}
+    >
       <div className="space-y-3">
         <SectionHeader as="h2" size="md" animated={false} showLeftAccent>
           {copy.heading}

--- a/src/components/sections/labs/job-market-lab-pulse-filters-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-pulse-filters-panel.tsx
@@ -20,6 +20,7 @@ import {
 
 export type JobMarketLabPulseFiltersPanelProps = {
   ownerPulse?: FetchOwnerJobMarketPulseSourceDeps;
+  embedded?: boolean;
 };
 
 type LoadState =
@@ -75,6 +76,7 @@ function FrequencySummary({ pulse }: { pulse: FilteredJobMarketPulse }) {
 
 export function JobMarketLabPulseFiltersPanel({
   ownerPulse,
+  embedded = false,
 }: JobMarketLabPulseFiltersPanelProps) {
   const { session, isLoading } = useSiteAuth();
   const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
@@ -136,18 +138,23 @@ export function JobMarketLabPulseFiltersPanel({
   }
 
   return (
-    <section className="mt-16 space-y-6" aria-labelledby="job-market-pulse-filters-heading">
+    <section
+      className={embedded ? 'space-y-4' : 'mt-16 space-y-6'}
+      aria-labelledby="job-market-pulse-filters-heading"
+    >
       <div className="space-y-2">
         <SectionHeader
           id="job-market-pulse-filters-heading"
-          as="h2"
-          size="md"
+          as={embedded ? 'h3' : 'h2'}
+          size={embedded ? 'sm' : 'md'}
           animated={false}
-          showLeftAccent
+          showLeftAccent={!embedded}
         >
           {jobMarketLab.console.pulseFiltersHeading}
         </SectionHeader>
-        <Text variant="muted">{jobMarketLab.console.pulseFiltersDescription}</Text>
+        <Text size={embedded ? 'sm' : 'base'} variant="muted">
+          {jobMarketLab.console.pulseFiltersDescription}
+        </Text>
       </div>
 
       {loadState.status === 'loading' || loadState.status === 'idle' ? (

--- a/src/components/sections/labs/job-market-lab-runs-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-runs-panel.tsx
@@ -1,19 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Heading, SectionHeader, Text } from '@/components/ui';
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Heading, SectionHeader, Text } from '@/components/ui';
+import { JobMarketLabAdminSection } from '@/components/sections/labs/job-market-lab-admin-section';
 import { jobMarketLab } from '@/data';
 import {
   listAnalysisRuns,
   type AnalysisRunRecord,
   type AnalysisRunStatus,
   type ListAnalysisRunsDeps,
+  type StartJobMarketRecompute,
 } from '@/lib/job-market-lab';
 import { createDefaultAmplifyAnalysisRunDeps } from '@/lib/job-market-analysis-runs-amplify';
 import { cn } from '@/lib/utils';
 
 export type JobMarketLabRunsPanelProps = {
   analysisRuns?: ListAnalysisRunsDeps;
+  startRecompute?: StartJobMarketRecompute;
 };
 
 function statusLabel(status: AnalysisRunStatus): string {
@@ -30,17 +33,36 @@ function statusLabel(status: AnalysisRunStatus): string {
   }
 }
 
-export function JobMarketLabRunsPanel({ analysisRuns }: JobMarketLabRunsPanelProps) {
+function formatCost(value: number | undefined): string {
+  if (value == null) {
+    return '—';
+  }
+  return new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 4,
+  }).format(value);
+}
+
+export function JobMarketLabRunsPanel({
+  analysisRuns,
+  startRecompute,
+}: JobMarketLabRunsPanelProps) {
   const [runs, setRuns] = useState<AnalysisRunRecord[] | null>(null);
   const [error, setError] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const load = useCallback(async () => {
+    const deps = analysisRuns ?? (await createDefaultAmplifyAnalysisRunDeps());
+    return listAnalysisRuns(deps);
+  }, [analysisRuns]);
 
   useEffect(() => {
     let cancelled = false;
 
-    async function load() {
+    void (async () => {
       try {
-        const deps = analysisRuns ?? (await createDefaultAmplifyAnalysisRunDeps());
-        const next = await listAnalysisRuns(deps);
+        const next = await load();
         if (!cancelled) {
           setRuns(next);
           setError(false);
@@ -51,21 +73,38 @@ export function JobMarketLabRunsPanel({ analysisRuns }: JobMarketLabRunsPanelPro
           setError(true);
         }
       }
-    }
+    })();
 
-    void load();
     return () => {
       cancelled = true;
     };
-  }, [analysisRuns]);
+  }, [load, reloadToken]);
 
   return (
-    <div className="mt-16 max-w-2xl space-y-6 border-t border-[var(--border)] pt-12">
+    <div className="space-y-6">
       <div className="space-y-3">
         <SectionHeader as="h2" size="md" animated={false} showLeftAccent>
           {jobMarketLab.console.runsHeading}
         </SectionHeader>
         <Text variant="muted">{jobMarketLab.console.runsDescription}</Text>
+      </div>
+
+      <JobMarketLabAdminSection
+        startRecompute={startRecompute}
+        variant="secondary"
+      />
+
+      <div className="flex items-center justify-between gap-3">
+        <Text size="sm" variant="muted">
+          {runs != null ? `${runs.length} runs` : ''}
+        </Text>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => setReloadToken((value) => value + 1)}
+        >
+          {jobMarketLab.console.runsReloadLabel}
+        </Button>
       </div>
 
       {error ? (
@@ -83,7 +122,7 @@ export function JobMarketLabRunsPanel({ analysisRuns }: JobMarketLabRunsPanelPro
       ) : null}
 
       {!error && runs !== null && runs.length > 0 ? (
-        <ul className="space-y-4">
+        <ul className="divide-y divide-[var(--border)] border-t border-[var(--border)]">
           {runs.map((run) => {
             const accentPrimary =
               run.status === 'running' || run.status === 'succeeded';
@@ -91,32 +130,53 @@ export function JobMarketLabRunsPanel({ analysisRuns }: JobMarketLabRunsPanelPro
               <li
                 key={run.id}
                 className={cn(
-                  'space-y-1 border-b border-[var(--border)] border-l-4 pb-4 pl-3 last:border-b-0',
+                  'grid gap-2 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start',
+                  'border-l-4 pl-3',
                   accentPrimary
                     ? 'border-l-[var(--primary)]'
                     : 'border-l-[var(--mono-300)]',
                 )}
               >
-                <div className="flex flex-wrap items-baseline justify-between gap-2">
-                  <Heading as="h3" size="sm">
-                    {run.id}
-                  </Heading>
-                  <span
-                    className={cn(
-                      'inline-flex rounded px-1.5 py-0.5 font-body text-xs font-medium',
-                      accentPrimary
-                        ? 'bg-[color-mix(in_oklab,var(--primary)_12%,transparent)] text-[var(--primary)]'
-                        : 'bg-[var(--muted)] text-[var(--mono-500)]',
-                    )}
-                  >
-                    {statusLabel(run.status)}
-                  </span>
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-baseline gap-2">
+                    <Heading as="h3" size="sm" className="truncate">
+                      {run.id}
+                    </Heading>
+                    <span
+                      className={cn(
+                        'inline-flex rounded px-1.5 py-0.5 font-body text-xs font-medium',
+                        accentPrimary
+                          ? 'bg-[color-mix(in_oklab,var(--primary)_12%,transparent)] text-[var(--primary)]'
+                          : 'bg-[var(--muted)] text-[var(--mono-500)]',
+                      )}
+                    >
+                      {statusLabel(run.status)}
+                    </span>
+                  </div>
+                  <dl className="grid gap-1 text-sm sm:grid-cols-2">
+                    <div className="flex gap-2">
+                      <dt className="text-[var(--mono-500)]">
+                        {jobMarketLab.console.runsDocsConsideredLabel}
+                      </dt>
+                      <dd className="tabular-nums">
+                        {run.docsConsidered ?? '—'}
+                      </dd>
+                    </div>
+                    <div className="flex gap-2">
+                      <dt className="text-[var(--mono-500)]">
+                        {jobMarketLab.console.runsEstimatedCostLabel}
+                      </dt>
+                      <dd className="tabular-nums">
+                        {formatCost(run.estimatedCostUsd)}
+                      </dd>
+                    </div>
+                  </dl>
+                  {run.status === 'failed' && run.errorMessage ? (
+                    <Text size="sm" variant="muted">
+                      {jobMarketLab.console.failureReasonLabel}: {run.errorMessage}
+                    </Text>
+                  ) : null}
                 </div>
-                {run.status === 'failed' && run.errorMessage ? (
-                  <Text size="sm" variant="muted">
-                    {jobMarketLab.console.failureReasonLabel}: {run.errorMessage}
-                  </Text>
-                ) : null}
               </li>
             );
           })}

--- a/src/components/sections/labs/job-market-lab-section.test.tsx
+++ b/src/components/sections/labs/job-market-lab-section.test.tsx
@@ -54,27 +54,45 @@ const published: PublishedJobMarketResult = {
 };
 
 describe('JobMarketLabSection', () => {
-  it('renders corpus freshness and aggregate visuals from a published snapshot', () => {
+  it('renders a data-first pulse with technologies, ranked themes, and map', () => {
     renderLab(published);
 
     expect(screen.queryByText(jobMarketLab.emptyState)).not.toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.brandEyebrow)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: jobMarketLab.heading })).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.purposeLine)).toBeInTheDocument();
     expect(screen.getByText(jobMarketLab.metricsHeading)).toBeInTheDocument();
+
     expect(screen.getByText('12')).toBeInTheDocument();
     expect(screen.getByText(/14 Jul 2026/i)).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.topSignalsLabel)).toBeInTheDocument();
+    expect(screen.getByText(/python · sql/i)).toBeInTheDocument();
 
     expect(screen.getByText(jobMarketLab.skillsHeading)).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.skillsCaption)).toBeInTheDocument();
     expect(screen.getByText('python')).toBeInTheDocument();
     expect(screen.getByText('sql')).toBeInTheDocument();
+
+    expect(screen.getByText(jobMarketLab.clustersHeading)).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.clustersSizeHeading)).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.clustersMapHeading)).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.clustersCaption)).toBeInTheDocument();
+    expect(screen.getByText('Theme 1')).toBeInTheDocument();
+    expect(screen.getByText('Theme 2')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: jobMarketLab.clustersMapHeading }),
+    ).toBeInTheDocument();
 
     expect(screen.getByText(jobMarketLab.taxonomyHeading)).toBeInTheDocument();
     expect(screen.getByText('senior')).toBeInTheDocument();
     expect(screen.getByText('data_science')).toBeInTheDocument();
 
-    expect(screen.getByText(jobMarketLab.clustersHeading)).toBeInTheDocument();
-    expect(screen.getByText('Theme 1')).toBeInTheDocument();
-    expect(screen.getByText('Theme 2')).toBeInTheDocument();
-
-    expect(screen.getByText(jobMarketLab.corpusNote)).toBeInTheDocument();
+    expect(screen.queryByText(/Aggregates only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Guests/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/sign-in/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: jobMarketLab.craft.heading }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: jobMarketLab.admin.heading }),
     ).not.toBeInTheDocument();
@@ -87,6 +105,34 @@ describe('JobMarketLabSection', () => {
     expect(
       screen.queryByRole('link', { name: jobMarketLab.console.openConsoleLabel }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders the craft methodology as its own visible section with all stages', () => {
+    renderLab(published);
+
+    expect(
+      screen.getByRole('heading', { name: jobMarketLab.craft.heading }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.craft.intro)).toBeInTheDocument();
+    if (jobMarketLab.craft.closing) {
+      expect(screen.getByText(jobMarketLab.craft.closing)).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText(/Owner curation/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Guests only/i)).not.toBeInTheDocument();
+    }
+
+    for (const stage of jobMarketLab.craft.stages) {
+      expect(screen.getByRole('heading', { name: stage.title })).toBeInTheDocument();
+      expect(screen.getByText(stage.inShort)).toBeInTheDocument();
+      expect(screen.getByText(stage.underTheHood)).toBeInTheDocument();
+    }
+
+    expect(screen.getAllByText(jobMarketLab.craft.inShortLabel).length).toBe(
+      jobMarketLab.craft.stages.length,
+    );
+    expect(screen.getAllByText(jobMarketLab.craft.underTheHoodLabel).length).toBe(
+      jobMarketLab.craft.stages.length,
+    );
   });
 
   it('never embeds owner management panels even for signed-in owners', async () => {
@@ -127,5 +173,9 @@ describe('JobMarketLabSection', () => {
 
     expect(screen.getByText(jobMarketLab.emptyState)).toBeInTheDocument();
     expect(screen.queryByText(jobMarketLab.skillsHeading)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: jobMarketLab.craft.heading }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(jobMarketLab.craft.stages[0]!.title)).toBeInTheDocument();
   });
 });

--- a/src/components/sections/labs/job-market-lab-section.tsx
+++ b/src/components/sections/labs/job-market-lab-section.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
-import { Container, Section, SectionHeader, Text } from '@/components/ui';
+import { Container, MotionReveal, SectionHeader, Text } from '@/components/ui';
 import { jobMarketLab } from '@/data';
 import type {
   JobMarketSnapshot,
@@ -22,6 +22,15 @@ interface JobMarketLabSectionProps {
   publication: PublishedJobMarketResult;
 }
 
+const CLUSTER_FILLS = [
+  'var(--primary)',
+  'var(--foreground)',
+  'color-mix(in oklab, var(--primary) 55%, var(--foreground))',
+  'color-mix(in oklab, var(--foreground) 45%, transparent)',
+  'color-mix(in oklab, var(--primary) 35%, var(--foreground))',
+  'color-mix(in oklab, var(--foreground) 70%, transparent)',
+] as const;
+
 function formatPublishedAt(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) {
@@ -37,22 +46,32 @@ function formatPublishedAt(iso: string): string {
 function FrequencyBars({
   items,
   labelledBy,
+  dense = false,
 }: {
   items: Array<SkillFrequency | TaxonomyBucket>;
   labelledBy: string;
+  dense?: boolean;
 }) {
   const max = Math.max(...items.map((item) => item.count), 1);
   const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
-    <ul className="space-y-3" aria-labelledby={labelledBy}>
+    <ul className={cn(dense ? 'space-y-2' : 'space-y-2.5')} aria-labelledby={labelledBy}>
       {items.map((item) => (
-        <li key={item.name} className="grid grid-cols-[minmax(0,7rem)_1fr_auto] items-center gap-3">
+        <li
+          key={item.name}
+          className={cn(
+            'grid items-center gap-2',
+            dense
+              ? 'grid-cols-[minmax(0,5.5rem)_1fr_auto]'
+              : 'grid-cols-[minmax(0,7rem)_1fr_auto] gap-3',
+          )}
+        >
           <Text size="sm" className="truncate">
             {item.name}
           </Text>
           <div
-            className="h-2 overflow-hidden rounded-sm bg-[color-mix(in_oklab,var(--foreground)_12%,transparent)]"
+            className="h-1.5 overflow-hidden rounded-sm bg-[color-mix(in_oklab,var(--foreground)_10%,transparent)]"
             role="presentation"
           >
             <div
@@ -72,7 +91,63 @@ function FrequencyBars({
   );
 }
 
-function ClusterProjection({ snapshot }: { snapshot: JobMarketSnapshot }) {
+function ThemeSizeBars({
+  clusters,
+  labelledBy,
+}: {
+  clusters: JobMarketSnapshot['clusters'];
+  labelledBy: string;
+}) {
+  const ranked = [...clusters]
+    .filter((cluster) => cluster.size > 0)
+    .sort((a, b) => b.size - a.size || a.label.localeCompare(b.label));
+  const max = Math.max(...ranked.map((cluster) => cluster.size), 1);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  if (ranked.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="space-y-2.5" aria-labelledby={labelledBy}>
+      {ranked.map((cluster) => (
+        <li
+          key={cluster.id}
+          className="grid grid-cols-[minmax(0,1fr)_minmax(4rem,8rem)_auto] items-center gap-3"
+        >
+          <Text size="sm" className="truncate">
+            <span
+              className="mr-2 inline-block h-2 w-2 rounded-full align-middle"
+              style={{ background: CLUSTER_FILLS[cluster.id % CLUSTER_FILLS.length] }}
+              aria-hidden
+            />
+            {cluster.label}
+          </Text>
+          <div
+            className="h-1.5 overflow-hidden rounded-sm bg-[color-mix(in_oklab,var(--foreground)_10%,transparent)]"
+            role="presentation"
+          >
+            <div
+              className={cn(
+                'h-full rounded-sm',
+                !prefersReducedMotion && 'transition-[width] duration-500 ease-out',
+              )}
+              style={{
+                width: `${(cluster.size / max) * 100}%`,
+                background: CLUSTER_FILLS[cluster.id % CLUSTER_FILLS.length],
+              }}
+            />
+          </div>
+          <Text size="sm" variant="muted" className="tabular-nums">
+            {cluster.size}
+          </Text>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ThemeMap({ snapshot }: { snapshot: JobMarketSnapshot }) {
   const prefersReducedMotion = usePrefersReducedMotion();
   const points = snapshot.projection.slice(0, 200);
 
@@ -90,44 +165,109 @@ function ClusterProjection({ snapshot }: { snapshot: JobMarketSnapshot }) {
   const spanY = maxY - minY || 1;
 
   return (
-    <div className="space-y-4">
-      <ul className="flex flex-wrap gap-x-4 gap-y-2" aria-label="Cluster sizes">
-        {snapshot.clusters.map((cluster) => (
-          <li key={cluster.id}>
-            <Text size="sm">
-              {cluster.label}
-              <span className="text-[var(--muted-foreground)]"> · {cluster.size}</span>
+    <svg
+      viewBox="0 0 420 240"
+      role="img"
+      aria-label={jobMarketLab.clustersMapHeading}
+      className="h-auto w-full border border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] bg-[color-mix(in_oklab,var(--foreground)_3%,transparent)]"
+    >
+      {points.map((point, index) => {
+        const cx = ((point.x - minX) / spanX) * 396 + 12;
+        const cy = 228 - ((point.y - minY) / spanY) * 216;
+        return (
+          <circle
+            key={`${point.clusterId}-${index}`}
+            cx={cx}
+            cy={cy}
+            r={4.5}
+            fill={CLUSTER_FILLS[point.clusterId % CLUSTER_FILLS.length]}
+            className={cn(!prefersReducedMotion && 'transition-opacity duration-300')}
+            opacity={0.88}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function CraftMethodologySection() {
+  const craft = jobMarketLab.craft;
+  const headingId = 'job-market-craft-heading';
+
+  return (
+    <section
+      className="relative mt-14 overflow-hidden border-t border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] pt-10 md:mt-16 md:pt-12"
+      aria-labelledby={headingId}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,color-mix(in_oklab,var(--primary)_7%,transparent),transparent_50%)]"
+      />
+      <div className="relative space-y-8">
+        <MotionReveal variant="fade-up" distance="sm" className="max-w-3xl space-y-3">
+          <SectionHeader
+            id={headingId}
+            as="h2"
+            size="md"
+            animated={false}
+            showLeftAccent
+          >
+            {craft.heading}
+          </SectionHeader>
+          <Text className="text-[var(--foreground)]">{craft.intro}</Text>
+        </MotionReveal>
+
+        <ol className="grid gap-x-8 gap-y-8 sm:grid-cols-2 xl:grid-cols-3">
+          {craft.stages.map((stage, index) => (
+            <li
+              key={stage.id}
+              className="relative space-y-3 border-l-2 border-[color-mix(in_oklab,var(--primary)_45%,transparent)] pl-4"
+            >
+              <MotionReveal
+                variant="fade-up"
+                distance="sm"
+                delay={Math.min(index * 0.04, 0.24)}
+                className="space-y-3"
+              >
+                <div className="flex items-baseline gap-3">
+                  <span
+                    className="font-body text-xs font-semibold tabular-nums tracking-wide text-[var(--primary)]"
+                    aria-hidden
+                  >
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <h3 className="font-body text-base font-semibold tracking-tight text-[var(--foreground)]">
+                    {stage.title}
+                  </h3>
+                </div>
+                <div className="space-y-1.5">
+                  <p className="font-body text-[0.65rem] font-medium uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+                    {craft.inShortLabel}
+                  </p>
+                  <Text size="sm">{stage.inShort}</Text>
+                </div>
+                <div className="space-y-1.5">
+                  <p className="font-body text-[0.65rem] font-medium uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+                    {craft.underTheHoodLabel}
+                  </p>
+                  <Text size="sm" variant="muted">
+                    {stage.underTheHood}
+                  </Text>
+                </div>
+              </MotionReveal>
+            </li>
+          ))}
+        </ol>
+
+        {craft.closing ? (
+          <MotionReveal variant="fade-up" distance="sm" delay={0.12} className="max-w-3xl">
+            <Text size="sm" variant="muted">
+              {craft.closing}
             </Text>
-          </li>
-        ))}
-      </ul>
-      <svg
-        viewBox="0 0 320 180"
-        role="img"
-        aria-label="Two-dimensional projection of requirement clusters"
-        className="h-auto w-full max-w-xl border border-[color-mix(in_oklab,var(--foreground)_14%,transparent)] bg-[color-mix(in_oklab,var(--foreground)_4%,transparent)]"
-      >
-        {points.map((point, index) => {
-          const cx = ((point.x - minX) / spanX) * 300 + 10;
-          const cy = 170 - ((point.y - minY) / spanY) * 160;
-          return (
-            <circle
-              key={`${point.clusterId}-${index}`}
-              cx={cx}
-              cy={cy}
-              r={4}
-              className={cn(
-                point.clusterId % 2 === 0
-                  ? 'fill-[var(--foreground)]'
-                  : 'fill-[color-mix(in_oklab,var(--foreground)_55%,transparent)]',
-                !prefersReducedMotion && 'transition-opacity duration-300',
-              )}
-              opacity={0.85}
-            />
-          );
-        })}
-      </svg>
-    </div>
+          </MotionReveal>
+        ) : null}
+      </div>
+    </section>
   );
 }
 
@@ -157,94 +297,158 @@ function PublishedDashboard({ snapshot }: { snapshot: JobMarketSnapshot }) {
   const technologiesId = 'job-market-technologies-heading';
   const taxonomyId = 'job-market-taxonomy-heading';
   const clustersId = 'job-market-clusters-heading';
+  const themeSizeId = 'job-market-theme-size-heading';
+  const themeMapId = 'job-market-theme-map-heading';
   const technologyPulse = displaySnapshot.technologies ?? displaySnapshot.skills;
+  const topSignals = technologyPulse.slice(0, 3).map((item) => item.name);
   const showTimeFilter = snapshot.corpusMeta != null;
 
   return (
-    <div className="space-y-14">
-      {showTimeFilter ? (
-        <section className="max-w-md space-y-2" aria-labelledby="job-market-time-filter-label">
-          <Text id="job-market-time-filter-label" size="sm" variant="muted">
-            {jobMarketLab.pulseFiltersTimeLabel}
+    <div className="space-y-8 md:space-y-10">
+      <div className="flex flex-col gap-4 border-b border-[color-mix(in_oklab,var(--foreground)_12%,transparent)] pb-6 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <Text size="sm" className="font-medium tracking-wide text-[var(--muted-foreground)]">
+            {jobMarketLab.metricsHeading}
           </Text>
-          <select
-            className="w-full rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent px-3 py-2 font-body text-base text-[var(--foreground)]"
-            value={timeWindow}
-            onChange={(event) => {
-              setTimeWindow(event.target.value as JobMarketPulseTimeWindow);
-            }}
-          >
-            {(['all', '3m', '6m', '12m', '18m'] as const).map((window) => (
-              <option key={window} value={window}>
-                {jobMarketLab.pulseFilterTimeOptions[window]}
-              </option>
-            ))}
-          </select>
-        </section>
-      ) : null}
-
-      <section className="space-y-4" aria-labelledby="job-market-metrics-heading">
-        <SectionHeader id="job-market-metrics-heading" as="h2" size="md" animated={false} showLeftAccent={false}>
-          {jobMarketLab.metricsHeading}
-        </SectionHeader>
-        <div className="grid gap-6 sm:grid-cols-2">
-          <div className="space-y-1">
-            <Text size="sm" variant="muted">
-              {jobMarketLab.documentCountLabel}
-            </Text>
-            <Text className="text-3xl font-semibold tabular-nums tracking-tight">
-              {displaySnapshot.documentCount}
-            </Text>
-          </div>
-          <div className="space-y-1">
-            <Text size="sm" variant="muted">
-              {jobMarketLab.publishedAtLabel}
-            </Text>
-            <Text className="text-xl font-medium tracking-tight">
-              {formatPublishedAt(displaySnapshot.publishedAt)}
-            </Text>
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+            <div>
+              <Text size="sm" variant="muted">
+                {jobMarketLab.documentCountLabel}
+              </Text>
+              <p className="font-body text-3xl font-semibold tabular-nums tracking-tight text-[var(--foreground)]">
+                {displaySnapshot.documentCount}
+              </p>
+            </div>
+            <div>
+              <Text size="sm" variant="muted">
+                {jobMarketLab.publishedAtLabel}
+              </Text>
+              <p className="font-body text-lg font-medium tracking-tight text-[var(--foreground)]">
+                {formatPublishedAt(displaySnapshot.publishedAt)}
+              </p>
+            </div>
+            {topSignals.length > 0 ? (
+              <div className="min-w-0">
+                <Text size="sm" variant="muted">
+                  {jobMarketLab.topSignalsLabel}
+                </Text>
+                <p className="font-body text-sm text-[var(--foreground)]">
+                  {topSignals.join(' · ')}
+                </p>
+              </div>
+            ) : null}
           </div>
         </div>
-      </section>
 
-      <section className="space-y-4" aria-labelledby={technologiesId}>
-        <SectionHeader id={technologiesId} as="h2" size="md" animated={false} showLeftAccent={false}>
-          {jobMarketLab.skillsHeading}
-        </SectionHeader>
-        <FrequencyBars items={technologyPulse.slice(0, 40)} labelledBy={technologiesId} />
-      </section>
+        {showTimeFilter ? (
+          <div className="w-full max-w-xs space-y-1.5 lg:shrink-0">
+            <label
+              htmlFor="job-market-time-filter"
+              className="font-body text-sm text-[var(--muted-foreground)]"
+            >
+              {jobMarketLab.pulseFiltersTimeLabel}
+            </label>
+            <select
+              id="job-market-time-filter"
+              className="w-full rounded-md border border-[color-mix(in_oklab,var(--foreground)_20%,transparent)] bg-transparent px-3 py-2 font-body text-sm text-[var(--foreground)]"
+              value={timeWindow}
+              onChange={(event) => {
+                setTimeWindow(event.target.value as JobMarketPulseTimeWindow);
+              }}
+            >
+              {(['all', '3m', '6m', '12m', '18m'] as const).map((window) => (
+                <option key={window} value={window}>
+                  {jobMarketLab.pulseFilterTimeOptions[window]}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+      </div>
 
-      <section className="space-y-6" aria-labelledby={taxonomyId}>
-        <SectionHeader id={taxonomyId} as="h2" size="md" animated={false} showLeftAccent={false}>
+      <div className="grid gap-10 lg:grid-cols-2 lg:gap-12">
+        <section className="space-y-3" aria-labelledby={technologiesId}>
+          <SectionHeader
+            id={technologiesId}
+            as="h2"
+            size="md"
+            animated={false}
+            showLeftAccent={false}
+          >
+            {jobMarketLab.skillsHeading}
+          </SectionHeader>
+          <Text size="sm" variant="muted">
+            {jobMarketLab.skillsCaption}
+          </Text>
+          <FrequencyBars items={technologyPulse.slice(0, 40)} labelledBy={technologiesId} />
+        </section>
+
+        <section className="space-y-4" aria-labelledby={clustersId}>
+          <SectionHeader
+            id={clustersId}
+            as="h2"
+            size="md"
+            animated={false}
+            showLeftAccent={false}
+          >
+            {jobMarketLab.clustersHeading}
+          </SectionHeader>
+          <Text size="sm" variant="muted">
+            {jobMarketLab.clustersCaption}
+          </Text>
+
+          <div className="space-y-3">
+            <Text id={themeSizeId} size="sm" className="font-medium">
+              {jobMarketLab.clustersSizeHeading}
+            </Text>
+            <ThemeSizeBars clusters={displaySnapshot.clusters} labelledBy={themeSizeId} />
+          </div>
+
+          <div className="space-y-3">
+            <Text id={themeMapId} size="sm" className="font-medium">
+              {jobMarketLab.clustersMapHeading}
+            </Text>
+            <ThemeMap snapshot={displaySnapshot} />
+          </div>
+        </section>
+      </div>
+
+      <section
+        className="space-y-3 border-t border-[color-mix(in_oklab,var(--foreground)_10%,transparent)] pt-6"
+        aria-labelledby={taxonomyId}
+      >
+        <SectionHeader
+          id={taxonomyId}
+          as="h2"
+          size="sm"
+          animated={false}
+          showLeftAccent={false}
+          className="text-[var(--muted-foreground)]"
+        >
           {jobMarketLab.taxonomyHeading}
         </SectionHeader>
-        <div className="grid gap-10 md:grid-cols-2">
-          <div className="space-y-3">
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div className="space-y-2">
             <Text size="sm" variant="muted">
               {jobMarketLab.seniorityLabel}
             </Text>
             <FrequencyBars
               items={displaySnapshot.seniority}
               labelledBy={taxonomyId}
+              dense
             />
           </div>
-          <div className="space-y-3">
+          <div className="space-y-2">
             <Text size="sm" variant="muted">
               {jobMarketLab.roleFamilyLabel}
             </Text>
             <FrequencyBars
               items={displaySnapshot.roleFamily}
               labelledBy={taxonomyId}
+              dense
             />
           </div>
         </div>
-      </section>
-
-      <section className="space-y-4" aria-labelledby={clustersId}>
-        <SectionHeader id={clustersId} as="h2" size="md" animated={false} showLeftAccent={false}>
-          {jobMarketLab.clustersHeading}
-        </SectionHeader>
-        <ClusterProjection snapshot={displaySnapshot} />
       </section>
     </div>
   );
@@ -254,16 +458,34 @@ export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
   const { session, isLoading } = useSiteAuth();
   const showConsoleLink =
     !isLoading && session !== null && session.status === 'authenticated';
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
-    <Section className="py-20">
-      <Container>
-        <div className="mb-12 max-w-2xl space-y-4">
-          <SectionHeader animated={false}>{jobMarketLab.heading}</SectionHeader>
-          <Text variant="muted">{jobMarketLab.description}</Text>
-          <Text size="sm" variant="muted">
-            {jobMarketLab.corpusNote}
-          </Text>
+    <div className="relative min-h-[calc(100vh-5rem)]">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,color-mix(in_oklab,var(--primary)_8%,transparent),transparent_55%),linear-gradient(180deg,color-mix(in_oklab,var(--foreground)_3%,transparent),transparent_40%)]"
+      />
+      <Container size="xl" className="relative py-8 md:py-10">
+        <header className="mb-8 flex flex-col gap-3 md:mb-10 md:gap-4">
+          <p className="font-body text-xs font-medium uppercase tracking-[0.14em] text-[var(--primary)]">
+            {jobMarketLab.brandEyebrow}
+          </p>
+          {/* Extra bottom padding clears xl heading descenders (tight line-height 0.8). */}
+          <SectionHeader
+            animated={!prefersReducedMotion}
+            size="xl"
+            showLeftAccent
+            className="max-w-3xl pb-[0.28em]"
+          >
+            {jobMarketLab.heading}
+          </SectionHeader>
+          <Text className="max-w-2xl text-[var(--foreground)]">{jobMarketLab.purposeLine}</Text>
+          {jobMarketLab.corpusNote ? (
+            <Text size="sm" variant="muted" className="max-w-2xl">
+              {jobMarketLab.corpusNote}
+            </Text>
+          ) : null}
           {showConsoleLink ? (
             <Link
               href="/labs/job-market/console"
@@ -272,16 +494,20 @@ export function JobMarketLabSection({ publication }: JobMarketLabSectionProps) {
               {jobMarketLab.console.openConsoleLabel}
             </Link>
           ) : null}
-        </div>
+        </header>
 
         {publication.status === 'empty' ? (
-          <div className="max-w-2xl space-y-2" role="status">
-            <Text>{jobMarketLab.emptyState}</Text>
+          <div className="space-y-4 py-8" role="status">
+            <Text className="max-w-xl">{jobMarketLab.emptyState}</Text>
+            <CraftMethodologySection />
           </div>
         ) : (
-          <PublishedDashboard snapshot={publication.snapshot} />
+          <>
+            <PublishedDashboard snapshot={publication.snapshot} />
+            <CraftMethodologySection />
+          </>
         )}
       </Container>
-    </Section>
+    </div>
   );
 }

--- a/src/components/sections/labs/job-market-lab-theme-labels-panel.tsx
+++ b/src/components/sections/labs/job-market-lab-theme-labels-panel.tsx
@@ -17,6 +17,7 @@ import { createDefaultAmplifyThemeLabelOverrideDeps } from '@/lib/job-market-the
 export type JobMarketLabThemeLabelsPanelProps = {
   publication?: GetPublishedJobMarketSnapshotDeps;
   themeLabels?: ListThemeLabelOverridesDeps & SetThemeLabelOverrideDeps;
+  embedded?: boolean;
 };
 
 type LoadState =
@@ -33,6 +34,7 @@ function formatSavedMessage(clusterKey: string): string {
 export function JobMarketLabThemeLabelsPanel({
   publication,
   themeLabels,
+  embedded = false,
 }: JobMarketLabThemeLabelsPanelProps) {
   const { session, isLoading } = useSiteAuth();
   const [deps] = useState(
@@ -108,18 +110,23 @@ export function JobMarketLabThemeLabelsPanel({
   }
 
   return (
-    <section className="mt-16 space-y-6" aria-labelledby="job-market-theme-labels-heading">
+    <section
+      className={embedded ? 'space-y-4' : 'mt-16 space-y-6'}
+      aria-labelledby="job-market-theme-labels-heading"
+    >
       <div className="space-y-2">
         <SectionHeader
           id="job-market-theme-labels-heading"
-          as="h2"
-          size="md"
+          as={embedded ? 'h3' : 'h2'}
+          size={embedded ? 'sm' : 'md'}
           animated={false}
-          showLeftAccent
+          showLeftAccent={!embedded}
         >
           {jobMarketLab.console.themeLabelsHeading}
         </SectionHeader>
-        <Text variant="muted">{jobMarketLab.console.themeLabelsDescription}</Text>
+        <Text size={embedded ? 'sm' : 'base'} variant="muted">
+          {jobMarketLab.console.themeLabelsDescription}
+        </Text>
       </div>
 
       {loadState.status === 'loading' || loadState.status === 'idle' ? (

--- a/src/components/sections/labs/labs-index-section.test.tsx
+++ b/src/components/sections/labs/labs-index-section.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { LabsIndexSection } from '@/components/sections/labs/labs-index-section';
+import { labs } from '@/data';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('LabsIndexSection', () => {
+  it('renders the flagship stage with Labs as the primary heading', () => {
+    render(<LabsIndexSection />);
+
+    expect(screen.getByText(labs.brandEyebrow)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: labs.heading })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: labs.flagshipTitle }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(labs.purposeLine)).toBeInTheDocument();
+
+    const cta = screen.getByRole('link', { name: labs.ctaLabel });
+    expect(cta).toHaveAttribute('href', labs.labs[0].href);
+    expect(screen.getByRole('figure', { name: labs.teaserAriaLabel })).toBeInTheDocument();
+  });
+
+  it('does not render a multi-lab list', () => {
+    render(<LabsIndexSection />);
+
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/labs-index-section.tsx
+++ b/src/components/sections/labs/labs-index-section.tsx
@@ -1,40 +1,199 @@
-import {
-  Button,
-  Container,
-  MotionReveal,
-  Section,
-  SectionHeader,
-  Text,
-} from '@/components/ui';
+'use client';
+
+import { Button, Container, Heading, Text } from '@/components/ui';
 import { labs } from '@/data';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
+import { cn } from '@/lib/utils';
+import { motion } from 'framer-motion';
+
+const flagship = labs.labs[0];
+
+const springEnter = { type: 'spring' as const, damping: 25, stiffness: 80 };
+
+/** Soft green radial (job-market) plus a quiet geometric wash (home DNA, muted). */
+function LabsStageAtmosphere() {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,color-mix(in_oklab,var(--primary)_8%,transparent),transparent_55%),linear-gradient(180deg,color-mix(in_oklab,var(--foreground)_3%,transparent),transparent_40%)]" />
+      <div className="absolute inset-0 geometric-pattern opacity-5" />
+      <div className="absolute top-[28%] left-0 h-px w-full bg-gradient-to-r from-transparent via-[var(--primary)] to-transparent opacity-15" />
+      <div className="absolute bottom-[32%] left-0 h-px w-20 -skew-x-12 bg-[var(--primary)] opacity-20 sm:w-24" />
+    </div>
+  );
+}
+
+/** Abstract dots suggesting signals coalescing; decorative only. */
+function LabsSignalTeaser({
+  prefersReducedMotion,
+  className,
+}: {
+  prefersReducedMotion: boolean;
+  className?: string;
+}) {
+  const dots = [
+    { cx: 18, cy: 42, r: 2.2, delay: 0 },
+    { cx: 32, cy: 28, r: 1.8, delay: 0.08 },
+    { cx: 48, cy: 52, r: 2, delay: 0.12 },
+    { cx: 58, cy: 22, r: 1.6, delay: 0.16 },
+    { cx: 72, cy: 38, r: 2.4, delay: 0.2 },
+    { cx: 88, cy: 48, r: 1.7, delay: 0.24 },
+    { cx: 102, cy: 30, r: 2.1, delay: 0.28 },
+    { cx: 118, cy: 44, r: 3.2, delay: 0.35 },
+    { cx: 128, cy: 36, r: 2.6, delay: 0.4 },
+    { cx: 136, cy: 48, r: 2, delay: 0.45 },
+  ];
+
+  return (
+    <figure
+      className={cn('relative mx-auto w-full max-w-[11rem] sm:max-w-[13rem]', className)}
+      aria-label={labs.teaserAriaLabel}
+    >
+      <svg
+        viewBox="0 0 160 70"
+        className="h-auto w-full text-[var(--primary)]"
+        aria-hidden
+      >
+        {dots.map((dot) => (
+          <motion.circle
+            key={`${dot.cx}-${dot.cy}`}
+            cx={dot.cx}
+            cy={dot.cy}
+            r={dot.r}
+            fill="currentColor"
+            initial={
+              prefersReducedMotion
+                ? { opacity: 0.35 }
+                : { opacity: 0, scale: 0.6 }
+            }
+            animate={{ opacity: 0.35, scale: 1 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0 }
+                : { ...springEnter, delay: 1.15 + dot.delay, duration: 0.7 }
+            }
+          />
+        ))}
+      </svg>
+    </figure>
+  );
+}
 
 export function LabsIndexSection() {
-  return (
-    <Section className="py-20">
-      <Container>
-        <div className="mb-16 max-w-2xl space-y-4">
-          <SectionHeader animated={false}>{labs.heading}</SectionHeader>
-          <Text variant="muted">{labs.description}</Text>
-        </div>
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const flagshipHref = flagship?.href ?? '/labs/job-market';
+  const flagshipTitle = labs.flagshipTitle || flagship?.title || 'Job Signal Lab';
 
-        <ul className="space-y-10">
-          {labs.labs.map((lab, index) => (
-            <MotionReveal key={lab.href} variant="fade-up" distance="sm" delay={index * 0.05}>
-              <li className="max-w-2xl space-y-4">
-                <SectionHeader size="md" animated={false} showLeftAccent={false}>
-                  {lab.title}
-                </SectionHeader>
-                <Text size="sm" variant="muted">
-                  {lab.description}
-                </Text>
-                <Button href={lab.href} variant="outline" size="sm">
-                  Open lab
-                </Button>
-              </li>
-            </MotionReveal>
-          ))}
-        </ul>
+  return (
+    <section className="relative flex min-h-[calc(100vh-5rem)] items-center overflow-hidden">
+      <LabsStageAtmosphere />
+
+      <Container className="relative z-10 w-full py-16 md:py-20">
+        <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+          <motion.p
+            className="mb-6 font-body text-xs font-medium uppercase tracking-[0.14em] text-[var(--primary)] sm:mb-8"
+            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0 }
+                : { ...springEnter, delay: 0.1, duration: 0.6 }
+            }
+          >
+            {labs.brandEyebrow}
+          </motion.p>
+
+          <motion.div
+            className="relative mb-10 sm:mb-12"
+            initial={
+              prefersReducedMotion
+                ? { opacity: 1 }
+                : { opacity: 0, y: 100, rotateX: 15 }
+            }
+            animate={{ opacity: 1, y: 0, rotateX: 0 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0 }
+                : { ...springEnter, duration: 1.2 }
+            }
+          >
+            <div
+              aria-hidden
+              className="absolute -top-5 -left-5 h-14 w-14 -translate-x-1/4 bg-[var(--primary)] opacity-5 rotate-45 sm:-top-7 sm:-left-7 sm:h-20 sm:w-20"
+            />
+            <div
+              aria-hidden
+              className="absolute -right-2 -bottom-2 h-10 w-10 border-2 border-[var(--primary)] opacity-10 -rotate-12 sm:-right-3 sm:-bottom-3 sm:h-14 sm:w-14"
+            />
+
+            <Heading
+              size="hero"
+              className="relative hero-text pb-[0.12em]"
+            >
+              <span className="relative z-10">{labs.heading}</span>
+              <motion.span
+                aria-hidden
+                className="absolute -right-2 -bottom-1 h-6 w-6 bg-[var(--primary)] opacity-20 rotate-45 sm:-right-3 sm:h-8 sm:w-8"
+                initial={
+                  prefersReducedMotion
+                    ? { scale: 1, rotate: 45 }
+                    : { scale: 0, rotate: 0 }
+                }
+                animate={{ scale: 1, rotate: 45 }}
+                transition={
+                  prefersReducedMotion
+                    ? { duration: 0 }
+                    : { delay: 0.9, duration: 0.8, ease: 'easeOut' }
+                }
+              />
+            </Heading>
+          </motion.div>
+
+          <motion.div
+            className="relative mb-5 max-w-xl space-y-4 sm:mb-6"
+            initial={
+              prefersReducedMotion
+                ? { opacity: 1 }
+                : { opacity: 0, y: 40, scale: 0.96 }
+            }
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0 }
+                : { ...springEnter, delay: 0.55, duration: 0.9 }
+            }
+          >
+            <div
+              aria-hidden
+              className="absolute top-1/2 -left-5 hidden h-px w-10 -translate-y-1/2 -skew-y-12 bg-[var(--primary)] opacity-30 sm:-left-8 sm:block sm:w-14"
+            />
+            <Heading
+              size="md"
+              as="h2"
+              className="text-[var(--foreground)]"
+            >
+              {flagshipTitle}
+            </Heading>
+            <Text className="text-[var(--foreground)]">{labs.purposeLine}</Text>
+          </motion.div>
+
+          <motion.div
+            className="mb-10 sm:mb-12"
+            initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={
+              prefersReducedMotion
+                ? { duration: 0 }
+                : { ...springEnter, delay: 1.05, duration: 0.7 }
+            }
+          >
+            <Button href={flagshipHref} variant="primary" size="md">
+              {labs.ctaLabel}
+            </Button>
+          </motion.div>
+
+          <LabsSignalTeaser prefersReducedMotion={prefersReducedMotion} />
+        </div>
       </Container>
-    </Section>
+    </section>
   );
 }

--- a/src/data/pages/job-market-lab.json
+++ b/src/data/pages/job-market-lab.json
@@ -1,16 +1,66 @@
 {
-  "heading": "Job market signal lab",
-  "description": "High-level aggregates from a private financial-services job-description corpus. This is a portfolio demonstration, not live job-board coverage or career advice.",
-  "emptyState": "No published snapshot is available yet. Check back after the next corpus recompute.",
-  "corpusNote": "Figures shown here are aggregates only. Raw job descriptions and employer identity are never published.",
-  "metricsHeading": "Corpus freshness",
-  "documentCountLabel": "Active documents in latest snapshot",
-  "publishedAtLabel": "Last published",
-  "skillsHeading": "Technology frequencies",
+  "brandEyebrow": "Hasha Dar's",
+  "heading": "Job Signal Lab",
+  "purposeLine": "A personal lab I use to analyse job listings that may be relevant to me and draw insights from what those roles ask for.",
+  "description": "I built this lab end-to-end: private corpus intake, ontology matching, embedding clusters, and a published pulse of market signals. What you see here is the results surface, not a job board or career advice.",
+  "emptyState": "No published pulse yet. The lab is ready; the next corpus recompute will populate this view.",
+  "craft": {
+    "heading": "How this is produced",
+    "intro": "I built this pipeline end-to-end so the published pulse is reproducible craft, not hand-picked charts. Here is the path from a private listing to published aggregates, with plain language first and a short technical note under each stage.",
+    "inShortLabel": "In short",
+    "underTheHoodLabel": "Under the hood",
+    "stages": [
+      {
+        "id": "ingest",
+        "title": "Collect Job Listings from the Web",
+        "inShort": "I collect job listings into a private corpus I control, never a public scrape dump.",
+        "underTheHood": "Markdown with YAML frontmatter lands in private storage via upload or career-page parse-and-review; ingest refreshes corpus metadata without starting a full recompute."
+      },
+      {
+        "id": "structure",
+        "title": "Tag Each Role with Context",
+        "inShort": "I tag each role with seniority, role family, and optional employer context so later filters mean something.",
+        "underTheHood": "Controlled vocabularies and an employer registry live in the owner console. Archiving excludes a document from the next recompute without deleting the stored file."
+      },
+      {
+        "id": "match",
+        "title": "Match Technologies Across Listings",
+        "inShort": "Technology counts come from a curated FinServ/AI dictionary, not every buzzword in the text.",
+        "underTheHood": "Alias-aware ontology matching collapses variants (for example k8s to Kubernetes) and ignores terms outside the dictionary, so frequency bars stay signal rather than noise."
+      },
+      {
+        "id": "cluster",
+        "title": "Fingerprint Requirements into Themes",
+        "inShort": "Each listing gets a numeric fingerprint; similar fingerprints group into themes of related requirements.",
+        "underTheHood": "Bedrock embeddings of the markdown body, cached by content hash, feed k-means themes. Labels default to top matched technologies; I can override them from the console."
+      },
+      {
+        "id": "project",
+        "title": "Lay Out the Theme Map",
+        "inShort": "The theme map is a similarity layout where nearby dots share requirement language, not geography or employer.",
+        "underTheHood": "PCA reduces embeddings to two principal components in the analyse worker. Those coordinates ship with the snapshot so the public map does not invent positions in the browser."
+      },
+      {
+        "id": "publish",
+        "title": "Publish Counts, Themes, and the Map",
+        "inShort": "The page shows published counts, themes, and the map; sensitive listing details stay redacted.",
+        "underTheHood": "Publication sanitises owner-only fields before the public query. I trigger a recompute from the console when the corpus changes; only one run may be in flight at a time."
+      }
+    ]
+  },
+  "metricsHeading": "Pulse",
+  "documentCountLabel": "Documents",
+  "publishedAtLabel": "Published",
+  "topSignalsLabel": "Top signals",
+  "skillsHeading": "Technologies",
+  "skillsCaption": "Curated tools and platforms matched in the listings from a controlled ontology, ranked by how often they appear.",
   "taxonomyHeading": "Seniority and role family",
   "seniorityLabel": "Seniority",
   "roleFamilyLabel": "Role family",
   "clustersHeading": "Requirement themes",
+  "clustersSizeHeading": "Theme size",
+  "clustersMapHeading": "Theme map",
+  "clustersCaption": "Groups of listings with similar overall requirements. Bars show theme size; the map places documents by how alike their requirement language is.",
   "pulseFiltersTimeLabel": "Time window",
   "pulseFilterTimeOptions": {
     "all": "All published documents",
@@ -23,8 +73,10 @@
     "heading": "Corpus recompute",
     "description": "Start an analysis run against the active corpus. Only one run may be queued or in progress at a time.",
     "startButtonLabel": "Start recompute",
-    "startingLabel": "StartingÔÇª",
-    "startedMessage": "Recompute started. Run id: {runId}. Check analysis runs below for live status.",
+    "startingLabel": "Starting…",
+    "startedMessage": "Recompute started. Run id: {runId}.",
+    "startedMessageWithRunsHint": "Recompute started. Run id: {runId}. Open Runs for live status.",
+    "secondaryStartDescription": "Secondary control for power users. Prefer starting recomputes from Analytics.",
     "rejectedHeading": "Could not start recompute"
   },
   "corpusAdmin": {
@@ -81,7 +133,7 @@
     "employerUnknownWarning": "Employer id '{id}' is not in the registry.",
     "parseListing": {
       "heading": "Listing URL",
-      "description": "Employer career or ATS pages work best. Some sites block automated fetch — paste the page text instead.",
+      "description": "Employer career or ATS pages work best. Some sites block automated fetch, so paste the page text instead.",
       "urlLabel": "URL",
       "urlPlaceholder": "https://boards.greenhouse.io/…",
       "submitLabel": "Parse listing",
@@ -136,19 +188,19 @@
           "id": "fit",
           "href": "/labs/job-market/console/fit",
           "label": "CV and fit",
-          "description": "Canonical CV and comparisons against roles and the market."
+          "description": "Edit the canonical CV and compare against roles or market demand."
         },
         {
           "id": "analytics",
           "href": "/labs/job-market/console/analytics",
           "label": "Analytics",
-          "description": "Theme labels, pulse filters, and pay or prestige summaries."
+          "description": "Coverage insights, pay and prestige, and start a corpus recompute."
         },
         {
           "id": "runs",
           "href": "/labs/job-market/console/runs",
           "label": "Runs",
-          "description": "Start a recompute and review analysis run history."
+          "description": "Audit analysis run history, costs, and failures."
         }
       ]
     },
@@ -167,15 +219,46 @@
       "openAreaLabel": "Open {label}"
     },
     "runsHeading": "Analysis runs",
-    "runsDescription": "Recent recompute lifecycle status. Failed runs include the failure reason.",
+    "runsDescription": "Audit recent recompute lifecycle, document counts, estimated cost, and failures.",
     "runsEmpty": "No analysis runs yet.",
-    "runsLoading": "Loading analysis runsÔÇª",
+    "runsLoading": "Loading analysis runs…",
     "runsError": "Analysis run history is temporarily unavailable.",
+    "runsDocsConsideredLabel": "Documents considered",
+    "runsEstimatedCostLabel": "Estimated cost (USD)",
+    "runsReloadLabel": "Reload",
     "runStatusQueued": "Queued",
     "runStatusRunning": "Running",
     "runStatusSucceeded": "Succeeded",
     "runStatusFailed": "Failed",
     "failureReasonLabel": "Failure reason",
+    "analyticsWorkspace": {
+      "heading": "Analytics",
+      "description": "Coverage and pay insights for the active corpus. Start a recompute here; review run history on Runs.",
+      "summaryHeading": "Coverage summary",
+      "activeDocumentsLabel": "Active documents",
+      "payDisclosedLabel": "Pay disclosed",
+      "payUndisclosedLabel": "Pay not disclosed",
+      "employerLinkedLabel": "Employer linked",
+      "completeCompensationLabel": "Complete compensation",
+      "startRecomputeHeading": "Recompute",
+      "startRecomputeDescription": "Primary control to start an analysis run against the active corpus.",
+      "viewRunsLabel": "View run history",
+      "secondaryToolsHeading": "Publication tools",
+      "secondaryToolsDescription": "Theme label overrides and pulse filters apply on the next recompute and publication."
+    },
+    "fitWorkspace": {
+      "heading": "CV and fit",
+      "description": "Keep the canonical CV visible while comparing against a role or market demand.",
+      "loadingLabel": "Loading fit workspace…",
+      "errorLabel": "Fit workspace is temporarily unavailable.",
+      "saveCvFirstHint": "Save a canonical CV before running a comparison.",
+      "modeRoleLabel": "Versus role",
+      "modeMarketLabel": "Versus market",
+      "jdSearchLabel": "Search roles",
+      "jdSearchPlaceholder": "Filter by title…",
+      "cvColumnHeading": "Canonical CV",
+      "resultsHeading": "Fit results"
+    },
     "cv": {
       "heading": "Canonical CV",
       "description": "Private owner CV for later fit comparison against job descriptions and market signals. Never published to guests.",
@@ -207,7 +290,7 @@
       "talkingPointsHeading": "Suggested talking points",
       "learningTargetsHeading": "Learning targets",
       "matchesEmpty": "No shared ontology technologies found between your CV and this job description.",
-      "gapsEmpty": "No technology gaps — your CV covers every ontology term in this job description.",
+      "gapsEmpty": "No technology gaps: your CV covers every ontology term in this job description.",
       "talkingPointsEmpty": "No talking points generated.",
       "learningTargetsEmpty": "No learning targets generated.",
       "matchTalkingPointTemplate": "Prepare a concise example of your {technology} work.",
@@ -228,7 +311,7 @@
       "talkingPointsHeading": "Suggested talking points",
       "learningTargetsHeading": "Learning targets",
       "matchesEmpty": "No shared technologies or themes found between your CV and current market demand.",
-      "gapsEmpty": "No market gaps — your CV reflects every demand theme and technology in the published pulse.",
+      "gapsEmpty": "No market gaps: your CV reflects every demand theme and technology in the published pulse.",
       "talkingPointsEmpty": "No talking points generated.",
       "learningTargetsEmpty": "No learning targets generated.",
       "matchTalkingPointTemplate": "Your CV aligns with current market demand for {technology}.",
@@ -293,7 +376,7 @@
       "unsetOption": "Not set",
       "gapEmployer": "Employer",
       "gapPay": "Pay",
-      "gapNone": "—",
+      "gapNone": "-",
       "saveRowLabel": "Save",
       "savingRowLabel": "Saving…",
       "rowSavedMessage": "Row saved.",
@@ -317,9 +400,15 @@
       "employerLabel": "Employer",
       "employerUnsetWarning": "No employer linked. Add one in the registry and select it here.",
       "employerUnknownWarning": "Employer id '{id}' is not in the registry. Create it under Employers or clear the field.",
-      "frontmatterMergedNotice": "Missing frontmatter fields were filled from the database projection — save markdown or metadata to persist them in the file.",
+      "frontmatterMergedNotice": "Missing frontmatter fields were filled from the database projection. Save markdown or metadata to persist them in the file.",
       "seniorityLabel": "Seniority",
       "roleFamilyLabel": "Role family",
+      "compensationDisclosureLabel": "Pay disclosure",
+      "compensationDisclosureOptions": {
+        "range": "Numeric range",
+        "competitive": "Competitive / negotiable",
+        "unknown": "Not disclosed"
+      },
       "compensationCurrencyLabel": "Currency",
       "compensationMinLabel": "Minimum",
       "compensationMaxLabel": "Maximum",
@@ -387,6 +476,12 @@
     "noEmployerOption": "No employer linked",
     "seniorityLabel": "Seniority",
     "roleFamilyLabel": "Role family",
+    "compensationDisclosureLabel": "Pay disclosure",
+    "compensationDisclosureOptions": {
+      "range": "Numeric range",
+      "competitive": "Competitive / negotiable",
+      "unknown": "Not disclosed"
+    },
     "compensationCurrencyLabel": "Currency",
     "compensationMinLabel": "Minimum",
     "compensationMaxLabel": "Maximum",
@@ -402,26 +497,33 @@
   },
   "payPrestigeAnalytics": {
     "heading": "Compensation and prestige analytics",
-    "description": "Owner-only aggregates from structured metadata. Missing-data rates show how much of the active corpus still lacks employer links or compensation fields.",
+    "description": "Owner-only aggregates from structured metadata. Missing-data rates show how much of the active corpus still lacks employer links or disclosed pay.",
     "loadingLabel": "Loading analytics…",
     "errorLabel": "Pay and prestige analytics are temporarily unavailable.",
     "activeDocumentsLabel": "Active documents in analytics scope",
     "missingDataHeading": "Missing-data rates",
+    "disclosureHeading": "Pay disclosure breakdown",
     "prestigeHeading": "Prestige tier breakdown",
     "sizeHeading": "Size tier breakdown",
     "compensationHeading": "Compensation by currency",
-    "compensationEmpty": "No structured compensation recorded on active documents.",
+    "compensationEmpty": "No structured compensation ranges recorded on active documents.",
     "presentLabel": "Present",
     "missingLabel": "Missing",
     "medianMinLabel": "Median minimum",
     "medianMaxLabel": "Median maximum",
     "documentCountLabel": "Documents",
+    "disclosureLabels": {
+      "range": "Numeric range",
+      "competitive": "Competitive / negotiable",
+      "unknown": "Not disclosed"
+    },
     "missingFieldLabels": {
       "employerLink": "Employer linked",
       "compensationCurrency": "Currency",
       "compensationMin": "Minimum",
       "compensationMax": "Maximum",
       "compensationPeriod": "Period",
+      "compensationDisclosed": "Pay disclosed",
       "completeCompensation": "Complete compensation record"
     }
   }

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -1,10 +1,15 @@
 {
   "heading": "Labs",
-  "description": "Interactive technical demos that show how I approach AI, data science, machine learning, and AWS full-stack work.",
+  "description": "Personal technical labs for exploring AI, data science, and full-stack craft, starting with Job Signal Lab.",
+  "brandEyebrow": "Hasha Dar's",
+  "purposeLine": "Personal labs for technical craft, with Job Signal Lab as the place I analyse listings that may be relevant to me.",
+  "ctaLabel": "Open Job Signal Lab",
+  "flagshipTitle": "Job Signal Lab",
+  "teaserAriaLabel": "Decorative motif of signals coalescing into a cluster",
   "labs": [
     {
-      "title": "Job market signal lab",
-      "description": "Aggregate labour-market signals from a private job-description corpus.",
+      "title": "Job Signal Lab",
+      "description": "A personal lab for analysing job listings and drawing market-signal insights.",
       "href": "/labs/job-market"
     }
   ]

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -137,6 +137,11 @@ export interface LabIndexItem {
 export interface LabsPageData {
   heading: string;
   description: string;
+  brandEyebrow: string;
+  purposeLine: string;
+  ctaLabel: string;
+  flagshipTitle: string;
+  teaserAriaLabel: string;
   labs: LabIndexItem[];
 }
 
@@ -146,7 +151,39 @@ export interface JobMarketLabAdminCopy {
   startButtonLabel: string;
   startingLabel: string;
   startedMessage: string;
+  startedMessageWithRunsHint: string;
+  secondaryStartDescription: string;
   rejectedHeading: string;
+}
+
+export interface JobMarketLabAnalyticsWorkspaceCopy {
+  heading: string;
+  description: string;
+  summaryHeading: string;
+  activeDocumentsLabel: string;
+  payDisclosedLabel: string;
+  payUndisclosedLabel: string;
+  employerLinkedLabel: string;
+  completeCompensationLabel: string;
+  startRecomputeHeading: string;
+  startRecomputeDescription: string;
+  viewRunsLabel: string;
+  secondaryToolsHeading: string;
+  secondaryToolsDescription: string;
+}
+
+export interface JobMarketLabFitWorkspaceCopy {
+  heading: string;
+  description: string;
+  loadingLabel: string;
+  errorLabel: string;
+  saveCvFirstHint: string;
+  modeRoleLabel: string;
+  modeMarketLabel: string;
+  jdSearchLabel: string;
+  jdSearchPlaceholder: string;
+  cvColumnHeading: string;
+  resultsHeading: string;
 }
 
 export interface JobMarketLabCorpusAdminData {
@@ -310,6 +347,12 @@ export interface JobMarketLabEmployerAdminCopy {
   rejectedHeading: string;
 }
 
+export interface JobMarketLabCompensationDisclosureOptions {
+  range: string;
+  competitive: string;
+  unknown: string;
+}
+
 export interface JobMarketLabMetadataAdminCopy {
   heading: string;
   description: string;
@@ -317,6 +360,8 @@ export interface JobMarketLabMetadataAdminCopy {
   noEmployerOption: string;
   seniorityLabel: string;
   roleFamilyLabel: string;
+  compensationDisclosureLabel: string;
+  compensationDisclosureOptions: JobMarketLabCompensationDisclosureOptions;
   compensationCurrencyLabel: string;
   compensationMinLabel: string;
   compensationMaxLabel: string;
@@ -381,11 +426,16 @@ export interface JobMarketLabConsoleCopy {
   runsEmpty: string;
   runsLoading: string;
   runsError: string;
+  runsDocsConsideredLabel: string;
+  runsEstimatedCostLabel: string;
+  runsReloadLabel: string;
   runStatusQueued: string;
   runStatusRunning: string;
   runStatusSucceeded: string;
   runStatusFailed: string;
   failureReasonLabel: string;
+  analyticsWorkspace: JobMarketLabAnalyticsWorkspaceCopy;
+  fitWorkspace: JobMarketLabFitWorkspaceCopy;
   cv: JobMarketLabCvCopy;
   compare: JobMarketLabCompareCopy;
   marketCompare: JobMarketLabMarketCompareCopy;
@@ -471,6 +521,8 @@ export interface JobMarketLabCorpusWorkspaceCopy {
   frontmatterMergedNotice: string;
   seniorityLabel: string;
   roleFamilyLabel: string;
+  compensationDisclosureLabel: string;
+  compensationDisclosureOptions: JobMarketLabCompensationDisclosureOptions;
   compensationCurrencyLabel: string;
   compensationMinLabel: string;
   compensationMaxLabel: string;
@@ -521,6 +573,7 @@ export interface JobMarketLabPayPrestigeAnalyticsCopy {
   errorLabel: string;
   activeDocumentsLabel: string;
   missingDataHeading: string;
+  disclosureHeading: string;
   prestigeHeading: string;
   sizeHeading: string;
   compensationHeading: string;
@@ -530,29 +583,58 @@ export interface JobMarketLabPayPrestigeAnalyticsCopy {
   medianMinLabel: string;
   medianMaxLabel: string;
   documentCountLabel: string;
+  disclosureLabels: JobMarketLabCompensationDisclosureOptions;
   missingFieldLabels: {
     employerLink: string;
     compensationCurrency: string;
     compensationMin: string;
     compensationMax: string;
     compensationPeriod: string;
+    compensationDisclosed: string;
     completeCompensation: string;
   };
 }
 
-export interface JobMarketLabPageData {
+export interface JobMarketLabCraftStage {
+  id: string;
+  title: string;
+  inShort: string;
+  underTheHood: string;
+}
+
+export interface JobMarketLabCraftCopy {
   heading: string;
+  intro: string;
+  inShortLabel: string;
+  underTheHoodLabel: string;
+  /** Optional closing note under the craft stages; omit on the public page when unused. */
+  closing?: string;
+  stages: JobMarketLabCraftStage[];
+}
+
+export interface JobMarketLabPageData {
+  /** Possessive brand line shown above the heading (e.g. "Hasha Dar's"). */
+  brandEyebrow: string;
+  heading: string;
+  purposeLine: string;
   description: string;
   emptyState: string;
-  corpusNote: string;
+  /** Optional privacy note under the hero; omit when not shown on the public page. */
+  corpusNote?: string;
+  craft: JobMarketLabCraftCopy;
   metricsHeading: string;
   documentCountLabel: string;
   publishedAtLabel: string;
+  topSignalsLabel: string;
   skillsHeading: string;
+  skillsCaption: string;
   taxonomyHeading: string;
   seniorityLabel: string;
   roleFamilyLabel: string;
   clustersHeading: string;
+  clustersSizeHeading: string;
+  clustersMapHeading: string;
+  clustersCaption: string;
   pulseFiltersTimeLabel: string;
   pulseFilterTimeOptions: JobMarketPulseFilterTimeOptions;
   admin: JobMarketLabAdminCopy;

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -121,6 +121,11 @@ export function assertValidLabsPage(data: unknown): void {
   const page = requireRecord(data, 'labs');
   requireString(page, 'heading', 'labs');
   requireString(page, 'description', 'labs');
+  requireString(page, 'brandEyebrow', 'labs');
+  requireString(page, 'purposeLine', 'labs');
+  requireString(page, 'ctaLabel', 'labs');
+  requireString(page, 'flagshipTitle', 'labs');
+  requireString(page, 'teaserAriaLabel', 'labs');
   requireArray(page.labs, 'labs.labs').forEach((lab, index) => {
     const item = requireRecord(lab, `labs.labs[${index}]`);
     requireString(item, 'title', `labs.labs[${index}]`);
@@ -131,18 +136,46 @@ export function assertValidLabsPage(data: unknown): void {
 
 export function assertValidJobMarketLabPage(data: unknown): void {
   const page = requireRecord(data, 'jobMarketLab');
+  requireString(page, 'brandEyebrow', 'jobMarketLab');
   requireString(page, 'heading', 'jobMarketLab');
+  requireString(page, 'purposeLine', 'jobMarketLab');
   requireString(page, 'description', 'jobMarketLab');
   requireString(page, 'emptyState', 'jobMarketLab');
-  requireString(page, 'corpusNote', 'jobMarketLab');
+  if (page.corpusNote !== undefined) {
+    requireString(page, 'corpusNote', 'jobMarketLab');
+  }
+  const craft = requireRecord(page.craft, 'jobMarketLab.craft');
+  requireString(craft, 'heading', 'jobMarketLab.craft');
+  requireString(craft, 'intro', 'jobMarketLab.craft');
+  requireString(craft, 'inShortLabel', 'jobMarketLab.craft');
+  requireString(craft, 'underTheHoodLabel', 'jobMarketLab.craft');
+  if (craft.closing !== undefined) {
+    requireString(craft, 'closing', 'jobMarketLab.craft');
+  }
+  const craftStages = requireArray(craft.stages, 'jobMarketLab.craft.stages');
+  if (craftStages.length === 0) {
+    fail('jobMarketLab.craft.stages: expected at least one stage');
+  }
+  for (const [index, stageValue] of craftStages.entries()) {
+    const stage = requireRecord(stageValue, `jobMarketLab.craft.stages[${index}]`);
+    requireString(stage, 'id', `jobMarketLab.craft.stages[${index}]`);
+    requireString(stage, 'title', `jobMarketLab.craft.stages[${index}]`);
+    requireString(stage, 'inShort', `jobMarketLab.craft.stages[${index}]`);
+    requireString(stage, 'underTheHood', `jobMarketLab.craft.stages[${index}]`);
+  }
   requireString(page, 'metricsHeading', 'jobMarketLab');
   requireString(page, 'documentCountLabel', 'jobMarketLab');
   requireString(page, 'publishedAtLabel', 'jobMarketLab');
+  requireString(page, 'topSignalsLabel', 'jobMarketLab');
   requireString(page, 'skillsHeading', 'jobMarketLab');
+  requireString(page, 'skillsCaption', 'jobMarketLab');
   requireString(page, 'taxonomyHeading', 'jobMarketLab');
   requireString(page, 'seniorityLabel', 'jobMarketLab');
   requireString(page, 'roleFamilyLabel', 'jobMarketLab');
   requireString(page, 'clustersHeading', 'jobMarketLab');
+  requireString(page, 'clustersSizeHeading', 'jobMarketLab');
+  requireString(page, 'clustersMapHeading', 'jobMarketLab');
+  requireString(page, 'clustersCaption', 'jobMarketLab');
   requireString(page, 'pulseFiltersTimeLabel', 'jobMarketLab');
   const pulseFilterTimeOptions = requireRecord(
     page.pulseFilterTimeOptions,
@@ -159,6 +192,8 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(admin, 'startButtonLabel', 'jobMarketLab.admin');
   requireString(admin, 'startingLabel', 'jobMarketLab.admin');
   requireString(admin, 'startedMessage', 'jobMarketLab.admin');
+  requireString(admin, 'startedMessageWithRunsHint', 'jobMarketLab.admin');
+  requireString(admin, 'secondaryStartDescription', 'jobMarketLab.admin');
   requireString(admin, 'rejectedHeading', 'jobMarketLab.admin');
   const corpusAdmin = requireRecord(page.corpusAdmin, 'jobMarketLab.corpusAdmin');
   requireString(corpusAdmin, 'heading', 'jobMarketLab.corpusAdmin');
@@ -258,6 +293,30 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(metadataAdmin, 'noEmployerOption', 'jobMarketLab.metadataAdmin');
   requireString(metadataAdmin, 'seniorityLabel', 'jobMarketLab.metadataAdmin');
   requireString(metadataAdmin, 'roleFamilyLabel', 'jobMarketLab.metadataAdmin');
+  requireString(
+    metadataAdmin,
+    'compensationDisclosureLabel',
+    'jobMarketLab.metadataAdmin',
+  );
+  const metadataDisclosureOptions = requireRecord(
+    metadataAdmin.compensationDisclosureOptions,
+    'jobMarketLab.metadataAdmin.compensationDisclosureOptions',
+  );
+  requireString(
+    metadataDisclosureOptions,
+    'range',
+    'jobMarketLab.metadataAdmin.compensationDisclosureOptions',
+  );
+  requireString(
+    metadataDisclosureOptions,
+    'competitive',
+    'jobMarketLab.metadataAdmin.compensationDisclosureOptions',
+  );
+  requireString(
+    metadataDisclosureOptions,
+    'unknown',
+    'jobMarketLab.metadataAdmin.compensationDisclosureOptions',
+  );
   requireString(metadataAdmin, 'compensationCurrencyLabel', 'jobMarketLab.metadataAdmin');
   requireString(metadataAdmin, 'compensationMinLabel', 'jobMarketLab.metadataAdmin');
   requireString(metadataAdmin, 'compensationMaxLabel', 'jobMarketLab.metadataAdmin');
@@ -288,6 +347,11 @@ export function assertValidJobMarketLabPage(data: unknown): void {
     'missingDataHeading',
     'jobMarketLab.payPrestigeAnalytics',
   );
+  requireString(
+    payPrestigeAnalytics,
+    'disclosureHeading',
+    'jobMarketLab.payPrestigeAnalytics',
+  );
   requireString(payPrestigeAnalytics, 'prestigeHeading', 'jobMarketLab.payPrestigeAnalytics');
   requireString(payPrestigeAnalytics, 'sizeHeading', 'jobMarketLab.payPrestigeAnalytics');
   requireString(
@@ -304,6 +368,25 @@ export function assertValidJobMarketLabPage(data: unknown): void {
     payPrestigeAnalytics,
     'documentCountLabel',
     'jobMarketLab.payPrestigeAnalytics',
+  );
+  const disclosureLabels = requireRecord(
+    payPrestigeAnalytics.disclosureLabels,
+    'jobMarketLab.payPrestigeAnalytics.disclosureLabels',
+  );
+  requireString(
+    disclosureLabels,
+    'range',
+    'jobMarketLab.payPrestigeAnalytics.disclosureLabels',
+  );
+  requireString(
+    disclosureLabels,
+    'competitive',
+    'jobMarketLab.payPrestigeAnalytics.disclosureLabels',
+  );
+  requireString(
+    disclosureLabels,
+    'unknown',
+    'jobMarketLab.payPrestigeAnalytics.disclosureLabels',
   );
   const missingFieldLabels = requireRecord(
     payPrestigeAnalytics.missingFieldLabels,
@@ -332,6 +415,11 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(
     missingFieldLabels,
     'compensationPeriod',
+    'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
+  );
+  requireString(
+    missingFieldLabels,
+    'compensationDisclosed',
     'jobMarketLab.payPrestigeAnalytics.missingFieldLabels',
   );
   requireString(
@@ -380,11 +468,58 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   requireString(consoleCopy, 'runsEmpty', 'jobMarketLab.console');
   requireString(consoleCopy, 'runsLoading', 'jobMarketLab.console');
   requireString(consoleCopy, 'runsError', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsDocsConsideredLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsEstimatedCostLabel', 'jobMarketLab.console');
+  requireString(consoleCopy, 'runsReloadLabel', 'jobMarketLab.console');
   requireString(consoleCopy, 'runStatusQueued', 'jobMarketLab.console');
   requireString(consoleCopy, 'runStatusRunning', 'jobMarketLab.console');
   requireString(consoleCopy, 'runStatusSucceeded', 'jobMarketLab.console');
   requireString(consoleCopy, 'runStatusFailed', 'jobMarketLab.console');
   requireString(consoleCopy, 'failureReasonLabel', 'jobMarketLab.console');
+  const analyticsWorkspace = requireRecord(
+    consoleCopy.analyticsWorkspace,
+    'jobMarketLab.console.analyticsWorkspace',
+  );
+  for (const key of [
+    'heading',
+    'description',
+    'summaryHeading',
+    'activeDocumentsLabel',
+    'payDisclosedLabel',
+    'payUndisclosedLabel',
+    'employerLinkedLabel',
+    'completeCompensationLabel',
+    'startRecomputeHeading',
+    'startRecomputeDescription',
+    'viewRunsLabel',
+    'secondaryToolsHeading',
+    'secondaryToolsDescription',
+  ] as const) {
+    requireString(
+      analyticsWorkspace,
+      key,
+      'jobMarketLab.console.analyticsWorkspace',
+    );
+  }
+  const fitWorkspace = requireRecord(
+    consoleCopy.fitWorkspace,
+    'jobMarketLab.console.fitWorkspace',
+  );
+  for (const key of [
+    'heading',
+    'description',
+    'loadingLabel',
+    'errorLabel',
+    'saveCvFirstHint',
+    'modeRoleLabel',
+    'modeMarketLabel',
+    'jdSearchLabel',
+    'jdSearchPlaceholder',
+    'cvColumnHeading',
+    'resultsHeading',
+  ] as const) {
+    requireString(fitWorkspace, key, 'jobMarketLab.console.fitWorkspace');
+  }
   const cv = requireRecord(consoleCopy.cv, 'jobMarketLab.console.cv');
   requireString(cv, 'heading', 'jobMarketLab.console.cv');
   requireString(cv, 'description', 'jobMarketLab.console.cv');
@@ -547,6 +682,7 @@ export function assertValidJobMarketLabPage(data: unknown): void {
     'frontmatterMergedNotice',
     'seniorityLabel',
     'roleFamilyLabel',
+    'compensationDisclosureLabel',
     'compensationCurrencyLabel',
     'compensationMinLabel',
     'compensationMaxLabel',
@@ -592,6 +728,25 @@ export function assertValidJobMarketLabPage(data: unknown): void {
   for (const key of corpusWorkspaceKeys) {
     requireString(corpusWorkspace, key, 'jobMarketLab.console.corpusWorkspace');
   }
+  const corpusDisclosureOptions = requireRecord(
+    corpusWorkspace.compensationDisclosureOptions,
+    'jobMarketLab.console.corpusWorkspace.compensationDisclosureOptions',
+  );
+  requireString(
+    corpusDisclosureOptions,
+    'range',
+    'jobMarketLab.console.corpusWorkspace.compensationDisclosureOptions',
+  );
+  requireString(
+    corpusDisclosureOptions,
+    'competitive',
+    'jobMarketLab.console.corpusWorkspace.compensationDisclosureOptions',
+  );
+  requireString(
+    corpusDisclosureOptions,
+    'unknown',
+    'jobMarketLab.console.corpusWorkspace.compensationDisclosureOptions',
+  );
 }
 
 export function assertValidLoginPage(data: unknown): void {

--- a/src/lib/job-description-frontmatter.test.ts
+++ b/src/lib/job-description-frontmatter.test.ts
@@ -26,6 +26,7 @@ describe('job-description-frontmatter', () => {
         ...parsed.data,
         employerId: 'emp-1',
         seniority: 'mid',
+        compensationDisclosure: 'range',
         compensationCurrency: 'GBP',
         compensationMin: 50000,
         compensationMax: 60000,
@@ -35,17 +36,58 @@ describe('job-description-frontmatter', () => {
     );
 
     expect(body).toContain('employerId: emp-1');
+    expect(body).toContain('compensationDisclosure: range');
     expect(body).toContain('compensationCurrency: GBP');
     expect(body).toContain('Do analysis.');
+  });
+
+  it('infers range from legacy numerics and unknown when unset', () => {
+    const withBand = parseJobDescriptionFrontmatter(`---
+collectedAt: 2026-01-15T00:00:00.000Z
+title: Analyst
+compensationMin: 50000
+compensationMax: 60000
+---
+
+Body.
+`);
+    expect(withBand.status).toBe('ok');
+    if (withBand.status === 'ok') {
+      expect(withBand.data.compensationDisclosure).toBe('range');
+      expect(withBand.data.compensationMin).toBe(50000);
+    }
+
+    const withoutPay = parseJobDescriptionFrontmatter(sample);
+    expect(withoutPay.status).toBe('ok');
+    if (withoutPay.status === 'ok') {
+      expect(withoutPay.data.compensationDisclosure).toBe('unknown');
+    }
+  });
+
+  it('strips numeric pay fields when disclosure is not range', () => {
+    const result = applyMetadataPatchToMarkdown(sample, {
+      compensationDisclosure: 'competitive',
+      compensationCurrency: 'GBP',
+      compensationMin: 50000,
+      compensationMax: 60000,
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.body).toContain('compensationDisclosure: competitive');
+    expect(result.body).not.toContain('compensationCurrency:');
+    expect(result.body).not.toContain('compensationMin:');
   });
 
   it('merges model-only fields into markdown for SSOT repair', () => {
     const merged = mergeModelFieldsIntoMarkdown(sample, {
       employerId: 'emp-9',
+      compensationDisclosure: 'range',
       compensationCurrency: 'USD',
       compensationMin: 100000,
+      compensationMax: 120000,
     });
     expect(merged).toContain('employerId: emp-9');
+    expect(merged).toContain('compensationDisclosure: range');
     expect(merged).toContain('compensationCurrency: USD');
     expect(merged).toContain('title: Analyst');
   });

--- a/src/lib/job-description-frontmatter.ts
+++ b/src/lib/job-description-frontmatter.ts
@@ -1,8 +1,11 @@
 import matter from 'gray-matter';
 import {
+  COMPENSATION_DISCLOSURES,
   COMPENSATION_PERIODS,
   JOB_DESCRIPTION_ROLE_FAMILIES,
   JOB_DESCRIPTION_SENIORITIES,
+  resolveCompensationDisclosure,
+  type CompensationDisclosure,
   type CompensationPeriod,
   type JobDescriptionRoleFamily,
   type JobDescriptionSeniority,
@@ -20,6 +23,7 @@ export const JOB_DESCRIPTION_FRONTMATTER_KEYS = [
   'compensationMin',
   'compensationMax',
   'compensationPeriod',
+  'compensationDisclosure',
 ] as const;
 
 export type JobDescriptionFrontmatterKey =
@@ -36,6 +40,7 @@ export type JobDescriptionFrontmatter = {
   compensationMin?: number;
   compensationMax?: number;
   compensationPeriod?: CompensationPeriod;
+  compensationDisclosure?: CompensationDisclosure;
 };
 
 export type ParseFrontmatterResult =
@@ -119,6 +124,39 @@ function yamlScalar(value: string | number): string {
   return value;
 }
 
+function normaliseCompensationFrontmatter(input: {
+  compensationDisclosure?: CompensationDisclosure;
+  compensationCurrency?: string;
+  compensationMin?: number;
+  compensationMax?: number;
+  compensationPeriod?: CompensationPeriod;
+}): Pick<
+  JobDescriptionFrontmatter,
+  | 'compensationDisclosure'
+  | 'compensationCurrency'
+  | 'compensationMin'
+  | 'compensationMax'
+  | 'compensationPeriod'
+> {
+  const compensationDisclosure = resolveCompensationDisclosure({
+    compensationDisclosure: input.compensationDisclosure,
+    compensationMin: input.compensationMin,
+    compensationMax: input.compensationMax,
+  });
+
+  if (compensationDisclosure !== 'range') {
+    return { compensationDisclosure };
+  }
+
+  return {
+    compensationDisclosure,
+    compensationCurrency: input.compensationCurrency,
+    compensationMin: input.compensationMin,
+    compensationMax: input.compensationMax,
+    compensationPeriod: input.compensationPeriod,
+  };
+}
+
 /** Parse and normalise JD frontmatter. Invalid enum values are dropped. */
 export function parseJobDescriptionFrontmatter(body: string): ParseFrontmatterResult {
   if (!body.startsWith('---')) {
@@ -157,6 +195,29 @@ export function parseJobDescriptionFrontmatter(body: string): ParseFrontmatterRe
     };
   }
 
+  const compensation = normaliseCompensationFrontmatter({
+    compensationDisclosure: optionalEnum(
+      data.compensationDisclosure,
+      COMPENSATION_DISCLOSURES,
+    ),
+    compensationCurrency: optionalString(data.compensationCurrency),
+    compensationMin,
+    compensationMax,
+    compensationPeriod: optionalEnum(data.compensationPeriod, COMPENSATION_PERIODS),
+  });
+
+  if (
+    compensation.compensationDisclosure === 'range' &&
+    compensation.compensationMin !== undefined &&
+    compensation.compensationMax !== undefined &&
+    compensation.compensationMin > compensation.compensationMax
+  ) {
+    return {
+      status: 'rejected',
+      reason: 'compensationMin must be less than or equal to compensationMax',
+    };
+  }
+
   return {
     status: 'ok',
     content,
@@ -167,10 +228,7 @@ export function parseJobDescriptionFrontmatter(body: string): ParseFrontmatterRe
       roleFamily: optionalRoleFamily(data.roleFamily),
       source: optionalString(data.source),
       employerId: optionalString(data.employerId),
-      compensationCurrency: optionalString(data.compensationCurrency),
-      compensationMin,
-      compensationMax,
-      compensationPeriod: optionalEnum(data.compensationPeriod, COMPENSATION_PERIODS),
+      ...compensation,
     },
   };
 }
@@ -179,23 +237,27 @@ export function serializeJobDescriptionFrontmatter(
   data: JobDescriptionFrontmatter,
   content: string,
 ): string {
+  const compensation = normaliseCompensationFrontmatter(data);
   const lines = ['---', `collectedAt: ${data.collectedAt}`];
   if (data.title) lines.push(`title: ${yamlScalar(data.title)}`);
   if (data.seniority) lines.push(`seniority: ${data.seniority}`);
   if (data.roleFamily) lines.push(`roleFamily: ${data.roleFamily}`);
   if (data.source) lines.push(`source: ${yamlScalar(data.source)}`);
   if (data.employerId) lines.push(`employerId: ${yamlScalar(data.employerId)}`);
-  if (data.compensationCurrency) {
-    lines.push(`compensationCurrency: ${yamlScalar(data.compensationCurrency)}`);
+  lines.push(`compensationDisclosure: ${compensation.compensationDisclosure}`);
+  if (compensation.compensationCurrency) {
+    lines.push(
+      `compensationCurrency: ${yamlScalar(compensation.compensationCurrency)}`,
+    );
   }
-  if (data.compensationMin !== undefined) {
-    lines.push(`compensationMin: ${yamlScalar(data.compensationMin)}`);
+  if (compensation.compensationMin !== undefined) {
+    lines.push(`compensationMin: ${yamlScalar(compensation.compensationMin)}`);
   }
-  if (data.compensationMax !== undefined) {
-    lines.push(`compensationMax: ${yamlScalar(data.compensationMax)}`);
+  if (compensation.compensationMax !== undefined) {
+    lines.push(`compensationMax: ${yamlScalar(compensation.compensationMax)}`);
   }
-  if (data.compensationPeriod) {
-    lines.push(`compensationPeriod: ${data.compensationPeriod}`);
+  if (compensation.compensationPeriod) {
+    lines.push(`compensationPeriod: ${compensation.compensationPeriod}`);
   }
   lines.push('---', '', content.replace(/^\n+/, '').trimEnd(), '');
   return lines.join('\n');
@@ -212,6 +274,7 @@ export type FrontmatterMetadataPatch = {
   compensationMin?: number | null;
   compensationMax?: number | null;
   compensationPeriod?: CompensationPeriod | null;
+  compensationDisclosure?: CompensationDisclosure | null;
 };
 
 function applyPatch(
@@ -250,8 +313,14 @@ function applyPatch(
   if ('compensationPeriod' in patch) {
     next.compensationPeriod = patch.compensationPeriod ?? undefined;
   }
+  if ('compensationDisclosure' in patch) {
+    next.compensationDisclosure = patch.compensationDisclosure ?? undefined;
+  }
 
-  return next;
+  return {
+    ...next,
+    ...normaliseCompensationFrontmatter(next),
+  };
 }
 
 /** Merge metadata into markdown frontmatter (SSOT write). */
@@ -265,6 +334,7 @@ export function applyMetadataPatchToMarkdown(
   }
   const next = applyPatch(parsed.data, patch);
   if (
+    next.compensationDisclosure === 'range' &&
     next.compensationMin !== undefined &&
     next.compensationMax !== undefined &&
     next.compensationMin > next.compensationMax
@@ -301,6 +371,14 @@ export function mergeModelFieldsIntoMarkdown(
   if (!parsed.data.employerId && model.employerId) patch.employerId = model.employerId;
   if (!parsed.data.seniority && model.seniority) patch.seniority = model.seniority;
   if (!parsed.data.roleFamily && model.roleFamily) patch.roleFamily = model.roleFamily;
+  if (
+    (parsed.data.compensationDisclosure === undefined ||
+      parsed.data.compensationDisclosure === 'unknown') &&
+    model.compensationDisclosure &&
+    model.compensationDisclosure !== 'unknown'
+  ) {
+    patch.compensationDisclosure = model.compensationDisclosure;
+  }
   if (!parsed.data.compensationCurrency && model.compensationCurrency) {
     patch.compensationCurrency = model.compensationCurrency;
   }
@@ -312,6 +390,17 @@ export function mergeModelFieldsIntoMarkdown(
   }
   if (!parsed.data.compensationPeriod && model.compensationPeriod) {
     patch.compensationPeriod = model.compensationPeriod;
+  }
+
+  // Infer range when merging a complete numeric band without an explicit disclosure.
+  if (
+    patch.compensationMin != null &&
+    patch.compensationMax != null &&
+    !patch.compensationDisclosure &&
+    (parsed.data.compensationDisclosure === undefined ||
+      parsed.data.compensationDisclosure === 'unknown')
+  ) {
+    patch.compensationDisclosure = 'range';
   }
 
   if (Object.keys(patch).length === 0) {

--- a/src/lib/job-market-corpus-amplify.ts
+++ b/src/lib/job-market-corpus-amplify.ts
@@ -6,6 +6,7 @@ import type {
 } from './job-market-corpus';
 
 import type {
+  CompensationDisclosure,
   CompensationPeriod,
   JobDescriptionRoleFamily,
   JobDescriptionSeniority,
@@ -26,6 +27,7 @@ export type AmplifyJobDescriptionRow = {
   compensationMin?: number | null;
   compensationMax?: number | null;
   compensationPeriod?: CompensationPeriod | null;
+  compensationDisclosure?: CompensationDisclosure | null;
 };
 
 type AmplifyDataResult<T> = {
@@ -67,6 +69,7 @@ function toCorpusRecord(row: AmplifyJobDescriptionRow): JobDescriptionCorpusReco
     compensationMin: row.compensationMin ?? undefined,
     compensationMax: row.compensationMax ?? undefined,
     compensationPeriod: row.compensationPeriod ?? undefined,
+    compensationDisclosure: row.compensationDisclosure ?? undefined,
   };
 }
 
@@ -102,6 +105,7 @@ export function createAmplifyCorpusDeps(
         compensationMin: record.compensationMin ?? null,
         compensationMax: record.compensationMax ?? null,
         compensationPeriod: record.compensationPeriod ?? null,
+        compensationDisclosure: record.compensationDisclosure ?? null,
       });
       throwIfErrors(errors);
     },

--- a/src/lib/job-market-corpus-table.test.ts
+++ b/src/lib/job-market-corpus-table.test.ts
@@ -25,10 +25,18 @@ describe('filterCorpusRecords', () => {
       title: 'Analyst',
       status: 'archived',
       employerId: 'emp-1',
+      compensationDisclosure: 'range',
       compensationCurrency: 'GBP',
       compensationMin: 1,
       compensationMax: 2,
       compensationPeriod: 'year',
+    },
+    {
+      ...base,
+      id: 'raw/c.md',
+      s3Key: 'raw/c.md',
+      title: 'Consultant',
+      compensationDisclosure: 'competitive',
     },
   ];
 
@@ -40,7 +48,7 @@ describe('filterCorpusRecords', () => {
         missingEmployer: true,
         missingPay: false,
       }).map((record) => record.id),
-    ).toEqual(['raw/a.md']);
+    ).toEqual(['raw/a.md', 'raw/c.md']);
   });
 
   it('filters by search text', () => {
@@ -53,6 +61,17 @@ describe('filterCorpusRecords', () => {
       }).map((record) => record.id),
     ).toEqual(['raw/b.md']);
   });
+
+  it('treats competitive as disclosed for missing-pay filter', () => {
+    expect(
+      filterCorpusRecords(records, {
+        status: 'all',
+        search: '',
+        missingEmployer: false,
+        missingPay: true,
+      }).map((record) => record.id),
+    ).toEqual(['raw/a.md']);
+  });
 });
 
 describe('corpus table helpers', () => {
@@ -63,6 +82,13 @@ describe('corpus table helpers', () => {
     expect(
       compensationSummary({
         ...base,
+        compensationDisclosure: 'competitive',
+      }),
+    ).toBe('Competitive');
+    expect(
+      compensationSummary({
+        ...base,
+        compensationDisclosure: 'range',
         compensationCurrency: 'GBP',
         compensationMin: 80_000,
         compensationMax: 100_000,

--- a/src/lib/job-market-corpus-table.ts
+++ b/src/lib/job-market-corpus-table.ts
@@ -1,4 +1,5 @@
 import type { JobDescriptionCorpusRecord } from '@/lib/job-market-corpus';
+import { resolveCompensationDisclosure } from '@/lib/job-market-employers';
 
 export type CorpusStatusFilter = 'all' | 'active' | 'archived';
 
@@ -9,13 +10,9 @@ export type CorpusTableFilters = {
   missingPay: boolean;
 };
 
+/** True when pay is not disclosed (`unknown`, including legacy unset). */
 export function hasMissingPay(record: JobDescriptionCorpusRecord): boolean {
-  return (
-    record.compensationCurrency == null ||
-    record.compensationMin == null ||
-    record.compensationMax == null ||
-    record.compensationPeriod == null
-  );
+  return resolveCompensationDisclosure(record) === 'unknown';
 }
 
 export function displayTitle(record: JobDescriptionCorpusRecord): string {
@@ -28,12 +25,19 @@ export function displayTitle(record: JobDescriptionCorpusRecord): string {
 }
 
 export function compensationSummary(record: JobDescriptionCorpusRecord): string {
+  const disclosure = resolveCompensationDisclosure(record);
+  if (disclosure === 'competitive') {
+    return 'Competitive';
+  }
+  if (disclosure !== 'range') {
+    return '—';
+  }
   if (
     record.compensationCurrency == null ||
     record.compensationMin == null ||
     record.compensationMax == null
   ) {
-    return '—';
+    return 'Range (incomplete)';
   }
   const period = record.compensationPeriod ? ` / ${record.compensationPeriod}` : '';
   return `${record.compensationCurrency} ${record.compensationMin}–${record.compensationMax}${period}`;

--- a/src/lib/job-market-corpus.ts
+++ b/src/lib/job-market-corpus.ts
@@ -1,4 +1,5 @@
 import type {
+  CompensationDisclosure,
   CompensationPeriod,
   JobDescriptionRoleFamily,
   JobDescriptionSeniority,
@@ -21,6 +22,7 @@ export type JobDescriptionCorpusRecord = {
   compensationMin?: number;
   compensationMax?: number;
   compensationPeriod?: CompensationPeriod;
+  compensationDisclosure?: CompensationDisclosure;
 };
 
 export const DEFAULT_MAX_AGE_MONTHS = 18;

--- a/src/lib/job-market-employers.test.ts
+++ b/src/lib/job-market-employers.test.ts
@@ -206,11 +206,13 @@ describe('updateJobDescriptionStructuredFields', () => {
         compensationMin: 80000,
         compensationMax: 95000,
         compensationPeriod: 'year',
+        compensationDisclosure: 'range',
       }),
     });
     const body = deps.files.get('raw/jd-1.md') ?? '';
     expect(body).toContain('employerId: emp-1');
     expect(body).toContain('seniority: senior');
+    expect(body).toContain('compensationDisclosure: range');
     expect(body).toContain('compensationCurrency: GBP');
     expect(body).toContain('compensationMin: 80000');
   });
@@ -288,6 +290,7 @@ Role body.
       'jd-1',
       {
         employerId: null,
+        compensationDisclosure: 'unknown',
         compensationCurrency: null,
         compensationMin: null,
         compensationMax: null,
@@ -303,6 +306,7 @@ Role body.
         employerId: undefined,
         seniority: 'lead',
         roleFamily: 'engineering',
+        compensationDisclosure: 'unknown',
         compensationCurrency: undefined,
         compensationMin: undefined,
         compensationMax: undefined,
@@ -312,6 +316,7 @@ Role body.
     const body = deps.files.get('raw/jd-1.md') ?? '';
     expect(body).not.toContain('employerId:');
     expect(body).not.toContain('compensationCurrency:');
+    expect(body).toContain('compensationDisclosure: unknown');
     expect(body).toContain('seniority: lead');
   });
 });

--- a/src/lib/job-market-employers.ts
+++ b/src/lib/job-market-employers.ts
@@ -30,11 +30,58 @@ export const JOB_DESCRIPTION_ROLE_FAMILIES = [
 
 export const COMPENSATION_PERIODS = ['year', 'month', 'day', 'hour'] as const;
 
+export const COMPENSATION_DISCLOSURES = [
+  'range',
+  'competitive',
+  'unknown',
+] as const;
+
 export type EmployerSizeTier = (typeof EMPLOYER_SIZE_TIERS)[number];
 export type EmployerPrestigeTier = (typeof EMPLOYER_PRESTIGE_TIERS)[number];
 export type JobDescriptionSeniority = (typeof JOB_DESCRIPTION_SENIORITIES)[number];
 export type JobDescriptionRoleFamily = (typeof JOB_DESCRIPTION_ROLE_FAMILIES)[number];
 export type CompensationPeriod = (typeof COMPENSATION_PERIODS)[number];
+export type CompensationDisclosure = (typeof COMPENSATION_DISCLOSURES)[number];
+
+/** Readers: competitive wins; valid band numerics → range; else unknown. */
+export function resolveCompensationDisclosure(input: {
+  compensationDisclosure?: CompensationDisclosure | null;
+  compensationMin?: number | null;
+  compensationMax?: number | null;
+}): CompensationDisclosure {
+  if (input.compensationDisclosure === 'competitive') {
+    return 'competitive';
+  }
+  if (input.compensationMin != null && input.compensationMax != null) {
+    return 'range';
+  }
+  if (input.compensationDisclosure === 'range') {
+    return 'range';
+  }
+  return 'unknown';
+}
+
+/** Clear numeric pay fields unless disclosure is an explicit range. */
+export function clearCompensationRangeFieldsWhenNotRange<
+  T extends {
+    compensationDisclosure: CompensationDisclosure;
+    compensationCurrency?: string | null;
+    compensationMin?: number | null;
+    compensationMax?: number | null;
+    compensationPeriod?: CompensationPeriod | null;
+  },
+>(fields: T): T {
+  if (fields.compensationDisclosure === 'range') {
+    return fields;
+  }
+  return {
+    ...fields,
+    compensationCurrency: null,
+    compensationMin: null,
+    compensationMax: null,
+    compensationPeriod: null,
+  };
+}
 
 export type EmployerRecord = {
   id: string;
@@ -79,6 +126,7 @@ export type JobDescriptionStructuredFieldsPatch = {
   compensationMin?: number | null;
   compensationMax?: number | null;
   compensationPeriod?: CompensationPeriod | null;
+  compensationDisclosure?: CompensationDisclosure | null;
 };
 
 export type UpdateJobDescriptionStructuredFieldsDeps = {
@@ -118,6 +166,12 @@ function isCompensationPeriod(value: string): value is CompensationPeriod {
   return (COMPENSATION_PERIODS as readonly string[]).includes(value);
 }
 
+function isCompensationDisclosure(
+  value: string,
+): value is CompensationDisclosure {
+  return (COMPENSATION_DISCLOSURES as readonly string[]).includes(value);
+}
+
 function validateEmployerInput(
   input: CreateEmployerInput,
 ): { status: 'valid' } | { status: 'rejected'; reason: string } {
@@ -139,6 +193,26 @@ function validateEmployerInput(
 function validateCompensationPatch(
   patch: JobDescriptionStructuredFieldsPatch,
 ): { status: 'valid' } | { status: 'rejected'; reason: string } {
+  if (
+    patch.compensationDisclosure != null &&
+    patch.compensationDisclosure !== undefined &&
+    !isCompensationDisclosure(patch.compensationDisclosure)
+  ) {
+    return {
+      status: 'rejected',
+      reason: 'Unrecognised compensation disclosure',
+    };
+  }
+
+  const disclosure =
+    patch.compensationDisclosure === undefined
+      ? undefined
+      : (patch.compensationDisclosure ?? 'unknown');
+
+  if (disclosure != null && disclosure !== 'range') {
+    return { status: 'valid' };
+  }
+
   if (
     patch.compensationMin != null &&
     patch.compensationMax != null &&
@@ -195,6 +269,18 @@ function applyStructuredFieldsPatch(
   }
   if ('compensationPeriod' in patch) {
     next.compensationPeriod = patch.compensationPeriod ?? undefined;
+  }
+  if ('compensationDisclosure' in patch) {
+    next.compensationDisclosure = patch.compensationDisclosure ?? undefined;
+  }
+
+  const disclosure = resolveCompensationDisclosure(next);
+  next.compensationDisclosure = disclosure;
+  if (disclosure !== 'range') {
+    next.compensationCurrency = undefined;
+    next.compensationMin = undefined;
+    next.compensationMax = undefined;
+    next.compensationPeriod = undefined;
   }
 
   return next;
@@ -311,6 +397,11 @@ export async function updateJobDescriptionStructuredFields(
   if (merged.data.title !== undefined) record.title = merged.data.title;
   if (merged.data.source !== undefined) record.source = merged.data.source;
   record.collectedAt = merged.data.collectedAt;
+  record.compensationDisclosure = merged.data.compensationDisclosure;
+  record.compensationCurrency = merged.data.compensationCurrency;
+  record.compensationMin = merged.data.compensationMin;
+  record.compensationMax = merged.data.compensationMax;
+  record.compensationPeriod = merged.data.compensationPeriod;
   await deps.saveJobDescription(record);
   return { status: 'updated', record };
 }

--- a/src/lib/job-market-lab.ts
+++ b/src/lib/job-market-lab.ts
@@ -304,12 +304,15 @@ export {
   JOB_DESCRIPTION_SENIORITIES,
   JOB_DESCRIPTION_ROLE_FAMILIES,
   COMPENSATION_PERIODS,
+  COMPENSATION_DISCLOSURES,
+  resolveCompensationDisclosure,
   type EmployerRecord,
   type EmployerSizeTier,
   type EmployerPrestigeTier,
   type JobDescriptionSeniority,
   type JobDescriptionRoleFamily,
   type CompensationPeriod,
+  type CompensationDisclosure,
   type JobDescriptionStructuredFieldsPatch,
   type UpdateJobDescriptionStructuredFieldsDeps,
 } from './job-market-employers';
@@ -329,6 +332,7 @@ export {
   type MissingDataRate,
   type TierBucket,
   type CompensationCurrencySummary,
+  type CompensationDisclosureBreakdown,
 } from './job-market-pay-prestige-analytics';
 
 export {

--- a/src/lib/job-market-pay-prestige-analytics-amplify.test.ts
+++ b/src/lib/job-market-pay-prestige-analytics-amplify.test.ts
@@ -15,6 +15,7 @@ describe('createAmplifyPayPrestigeAnalyticsDeps', () => {
         compensationCurrency: 'GBP',
         compensationMin: 90000,
         compensationPeriod: 'year',
+        compensationDisclosure: 'range',
       },
     ];
     const employers: EmployerRecord[] = [

--- a/src/lib/job-market-pay-prestige-analytics.test.ts
+++ b/src/lib/job-market-pay-prestige-analytics.test.ts
@@ -79,11 +79,22 @@ describe('getOwnerPayPrestigeAnalytics', () => {
         missingRate: 1 / 3,
       },
       {
+        field: 'compensationDisclosed',
+        present: 2,
+        missing: 1,
+        missingRate: 1 / 3,
+      },
+      {
         field: 'completeCompensation',
         present: 2,
         missing: 1,
         missingRate: 1 / 3,
       },
+    ]);
+    expect(result.compensationDisclosureBreakdown).toEqual([
+      { disclosure: 'range', count: 2 },
+      { disclosure: 'competitive', count: 0 },
+      { disclosure: 'unknown', count: 1 },
     ]);
     expect(result.prestigeTierBreakdown).toEqual([
       { tier: 'low', count: 0 },
@@ -123,7 +134,13 @@ describe('getOwnerPayPrestigeAnalytics', () => {
       { field: 'compensationMin', present: 0, missing: 0, missingRate: 0 },
       { field: 'compensationMax', present: 0, missing: 0, missingRate: 0 },
       { field: 'compensationPeriod', present: 0, missing: 0, missingRate: 0 },
+      { field: 'compensationDisclosed', present: 0, missing: 0, missingRate: 0 },
       { field: 'completeCompensation', present: 0, missing: 0, missingRate: 0 },
+    ]);
+    expect(result.compensationDisclosureBreakdown).toEqual([
+      { disclosure: 'range', count: 0 },
+      { disclosure: 'competitive', count: 0 },
+      { disclosure: 'unknown', count: 0 },
     ]);
     expect(result.prestigeTierBreakdown).toEqual([
       { tier: 'low', count: 0 },
@@ -170,6 +187,34 @@ describe('getOwnerPayPrestigeAnalytics', () => {
       { tier: 'enterprise', count: 0 },
       { tier: 'big4', count: 1 },
       { tier: 'other', count: 0 },
+    ]);
+  });
+
+  it('treats competitive disclosure as present, not missing compensation', async () => {
+    const result = await getOwnerPayPrestigeAnalytics({
+      listJobDescriptions: async () => [
+        doc({ id: 'jd-1', compensationDisclosure: 'competitive' }),
+        doc({ id: 'jd-2' }),
+      ],
+      listEmployers: async () => [],
+    });
+
+    expect(result.missingDataRates).toContainEqual({
+      field: 'compensationDisclosed',
+      present: 1,
+      missing: 1,
+      missingRate: 0.5,
+    });
+    expect(result.missingDataRates).toContainEqual({
+      field: 'completeCompensation',
+      present: 1,
+      missing: 1,
+      missingRate: 0.5,
+    });
+    expect(result.compensationDisclosureBreakdown).toEqual([
+      { disclosure: 'range', count: 0 },
+      { disclosure: 'competitive', count: 1 },
+      { disclosure: 'unknown', count: 1 },
     ]);
   });
 });

--- a/src/lib/job-market-pay-prestige-analytics.ts
+++ b/src/lib/job-market-pay-prestige-analytics.ts
@@ -1,7 +1,10 @@
 import { selectActiveCorpus, type JobDescriptionCorpusRecord } from './job-market-corpus';
 import {
+  COMPENSATION_DISCLOSURES,
   EMPLOYER_PRESTIGE_TIERS,
   EMPLOYER_SIZE_TIERS,
+  resolveCompensationDisclosure,
+  type CompensationDisclosure,
   type EmployerRecord,
 } from './job-market-employers';
 
@@ -12,6 +15,7 @@ export type MissingDataRate = {
     | 'compensationMin'
     | 'compensationMax'
     | 'compensationPeriod'
+    | 'compensationDisclosed'
     | 'completeCompensation';
   present: number;
   missing: number;
@@ -30,12 +34,18 @@ export type CompensationCurrencySummary = {
   medianMax?: number;
 };
 
+export type CompensationDisclosureBreakdown = {
+  disclosure: CompensationDisclosure;
+  count: number;
+};
+
 export type OwnerPayPrestigeAnalytics = {
   activeDocumentCount: number;
   missingDataRates: MissingDataRate[];
   prestigeTierBreakdown: TierBucket[];
   sizeTierBreakdown: TierBucket[];
   compensationByCurrency: CompensationCurrencySummary[];
+  compensationDisclosureBreakdown: CompensationDisclosureBreakdown[];
 };
 
 export type GetOwnerPayPrestigeAnalyticsDeps = {
@@ -49,6 +59,7 @@ const MISSING_DATA_FIELDS = [
   'compensationMin',
   'compensationMax',
   'compensationPeriod',
+  'compensationDisclosed',
   'completeCompensation',
 ] as const satisfies ReadonlyArray<MissingDataRate['field']>;
 
@@ -87,7 +98,19 @@ function hasCompensationPeriod(record: JobDescriptionCorpusRecord): boolean {
   return record.compensationPeriod != null;
 }
 
+function hasCompensationDisclosed(record: JobDescriptionCorpusRecord): boolean {
+  // Competitive counts as disclosed; unknown (including legacy unset) does not.
+  return resolveCompensationDisclosure(record) !== 'unknown';
+}
+
 function hasCompleteCompensation(record: JobDescriptionCorpusRecord): boolean {
+  const disclosure = resolveCompensationDisclosure(record);
+  if (disclosure === 'competitive') {
+    return true;
+  }
+  if (disclosure !== 'range') {
+    return false;
+  }
   return (
     hasCompensationCurrency(record) &&
     hasCompensationPeriod(record) &&
@@ -110,6 +133,8 @@ function fieldPresent(
       return hasCompensationMax(record);
     case 'compensationPeriod':
       return hasCompensationPeriod(record);
+    case 'compensationDisclosed':
+      return hasCompensationDisclosed(record);
     case 'completeCompensation':
       return hasCompleteCompensation(record);
   }
@@ -149,6 +174,9 @@ function buildCompensationByCurrency(
   const byCurrency = new Map<string, { mins: number[]; maxes: number[] }>();
 
   for (const record of records) {
+    if (resolveCompensationDisclosure(record) !== 'range') {
+      continue;
+    }
     if (!hasCompensationCurrency(record)) {
       continue;
     }
@@ -178,6 +206,23 @@ function buildCompensationByCurrency(
       medianMin: median(values.mins),
       medianMax: median(values.maxes),
     }));
+}
+
+function buildCompensationDisclosureBreakdown(
+  records: JobDescriptionCorpusRecord[],
+): CompensationDisclosureBreakdown[] {
+  const counts = new Map<CompensationDisclosure, number>();
+  for (const disclosure of COMPENSATION_DISCLOSURES) {
+    counts.set(disclosure, 0);
+  }
+  for (const record of records) {
+    const disclosure = resolveCompensationDisclosure(record);
+    counts.set(disclosure, (counts.get(disclosure) ?? 0) + 1);
+  }
+  return COMPENSATION_DISCLOSURES.map((disclosure) => ({
+    disclosure,
+    count: counts.get(disclosure) ?? 0,
+  }));
 }
 
 export async function getOwnerPayPrestigeAnalytics(
@@ -219,5 +264,7 @@ export async function getOwnerPayPrestigeAnalytics(
     prestigeTierBreakdown: buildTierBreakdown(EMPLOYER_PRESTIGE_TIERS, prestigeCounts),
     sizeTierBreakdown: buildTierBreakdown(EMPLOYER_SIZE_TIERS, sizeCounts),
     compensationByCurrency: buildCompensationByCurrency(activeRecords),
+    compensationDisclosureBreakdown:
+      buildCompensationDisclosureBreakdown(activeRecords),
   };
 }


### PR DESCRIPTION
## Summary
- Add compensation disclosure (range/competitive/unknown) through parse, ingest, frontmatter, and console metadata/analytics.
- Expand owner console with analytics and fit workspaces, embedding projection, and richer runs/compare flows.
- Redesign the public Job Signal Lab and labs index (craft stage, brand-led copy) and document the lab surface.

## Test plan
- [ ] Verify salary disclosure fields appear on JD detail and metadata admin; ingest/parse a listing with competitive/unknown pay.
- [ ] Smoke-test console Analytics, Fit, Runs, and Corpus pages as owner.
- [ ] Confirm public `/labs` and `/labs/job-market` render the redesigned Job Signal Lab (craft section, labs index stage).
- [ ] Run unit tests for frontmatter, pay-prestige analytics, fit workspace, labs index, and analyse embedding projection.
- [ ] Confirm guests still cannot see owner-only fields/actions.


Made with [Cursor](https://cursor.com)