### PR TITLE
Fix Opportunity Body S3 path and Pass DecisionEvent null GSI

### DIFF
--- a/src/lib/job-os-amplify.test.ts
+++ b/src/lib/job-os-amplify.test.ts
@@ -59,6 +59,71 @@ function createMockClient(
   return { client, create };
 }
 
+describe('createAmplifyJobOsStore decision events', () => {
+  it('omits applicationId on Pass so DynamoDB GSI keys are never null', async () => {
+    const create = vi.fn(async (input: Record<string, unknown>) => ({
+      data: {
+        id: 'evt-1',
+        kind: 'opportunity_passed' as const,
+        opportunityId: String(input.opportunityId),
+        occurredAt: String(input.occurredAt),
+      },
+      errors: null,
+    }));
+    const { client } = createMockClient({ data: [] });
+    client.DecisionEvent.create = create;
+
+    await createAmplifyJobOsStore(client).appendDecisionEvent({
+      id: 'evt-1',
+      kind: 'opportunity_passed',
+      opportunityId: 'opp-1',
+      occurredAt: '2026-07-28T12:00:00.000Z',
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const payload = create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload).toEqual({
+      id: 'evt-1',
+      kind: 'opportunity_passed',
+      opportunityId: 'opp-1',
+      occurredAt: '2026-07-28T12:00:00.000Z',
+    });
+    expect(payload).not.toHaveProperty('applicationId');
+  });
+
+  it('includes applicationId when Pursue records application_started', async () => {
+    const create = vi.fn(async (input: Record<string, unknown>) => ({
+      data: {
+        id: 'evt-2',
+        kind: 'application_started' as const,
+        opportunityId: String(input.opportunityId),
+        applicationId: String(input.applicationId),
+        toStatus: String(input.toStatus),
+        occurredAt: String(input.occurredAt),
+      },
+      errors: null,
+    }));
+    const { client } = createMockClient({ data: [] });
+    client.DecisionEvent.create = create;
+
+    await createAmplifyJobOsStore(client).appendDecisionEvent({
+      id: 'evt-2',
+      kind: 'application_started',
+      opportunityId: 'opp-1',
+      applicationId: 'app-1',
+      toStatus: 'researching',
+      occurredAt: '2026-07-28T12:00:00.000Z',
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: 'app-1',
+        toStatus: 'researching',
+      }),
+    );
+  });
+});
+
 describe('createAmplifyJobOsStore employers', () => {
   it('treats missing isAnon as false when listing', async () => {
     const { client } = createMockClient({

--- a/src/lib/job-os-amplify.ts
+++ b/src/lib/job-os-amplify.ts
@@ -339,14 +339,32 @@ export function createAmplifyJobOsStore(
         .map(toDecisionEventRecord);
     },
     async appendDecisionEvent(input) {
-      const row = {
+      const row: {
+        id?: string;
+        kind: typeof input.kind;
+        opportunityId: string;
+        applicationId?: string;
+        fromStatus?: string;
+        toStatus?: string;
+        occurredAt: string;
+      } = {
         kind: input.kind,
         opportunityId: input.opportunityId,
-        applicationId: input.applicationId ?? null,
-        fromStatus: input.fromStatus ?? null,
-        toStatus: input.toStatus ?? null,
         occurredAt: input.occurredAt,
       };
+      // Omit optional GSI keys — DynamoDB rejects NULL on index attributes.
+      if (input.id) {
+        row.id = input.id;
+      }
+      if (input.applicationId) {
+        row.applicationId = input.applicationId;
+      }
+      if (input.fromStatus) {
+        row.fromStatus = input.fromStatus;
+      }
+      if (input.toStatus) {
+        row.toStatus = input.toStatus;
+      }
       const { data, errors } = await client.DecisionEvent.create(row);
       throwIfErrors(errors);
       if (!data) {

--- a/src/lib/job-os-body-storage.ts
+++ b/src/lib/job-os-body-storage.ts
@@ -1,5 +1,10 @@
-import type { BodyEntityKind, JobOsBodyStorage } from '@/lib/job-os';
+import {
+  bodyEntityS3Key,
+  type JobOsBodyStorage,
+} from '@/lib/job-os';
 import { isAmplifyClientConfigured } from '@/lib/is-amplify-client-configured';
+
+export { bodyEntityS3Key };
 
 export const BODY_CLIENT_NOT_CONFIGURED_REASON =
   'Body storage client is not configured';
@@ -23,13 +28,6 @@ function isUnauthenticatedError(message: string): boolean {
     lower.includes('not authenticated') ||
     lower.includes('user is not authenticated')
   );
-}
-
-export function bodyEntityS3Key(
-  entityKind: BodyEntityKind,
-  entityId: string,
-): string {
-  return `bodies/${entityKind}s/${entityId}.md`;
 }
 
 export function proseToBinary(body: string): Uint8Array {

--- a/src/lib/job-os.test.ts
+++ b/src/lib/job-os.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   ANON_EMPLOYER_NAME,
+  bodyEntityS3Key,
   createJobOs,
   createMemoryJobOsBodyStorage,
   createMemoryJobOsStore,
@@ -20,6 +21,18 @@ function createTestJobOs(options?: { now?: string }) {
   });
   return { jobOs, store, bodies };
 }
+
+describe('Job OS Body S3 keys', () => {
+  it('uses plural path segments that match storage access rules', () => {
+    expect(bodyEntityS3Key('employer', 'e1')).toBe('bodies/employers/e1.md');
+    expect(bodyEntityS3Key('opportunity', 'o1')).toBe(
+      'bodies/opportunities/o1.md',
+    );
+    expect(bodyEntityS3Key('application', 'a1')).toBe(
+      'bodies/applications/a1.md',
+    );
+  });
+});
 
 describe('Job OS facade — Employers', () => {
   it('bootstraps the reserved Anon Employer once', async () => {

--- a/src/lib/job-os.ts
+++ b/src/lib/job-os.ts
@@ -70,6 +70,19 @@ export type DecisionEventKind = (typeof DECISION_EVENT_KINDS)[number];
 
 export type BodyEntityKind = 'employer' | 'opportunity' | 'application';
 
+const BODY_ENTITY_PATH_SEGMENTS: Record<BodyEntityKind, string> = {
+  employer: 'employers',
+  opportunity: 'opportunities',
+  application: 'applications',
+};
+
+export function bodyEntityS3Key(
+  entityKind: BodyEntityKind,
+  entityId: string,
+): string {
+  return `bodies/${BODY_ENTITY_PATH_SEGMENTS[entityKind]}/${entityId}.md`;
+}
+
 export type EmployerRecord = {
   id: string;
   name: string;
@@ -940,7 +953,7 @@ export function createMemoryJobOsBodyStorage(): JobOsBodyStorage {
 
   return {
     async putBody({ entityKind, entityId, prose }) {
-      const s3Key = `bodies/${entityKind}s/${entityId}.md`;
+      const s3Key = bodyEntityS3Key(entityKind, entityId);
       bodies.set(s3Key, prose);
       return { s3Key };
     },


### PR DESCRIPTION
## Summary
- Use correct Body S3 plurals (`opportunities` not `opportunitys`) so Opportunity Body uploads match Amplify storage ACLs
- Omit `applicationId` on Pass DecisionEvent create — DynamoDB rejects NULL on the Application GSI

Follow-up to #109 / #108 after live diagnosis.

## Test plan
- [ ] `npx vitest run src/lib/job-os.test.ts src/lib/job-os-amplify.test.ts`
- [ ] Opportunity Body save persists and sets `s3Key`
- [ ] Pass records `opportunity_passed` without GraphQL DynamoDB GSI error

Made with [Cursor](https://cursor.com)