### PR TITLE
Fix Job OS Pass/Pursue/Body save stuck busy (#108)

### DIFF
--- a/src/components/sections/labs/job-os/job-os-employers-workspace.tsx
+++ b/src/components/sections/labs/job-os/job-os-employers-workspace.tsx
@@ -237,40 +237,46 @@ export function JobOsEmployersWorkspace({
     }
     setBusy(true);
     setError(null);
-    const result = await client.updateEmployer({
-      id: selected.id,
-      name,
-      sizeTier,
-      prestigeTier,
-      summary,
-      websiteUrl,
-      linkedinUrl,
-      notes,
-    });
-    if (result.status === 'rejected' || result.status === 'not_found') {
-      setBusy(false);
-      setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
-      return;
-    }
-
-    if (body.trim()) {
-      const bodyResult = await client.updateEmployerBody(selected.id, body);
-      if (bodyResult.status === 'rejected' || bodyResult.status === 'not_found') {
-        setBusy(false);
-        setError(
-          bodyResult.status === 'rejected' ? bodyResult.reason : copy.errorLabel,
-        );
+    try {
+      const result = await client.updateEmployer({
+        id: selected.id,
+        name,
+        sizeTier,
+        prestigeTier,
+        summary,
+        websiteUrl,
+        linkedinUrl,
+        notes,
+      });
+      if (result.status === 'rejected' || result.status === 'not_found') {
+        setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
         return;
       }
-      setSelected(bodyResult.employer);
-      setMessage(copy.bodySavedLabel);
-    } else {
-      setSelected(result.employer);
-      setMessage(copy.savedLabel);
-    }
 
-    await refresh(client);
-    setBusy(false);
+      if (body.trim()) {
+        const bodyResult = await client.updateEmployerBody(selected.id, body);
+        if (
+          bodyResult.status === 'rejected' ||
+          bodyResult.status === 'not_found'
+        ) {
+          setError(
+            bodyResult.status === 'rejected'
+              ? bodyResult.reason
+              : copy.errorLabel,
+          );
+          return;
+        }
+        setSelected(bodyResult.employer);
+        setMessage(copy.bodySavedLabel);
+      } else {
+        setSelected(result.employer);
+        setMessage(copy.savedLabel);
+      }
+
+      await refresh(client);
+    } finally {
+      setBusy(false);
+    }
   }
 
   function openCountFor(employerId: string): number {

--- a/src/components/sections/labs/job-os/job-os-opportunities-workspace.tsx
+++ b/src/components/sections/labs/job-os/job-os-opportunities-workspace.tsx
@@ -351,33 +351,39 @@ export function JobOsOpportunitiesWorkspace({
     }
     setBusy(true);
     setError(null);
-    const result = await client.updateOpportunity({
-      id: selected.id,
-      ...buildInput(),
-    });
-    if (result.status === 'rejected' || result.status === 'not_found') {
-      setBusy(false);
-      setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
-      return;
-    }
-
-    if (body.trim()) {
-      const bodyResult = await client.updateOpportunityBody(selected.id, body);
-      if (bodyResult.status === 'rejected' || bodyResult.status === 'not_found') {
-        setBusy(false);
-        setError(
-          bodyResult.status === 'rejected' ? bodyResult.reason : copy.errorLabel,
-        );
+    try {
+      const result = await client.updateOpportunity({
+        id: selected.id,
+        ...buildInput(),
+      });
+      if (result.status === 'rejected' || result.status === 'not_found') {
+        setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
         return;
       }
-      setSelected(bodyResult.opportunity);
-    } else {
-      setSelected(result.opportunity);
-    }
 
-    await refresh(client);
-    setMessage(copy.savedLabel);
-    setBusy(false);
+      if (body.trim()) {
+        const bodyResult = await client.updateOpportunityBody(selected.id, body);
+        if (
+          bodyResult.status === 'rejected' ||
+          bodyResult.status === 'not_found'
+        ) {
+          setError(
+            bodyResult.status === 'rejected'
+              ? bodyResult.reason
+              : copy.errorLabel,
+          );
+          return;
+        }
+        setSelected(bodyResult.opportunity);
+      } else {
+        setSelected(result.opportunity);
+      }
+
+      await refresh(client);
+      setMessage(copy.savedLabel);
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function handlePass(opportunityId: string) {
@@ -386,18 +392,21 @@ export function JobOsOpportunitiesWorkspace({
     }
     setBusyId(opportunityId);
     setError(null);
-    const result = await client.passOpportunity(opportunityId);
-    setBusyId(null);
-    if (result.status !== 'passed') {
-      setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
-      return;
+    try {
+      const result = await client.passOpportunity(opportunityId);
+      if (result.status !== 'passed') {
+        setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
+        return;
+      }
+      if (selected?.id === opportunityId) {
+        setSelected(result.opportunity);
+        setEvents(await client.listDecisionEvents(opportunityId));
+      }
+      await refresh(client);
+      setMessage(copy.passedLabel);
+    } finally {
+      setBusyId(null);
     }
-    if (selected?.id === opportunityId) {
-      setSelected(result.opportunity);
-      setEvents(await client.listDecisionEvents(opportunityId));
-    }
-    await refresh(client);
-    setMessage(copy.passedLabel);
   }
 
   async function handlePursue(opportunityId: string) {
@@ -406,18 +415,21 @@ export function JobOsOpportunitiesWorkspace({
     }
     setBusyId(opportunityId);
     setError(null);
-    const result = await client.pursueOpportunity(opportunityId);
-    setBusyId(null);
-    if (result.status !== 'pursued') {
-      setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
-      return;
+    try {
+      const result = await client.pursueOpportunity(opportunityId);
+      if (result.status !== 'pursued') {
+        setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
+        return;
+      }
+      if (selected?.id === opportunityId) {
+        setHasApplication(true);
+        setEvents(await client.listDecisionEvents(opportunityId));
+      }
+      await refresh(client);
+      setMessage(copy.pursuedLabel);
+    } finally {
+      setBusyId(null);
     }
-    if (selected?.id === opportunityId) {
-      setHasApplication(true);
-      setEvents(await client.listDecisionEvents(opportunityId));
-    }
-    await refresh(client);
-    setMessage(copy.pursuedLabel);
   }
 
   function employerName(id: string): string {

--- a/src/lib/job-os.test.ts
+++ b/src/lib/job-os.test.ts
@@ -112,6 +112,44 @@ describe('Job OS facade — Employers', () => {
       reason: 'Anon Employer is reserved; use ensureAnonEmployer',
     });
   });
+
+  it('rejects Employer Body update when body storage fails', async () => {
+    const store = createMemoryJobOsStore();
+    const bodies = createMemoryJobOsBodyStorage();
+    const jobOs = createJobOs({
+      store,
+      bodies: {
+        ...bodies,
+        putBody: async () => {
+          throw new Error('storage unavailable');
+        },
+      },
+      now: () => '2026-07-27T12:00:00.000Z',
+      createId: (() => {
+        let n = 0;
+        return () => `id-${++n}`;
+      })(),
+    });
+    const created = await jobOs.createEmployer({
+      name: 'Acme Analytics',
+      sizeTier: 'scaleup',
+      prestigeTier: 'mid',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const result = await jobOs.updateEmployerBody(
+      created.employer.id,
+      'Standing notes about the hiring team.',
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Could not save Employer Body',
+    });
+  });
 });
 
 describe('Job OS facade — Opportunities', () => {
@@ -184,6 +222,45 @@ describe('Job OS facade — Opportunities', () => {
     }
     expect(reopened.opportunity.status).toBe('open');
   });
+
+  it('rejects Opportunity Body update when body storage fails', async () => {
+    const store = createMemoryJobOsStore();
+    const bodies = createMemoryJobOsBodyStorage();
+    const jobOs = createJobOs({
+      store,
+      bodies: {
+        ...bodies,
+        putBody: async () => {
+          throw new Error('storage unavailable');
+        },
+      },
+      now: () => '2026-07-27T12:00:00.000Z',
+      createId: (() => {
+        let n = 0;
+        return () => `id-${++n}`;
+      })(),
+    });
+    const anon = await jobOs.ensureAnonEmployer();
+    const created = await jobOs.createOpportunity({
+      employerId: anon.id,
+      noticedAt: '2026-07-20T09:00:00.000Z',
+      title: 'Staff Data Scientist',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const result = await jobOs.updateOpportunityBody(
+      created.opportunity.id,
+      'Pasted listing prose.',
+    );
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Could not save Opportunity Body',
+    });
+  });
 });
 
 describe('Job OS facade — Pass and Decision Events', () => {
@@ -217,6 +294,42 @@ describe('Job OS facade — Pass and Decision Events', () => {
     expect(timeline).toHaveLength(1);
     expect(timeline[0]?.kind).toBe('opportunity_passed');
   });
+
+  it('rejects Pass when Decision Event persistence fails', async () => {
+    const store = createMemoryJobOsStore();
+    const bodies = createMemoryJobOsBodyStorage();
+    const jobOs = createJobOs({
+      store: {
+        ...store,
+        appendDecisionEvent: async () => {
+          throw new Error('AppSync unavailable');
+        },
+      },
+      bodies,
+      now: () => '2026-07-27T15:30:00.000Z',
+      createId: (() => {
+        let n = 0;
+        return () => `id-${++n}`;
+      })(),
+    });
+    const anon = await jobOs.ensureAnonEmployer();
+    const created = await jobOs.createOpportunity({
+      employerId: anon.id,
+      noticedAt: '2026-07-22T08:00:00.000Z',
+      title: 'Platform Engineer',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const result = await jobOs.passOpportunity(created.opportunity.id);
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Could not record Pass decision',
+    });
+  });
 });
 
 describe('Job OS facade — Applications', () => {
@@ -241,6 +354,42 @@ describe('Job OS facade — Applications', () => {
     expect(pursued.application.status).toBe('researching');
     expect(pursued.event.kind).toBe('application_started');
     expect(pursued.event.toStatus).toBe('researching');
+  });
+
+  it('rejects Pursue when Application persistence fails', async () => {
+    const store = createMemoryJobOsStore();
+    const bodies = createMemoryJobOsBodyStorage();
+    const jobOs = createJobOs({
+      store: {
+        ...store,
+        insertApplication: async () => {
+          throw new Error('AppSync unavailable');
+        },
+      },
+      bodies,
+      now: () => '2026-07-27T12:00:00.000Z',
+      createId: (() => {
+        let n = 0;
+        return () => `id-${++n}`;
+      })(),
+    });
+    const anon = await jobOs.ensureAnonEmployer();
+    const created = await jobOs.createOpportunity({
+      employerId: anon.id,
+      noticedAt: '2026-07-23T11:00:00.000Z',
+      title: 'Research Scientist',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const result = await jobOs.pursueOpportunity(created.opportunity.id);
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'Could not start Application',
+    });
   });
 
   it('rejects a second Application on the same Opportunity', async () => {

--- a/src/lib/job-os.ts
+++ b/src/lib/job-os.ts
@@ -403,6 +403,17 @@ export function createJobOs(deps: JobOsDeps) {
         ? crypto.randomUUID()
         : `id-${Date.now()}-${Math.random().toString(16).slice(2)}`);
 
+  async function withAdapterRejection<T>(
+    reason: string,
+    operation: () => Promise<T>,
+  ): Promise<T | Rejected> {
+    try {
+      return await operation();
+    } catch {
+      return { status: 'rejected', reason };
+    }
+  }
+
   async function ensureAnonEmployer(): Promise<EmployerRecord> {
     const existing = (await deps.store.listEmployers()).find(
       (employer) => employer.isAnon,
@@ -538,14 +549,16 @@ export function createJobOs(deps: JobOsDeps) {
       return { status: 'rejected', reason: 'Body prose cannot be blank' };
     }
 
-    const { s3Key } = await deps.bodies.putBody({
-      entityKind: 'employer',
-      entityId: id,
-      prose: trimmed,
+    return withAdapterRejection('Could not save Employer Body', async () => {
+      const { s3Key } = await deps.bodies.putBody({
+        entityKind: 'employer',
+        entityId: id,
+        prose: trimmed,
+      });
+      const employer: EmployerRecord = { ...existing, s3Key };
+      await deps.store.persistEmployer(employer);
+      return { status: 'updated' as const, employer, body: trimmed };
     });
-    const employer: EmployerRecord = { ...existing, s3Key };
-    await deps.store.persistEmployer(employer);
-    return { status: 'updated', employer, body: trimmed };
   }
 
   async function getEmployerBody(
@@ -658,14 +671,16 @@ export function createJobOs(deps: JobOsDeps) {
       return { status: 'rejected', reason: 'Body prose cannot be blank' };
     }
 
-    const { s3Key } = await deps.bodies.putBody({
-      entityKind: 'opportunity',
-      entityId: id,
-      prose: trimmed,
+    return withAdapterRejection('Could not save Opportunity Body', async () => {
+      const { s3Key } = await deps.bodies.putBody({
+        entityKind: 'opportunity',
+        entityId: id,
+        prose: trimmed,
+      });
+      const opportunity: OpportunityRecord = { ...existing, s3Key };
+      await deps.store.persistOpportunity(opportunity);
+      return { status: 'updated' as const, opportunity, body: trimmed };
     });
-    const opportunity: OpportunityRecord = { ...existing, s3Key };
-    await deps.store.persistOpportunity(opportunity);
-    return { status: 'updated', opportunity, body: trimmed };
   }
 
   async function getOpportunityBody(
@@ -701,14 +716,16 @@ export function createJobOs(deps: JobOsDeps) {
       return { status: 'not_found' };
     }
 
-    const event = await deps.store.appendDecisionEvent({
-      id: createId(),
-      kind: 'opportunity_passed',
-      opportunityId,
-      occurredAt: now(),
-    });
+    return withAdapterRejection('Could not record Pass decision', async () => {
+      const event = await deps.store.appendDecisionEvent({
+        id: createId(),
+        kind: 'opportunity_passed',
+        opportunityId,
+        occurredAt: now(),
+      });
 
-    return { status: 'passed', opportunity, event };
+      return { status: 'passed' as const, opportunity, event };
+    });
   }
 
   async function listDecisionEvents(
@@ -744,22 +761,24 @@ export function createJobOs(deps: JobOsDeps) {
       };
     }
 
-    const application = await deps.store.insertApplication({
-      id: createId(),
-      opportunityId,
-      status: 'researching',
-    });
+    return withAdapterRejection('Could not start Application', async () => {
+      const application = await deps.store.insertApplication({
+        id: createId(),
+        opportunityId,
+        status: 'researching',
+      });
 
-    const event = await deps.store.appendDecisionEvent({
-      id: createId(),
-      kind: 'application_started',
-      opportunityId,
-      applicationId: application.id,
-      toStatus: 'researching',
-      occurredAt: now(),
-    });
+      const event = await deps.store.appendDecisionEvent({
+        id: createId(),
+        kind: 'application_started',
+        opportunityId,
+        applicationId: application.id,
+        toStatus: 'researching',
+        occurredAt: now(),
+      });
 
-    return { status: 'pursued', application, event };
+      return { status: 'pursued' as const, application, event };
+    });
   }
 
   async function listApplications(): Promise<ApplicationRecord[]> {


### PR DESCRIPTION
## Summary
- Map Amplify/store/body adapter throws to `Rejected` for Pass, Pursue, Opportunity Body, and Employer Body so the UI always gets a discriminant result
- Clear Opportunity and Employer busy flags with `try/finally` so buttons never stay permanently disabled on failure
- Add Vitest coverage for adapter-failure Rejected paths

Closes #108.

## Test plan
- [ ] `npx vitest run src/lib/job-os.test.ts`
- [ ] In Job OS Opportunities: Pass and Pursue either succeed or show a clear error; buttons re-enable
- [ ] Opportunity Body save either persists or shows an error; never stuck on Saving
- [ ] Employer Body save behaves the same way

Made with [Cursor](https://cursor.com)