### PR TITLE
Tolerate GraphQL partial success on corpus JobDescription reads

### DIFF
--- a/src/lib/job-market-corpus-amplify.test.ts
+++ b/src/lib/job-market-corpus-amplify.test.ts
@@ -90,4 +90,66 @@ describe('createAmplifyCorpusDeps', () => {
       } satisfies Partial<JobDescriptionCorpusRecord>),
     );
   });
+
+  it('returns records on GraphQL partial success (data with non-fatal field errors)', async () => {
+    // Mirrors prod: stored seniority/roleFamily outside the enum are nulled by
+    // AppSync and reported as per-field errors alongside valid data.
+    const client: AmplifyJobDescriptionModelClient = {
+      async get() {
+        return {
+          data: row({ id: 'jd-1', seniority: null, roleFamily: null }),
+          errors: [
+            {
+              message:
+                "Can't serialize value (/getJobDescription/seniority) : Invalid input for Enum 'JobDescriptionSeniority'.",
+            },
+          ],
+        };
+      },
+      async list() {
+        return {
+          data: [row({ id: 'jd-1', seniority: null, roleFamily: null })],
+          errors: [
+            {
+              message:
+                "Can't serialize value (/listJobDescriptions/items[0]/seniority) : Invalid input for Enum 'JobDescriptionSeniority'.",
+            },
+            {
+              message:
+                "Can't serialize value (/listJobDescriptions/items[0]/roleFamily) : Invalid input for Enum 'JobDescriptionRoleFamily'.",
+            },
+          ],
+        };
+      },
+      async update(input) {
+        return { data: row({ id: input.id }) };
+      },
+    };
+    const deps = createAmplifyCorpusDeps(client);
+
+    await expect(deps.listJobDescriptions()).resolves.toEqual([
+      expect.objectContaining({ id: 'jd-1', seniority: undefined, roleFamily: undefined }),
+    ]);
+    await expect(deps.getJobDescription('jd-1')).resolves.toEqual(
+      expect.objectContaining({ id: 'jd-1' }),
+    );
+  });
+
+  it('throws when the read returns no data alongside errors', async () => {
+    const client: AmplifyJobDescriptionModelClient = {
+      async get() {
+        return { data: null, errors: [{ message: 'Not Authorized to access getJobDescription' }] };
+      },
+      async list() {
+        return { data: null, errors: [{ message: 'Not Authorized to access listJobDescriptions' }] };
+      },
+      async update(input) {
+        return { data: row({ id: input.id }) };
+      },
+    };
+    const deps = createAmplifyCorpusDeps(client);
+
+    await expect(deps.listJobDescriptions()).rejects.toThrow(/Not Authorized/);
+    await expect(deps.getJobDescription('jd-1')).rejects.toThrow(/Not Authorized/);
+  });
 });

--- a/src/lib/job-market-corpus-amplify.ts
+++ b/src/lib/job-market-corpus-amplify.ts
@@ -53,6 +53,19 @@ function throwIfErrors(errors: Array<{ message: string }> | null | undefined): v
   }
 }
 
+// Reads tolerate GraphQL partial success: AppSync returns rows with unresolved
+// enum fields nulled plus non-fatal field errors. Surface data when present and
+// only throw when the operation returned none.
+function warnFieldErrors(errors: Array<{ message: string }> | null | undefined): void {
+  if (errors?.length) {
+    console.warn(
+      `JobDescription read returned field errors: ${errors
+        .map((error) => error.message)
+        .join('; ')}`,
+    );
+  }
+}
+
 function toCorpusRecord(row: AmplifyJobDescriptionRow): JobDescriptionCorpusRecord {
   return {
     id: row.id,
@@ -79,13 +92,21 @@ export function createAmplifyCorpusDeps(
   return {
     async getJobDescription(id) {
       const { data, errors } = await client.get({ id });
-      throwIfErrors(errors);
-      return data ? toCorpusRecord(data) : null;
+      if (data == null) {
+        throwIfErrors(errors);
+        return null;
+      }
+      warnFieldErrors(errors);
+      return toCorpusRecord(data);
     },
     async listJobDescriptions() {
       const { data, errors } = await client.list();
-      throwIfErrors(errors);
-      return (data ?? []).map(toCorpusRecord);
+      if (data == null) {
+        throwIfErrors(errors);
+        return [];
+      }
+      warnFieldErrors(errors);
+      return data.map(toCorpusRecord);
     },
     async saveJobDescription(record) {
       // Model update only — never remove the S3 object for soft-archive/restore.


### PR DESCRIPTION
﻿## Summary
- Stop treating AppSync field-level enum serialisation errors as fatal when JobDescription list/get still returns usable data.
- Fixes the production corpus console blanking with "Corpus is temporarily unavailable" after seniority/roleFamily became strict enums while legacy rows retained invalid values.
- Adds regression coverage for partial-success reads and for genuine no-data error responses.

## Test plan
- [ ] `npx vitest run src/lib/job-market-corpus-amplify.test.ts`
- [ ] Deploy to Amplify / merge and open `/labs/job-market/console/corpus` while signed in
- [ ] Confirm job descriptions list instead of the unavailable error
- [ ] Confirm browser console may warn about enum field errors for legacy rows, without failing the page
