### PR TITLE
Fix legacy Employers listing without sector

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -41,7 +41,9 @@ const schema = a.schema({
       name: a.string().required(),
       sizeTier: a.string().required(),
       prestigeTier: a.string().required(),
-      sector: a.string().required(),
+      // Not required: legacy Employer rows predate sector and must still list.
+      // Default applies on create; adapter backfills missing DynamoDB attrs.
+      sector: a.string().default('other'),
       summary: a.string(),
       websiteUrl: a.string(),
       linkedinUrl: a.string(),

--- a/src/lib/job-os-amplify.test.ts
+++ b/src/lib/job-os-amplify.test.ts
@@ -199,4 +199,29 @@ describe('createAmplifyJobOsStore employers', () => {
       expect.objectContaining({ isAnon: false }),
     );
   });
+
+  it('defaults and backfills missing Employer sector on list', async () => {
+    const update = vi.fn(async () => ({ data: null, errors: null }));
+    const { client } = createMockClient({
+      data: [
+        {
+          id: 'emp-legacy',
+          name: 'Legacy Co',
+          sizeTier: 'other',
+          prestigeTier: 'low',
+          isAnon: false,
+        },
+      ],
+    });
+    client.Employer.update = update;
+
+    const employers = await createAmplifyJobOsStore(client).listEmployers();
+
+    expect(employers).toEqual([
+      expect.objectContaining({ id: 'emp-legacy', sector: 'other' }),
+    ]);
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'emp-legacy', sector: 'other' }),
+    );
+  });
 });

--- a/src/lib/job-os-amplify.ts
+++ b/src/lib/job-os-amplify.ts
@@ -274,11 +274,11 @@ export function createAmplifyJobOsStore(
         rows
           .filter((row) => row.sector == null || row.sector === '')
           .map(async (row) => {
-            const { errors: updateErrors } = await client.Employer.update({
+            const result = await client.Employer.update({
               ...employerToRow(toEmployerRecord(row)),
               sector: 'other',
             });
-            throwIfErrors(updateErrors);
+            throwIfErrors(result?.errors);
           }),
       );
       return employers;

--- a/src/lib/job-os-amplify.ts
+++ b/src/lib/job-os-amplify.ts
@@ -268,7 +268,20 @@ export function createAmplifyJobOsStore(
         throwIfErrors(errors);
         return [];
       }
-      return rows.map(toEmployerRecord);
+      const employers = rows.map(toEmployerRecord);
+      // Persist default sector onto legacy rows so DynamoDB attrs catch up.
+      await Promise.all(
+        rows
+          .filter((row) => row.sector == null || row.sector === '')
+          .map(async (row) => {
+            const { errors: updateErrors } = await client.Employer.update({
+              ...employerToRow(toEmployerRecord(row)),
+              sector: 'other',
+            });
+            throwIfErrors(updateErrors);
+          }),
+      );
+      return employers;
     },
     async getEmployer(id) {
       const { data, errors } = await client.Employer.get({ id });

--- a/src/lib/job-os.ts
+++ b/src/lib/job-os.ts
@@ -516,6 +516,8 @@ export function createJobOs(deps: JobOsDeps) {
     }
   }
 
+  let vocabularySeedPromise: Promise<VocabularyTermRecord[]> | null = null;
+
   async function hasActiveVocabularyValue(
     kind: VocabularyKind,
     value: string,
@@ -563,40 +565,55 @@ export function createJobOs(deps: JobOsDeps) {
   }
 
   async function ensureVocabularyDefaults(): Promise<VocabularyTermRecord[]> {
-    const existing = await deps.store.listVocabularyTerms();
-    const existingKeys = new Set(
-      existing.map((term) => `${term.kind}:${term.value}`),
-    );
-    for (const seed of VOCABULARY_SEED_DEFAULTS) {
-      const key = `${seed.kind}:${seed.value}`;
-      if (existingKeys.has(key)) {
-        continue;
-      }
-      await deps.store.insertVocabularyTerm({
-        id: createId(),
-        kind: seed.kind,
-        value: seed.value,
-        label: seed.label,
-        sortOrder: seed.sortOrder,
-        active: true,
-      });
-      existingKeys.add(key);
+    if (!vocabularySeedPromise) {
+      vocabularySeedPromise = (async () => {
+        const existing = await deps.store.listVocabularyTerms();
+        const existingKeys = new Set(
+          existing.map((term) => `${term.kind}:${term.value}`),
+        );
+        for (const seed of VOCABULARY_SEED_DEFAULTS) {
+          const key = `${seed.kind}:${seed.value}`;
+          if (existingKeys.has(key)) {
+            continue;
+          }
+          await deps.store.insertVocabularyTerm({
+            id: createId(),
+            kind: seed.kind,
+            value: seed.value,
+            label: seed.label,
+            sortOrder: seed.sortOrder,
+            active: true,
+          });
+          existingKeys.add(key);
+        }
+        return listVocabularyTerms();
+      })();
     }
-    return listVocabularyTerms();
+    return vocabularySeedPromise;
   }
 
   async function listVocabularyTerms(
     kind?: VocabularyKind,
   ): Promise<VocabularyTermRecord[]> {
     const terms = await deps.store.listVocabularyTerms(kind);
-    return [...terms].sort((a, b) => {
+    const deduped: VocabularyTermRecord[] = [];
+    const seen = new Set<string>();
+    for (const term of [...terms].sort((a, b) => {
       const orderA = a.sortOrder ?? Number.MAX_SAFE_INTEGER;
       const orderB = b.sortOrder ?? Number.MAX_SAFE_INTEGER;
       if (orderA !== orderB) {
         return orderA - orderB;
       }
       return a.label.localeCompare(b.label);
-    });
+    })) {
+      const key = `${term.kind}:${term.value}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      deduped.push(term);
+    }
+    return deduped;
   }
 
   async function createVocabularyTerm(


### PR DESCRIPTION
## Summary
- Make Employer `sector` optional in Amplify (with default `other`) so pre-migration DynamoDB rows no longer null out `listEmployers`
- Backfill missing `sector` to `other` on list
- Serialise vocabulary seeding and dedupe list results (concurrent seed had duplicated terms)

**Requires Amplify backend deploy** after merge.

## Test plan
- [ ] Deploy Amplify schema change
- [ ] Open Job OS Employers — ledger loads (no all-null list)
- [ ] Legacy employers show sector Other and persist after first list
- [ ] `npx vitest run src/lib/job-os-amplify.test.ts src/lib/job-os.test.ts`

Made with [Cursor](https://cursor.com)