### PR TITLE
Fix Job OS noticedAt drift and Bedrock fit model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -16,12 +16,20 @@ const backend = defineBackend({
 // Owner-only Cognito: disable self-sign-up (admin invite / AdminCreateUser only).
 const { cfnUserPool } = backend.auth.resources.cfnResources;
 cfnUserPool.adminCreateUserConfig = {
-  adminCreateUserOnly: true,
+  allowAdminCreateUserOnly: true,
 };
 
+// Open-weight Bedrock models (e.g. Meta Llama) need invoke on foundation
+// models and inference profiles; no Marketplace subscription required.
 backend.analyseFit.resources.lambda.addToRolePolicy(
   new PolicyStatement({
-    actions: ['bedrock:InvokeModel'],
-    resources: ['arn:aws:bedrock:*::foundation-model/*'],
+    actions: [
+      'bedrock:InvokeModel',
+      'bedrock:InvokeModelWithResponseStream',
+    ],
+    resources: [
+      'arn:aws:bedrock:*::foundation-model/*',
+      'arn:aws:bedrock:*:*:inference-profile/*',
+    ],
   }),
 );

--- a/amplify/functions/analyse-fit/handler.ts
+++ b/amplify/functions/analyse-fit/handler.ts
@@ -4,7 +4,9 @@ import {
 } from '@aws-sdk/client-bedrock-runtime';
 import type { Schema } from '../../data/resource';
 
-const client = new BedrockRuntimeClient({});
+const client = new BedrockRuntimeClient({
+  region: process.env.BEDROCK_REGION ?? process.env.AWS_REGION,
+});
 
 const SYSTEM_PROMPT = `You are analysing job-hunt fit for a private Site Admin.
 Given a Hunt Profile (structured targets/constraints plus optional Body), an Opportunity (structured listing evidence plus optional Body), and an Employer (structured fields plus optional Body), return ONLY valid JSON with this shape:
@@ -32,7 +34,7 @@ export const handler: Schema['analyseFitWithBedrock']['functionHandler'] =
   async (event) => {
     const modelId =
       process.env.BEDROCK_MODEL_ID ??
-      'anthropic.claude-3-haiku-20240307-v1:0';
+      'us.meta.llama3-3-70b-instruct-v1:0';
     const contextJson = event.arguments.contextJson;
 
     const response = await client.send(

--- a/amplify/functions/analyse-fit/package-lock.json
+++ b/amplify/functions/analyse-fit/package-lock.json
@@ -1,0 +1,449 @@
+{
+  "name": "analyse-fit",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "analyse-fit",
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.758.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1101.0.tgz",
+      "integrity": "sha512-Qd2bKUkV4qX8vEA3aSwKktfM8LFNvOq9YzM3JzFiCxmzvGhFPy6wfP7ZtpQjfuAwelp4DwcHeJCcnEbmrmID8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
+        "@aws-sdk/eventstream-handler-node": "^3.972.31",
+        "@aws-sdk/middleware-eventstream": "^3.972.26",
+        "@aws-sdk/middleware-websocket": "^3.972.47",
+        "@aws-sdk/token-providers": "3.1101.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
+      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
+      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
+      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
+      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-env": "^3.972.65",
+        "@aws-sdk/credential-provider-http": "^3.972.67",
+        "@aws-sdk/credential-provider-login": "^3.972.72",
+        "@aws-sdk/credential-provider-process": "^3.972.65",
+        "@aws-sdk/credential-provider-sso": "^3.973.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
+      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
+      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.65",
+        "@aws-sdk/credential-provider-http": "^3.972.67",
+        "@aws-sdk/credential-provider-ini": "^3.973.10",
+        "@aws-sdk/credential-provider-process": "^3.972.65",
+        "@aws-sdk/credential-provider-sso": "^3.973.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
+      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
+      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/token-providers": "3.1100.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
+      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
+      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.47.tgz",
+      "integrity": "sha512-UcPdY05u3TzvDah86NG6B9FgePYU6bXO7CRQIzQrieFL5xBBGajM7g1lCngmP4WA8EPed/kgT5CvM28cqSlBbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
+      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1101.0.tgz",
+      "integrity": "sha512-S9yC1qsmfczOSclMEaRYS0p0gj75ad5gOcbvhUEAl1vQAClupSLN0s2v5sSKfkhxkhfDiGgriubin6X6NSzSFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/amplify/functions/analyse-fit/resource.ts
+++ b/amplify/functions/analyse-fit/resource.ts
@@ -5,7 +5,8 @@ export const analyseFit = defineFunction({
   entry: './handler.ts',
   timeoutSeconds: 60,
   environment: {
-    BEDROCK_MODEL_ID:
-      'anthropic.claude-3-haiku-20240307-v1:0',
+    // Open-weight Meta model; US geo profile (no Marketplace subscription).
+    BEDROCK_MODEL_ID: 'us.meta.llama3-3-70b-instruct-v1:0',
+    BEDROCK_REGION: 'us-east-1',
   },
 });

--- a/src/components/sections/labs/job-os/job-os-ledger.test.ts
+++ b/src/components/sections/labs/job-os/job-os-ledger.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   formatCompensation,
   formatNoticedAge,
+  fromDatetimeLocalValue,
+  toDatetimeLocalValue,
 } from '@/components/sections/labs/job-os/job-os-ledger';
 
 describe('Job OS ledger formatters', () => {
@@ -16,6 +18,38 @@ describe('Job OS ledger formatters', () => {
     expect(
       formatNoticedAge('2026-07-24T12:00:00.000Z', now),
     ).toBe('3d');
+  });
+
+  it('round-trips noticedAt through datetime-local without drifting on save', () => {
+    const original = '2026-08-01T10:05:00.000Z';
+    let iso = original;
+    for (let i = 0; i < 3; i += 1) {
+      iso = fromDatetimeLocalValue(toDatetimeLocalValue(new Date(iso)));
+    }
+    // datetime-local is minute precision; allow sub-minute truncation only
+    expect(Math.abs(Date.parse(iso) - Date.parse(original))).toBeLessThan(
+      60_000,
+    );
+  });
+
+  it('does not treat UTC ISO wall-clock as datetime-local (regression)', () => {
+    const original = '2026-08-01T10:05:00.000Z';
+    const offsetMinutes = new Date(original).getTimezoneOffset();
+    if (offsetMinutes === 0) {
+      return; // UTC hosts cannot observe the slice bug
+    }
+
+    // Previous bug: feed ISO.slice(0, 16) into datetime-local, then Date(value).toISOString()
+    let drifted = original;
+    for (let i = 0; i < 3; i += 1) {
+      drifted = new Date(drifted.slice(0, 16)).toISOString();
+    }
+    expect(Math.abs(Date.parse(drifted) - Date.parse(original))).toBeGreaterThanOrEqual(
+      60_000,
+    );
+
+    const local = toDatetimeLocalValue(new Date(original));
+    expect(local).not.toBe(original.slice(0, 16));
   });
 
   it('formats compensation ranges compactly', () => {

--- a/src/components/sections/labs/job-os/job-os-ledger.tsx
+++ b/src/components/sections/labs/job-os/job-os-ledger.tsx
@@ -212,6 +212,24 @@ export function JobOsFocusSection({
   );
 }
 
+/** Local wall-clock value for `<input type="datetime-local">` (no timezone suffix). */
+export function toDatetimeLocalValue(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** Parse a datetime-local value as local time and return UTC ISO. */
+export function fromDatetimeLocalValue(
+  value: string,
+  fallback: () => Date = () => new Date(),
+): string {
+  const asDate = new Date(value);
+  if (Number.isNaN(asDate.getTime())) {
+    return fallback().toISOString();
+  }
+  return asDate.toISOString();
+}
+
 export function formatNoticedAge(iso: string, now = Date.now()): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {

--- a/src/components/sections/labs/job-os/job-os-opportunities-workspace.tsx
+++ b/src/components/sections/labs/job-os/job-os-opportunities-workspace.tsx
@@ -7,6 +7,7 @@ import { jobOsFieldClassName } from '@/components/sections/labs/job-os/job-os-fi
 import {
   formatCompensation,
   formatNoticedAge,
+  fromDatetimeLocalValue,
   JobOsCaptureStrip,
   JobOsFocusSection,
   JobOsLedger,
@@ -14,6 +15,7 @@ import {
   JobOsLedgerRow,
   JobOsPill,
   JobOsWorkspaceIntro,
+  toDatetimeLocalValue,
 } from '@/components/sections/labs/job-os/job-os-ledger';
 import { jobOs } from '@/data';
 import {
@@ -99,8 +101,8 @@ export function JobOsOpportunitiesWorkspace({
   const [employerId, setEmployerId] = useState('');
   const [title, setTitle] = useState('');
   const [source, setSource] = useState('');
-  const [noticedAt, setNoticedAt] = useState(
-    () => new Date().toISOString().slice(0, 16),
+  const [noticedAt, setNoticedAt] = useState(() =>
+    toDatetimeLocalValue(new Date()),
   );
   const [status, setStatus] = useState<OpportunityStatus>('open');
   const [seniority, setSeniority] = useState<OpportunitySeniority | ''>('');
@@ -181,7 +183,7 @@ export function JobOsOpportunitiesWorkspace({
       setEmployerId(opportunity.employerId);
       setTitle(opportunity.title ?? '');
       setSource(opportunity.source ?? '');
-      setNoticedAt(opportunity.noticedAt.slice(0, 16));
+      setNoticedAt(toDatetimeLocalValue(new Date(opportunity.noticedAt)));
       setStatus(opportunity.status);
       setSeniority(opportunity.seniority ?? '');
       setRoleFamily(opportunity.roleFamily ?? '');
@@ -262,7 +264,7 @@ export function JobOsOpportunitiesWorkspace({
       event.preventDefault();
       setTitle('');
       setSource('');
-      setNoticedAt(new Date().toISOString().slice(0, 16));
+      setNoticedAt(toDatetimeLocalValue(new Date()));
       setStatus('open');
       setSeniority('');
       setRoleFamily('');
@@ -318,20 +320,11 @@ export function JobOsOpportunitiesWorkspace({
     setPursuitById(next);
   }
 
-  function toIsoNoticedAt(value: string): string {
-    const asDate = new Date(value);
-    if (Number.isNaN(asDate.getTime())) {
-      return new Date().toISOString();
-    }
-    return asDate.toISOString();
-  }
-
-  function buildInput() {
-    return {
+  function buildInput(mode: 'create' | 'update') {
+    const shared = {
       employerId,
       title,
       source,
-      noticedAt: toIsoNoticedAt(noticedAt),
       status,
       seniority: seniority || undefined,
       roleFamily: roleFamily || undefined,
@@ -345,12 +338,19 @@ export function JobOsOpportunitiesWorkspace({
         .map((tech) => tech.trim())
         .filter(Boolean),
     };
+    if (mode === 'create') {
+      return {
+        ...shared,
+        noticedAt: fromDatetimeLocalValue(noticedAt),
+      };
+    }
+    return shared;
   }
 
   function resetCaptureFields() {
     setTitle('');
     setSource('');
-    setNoticedAt(new Date().toISOString().slice(0, 16));
+    setNoticedAt(toDatetimeLocalValue(new Date()));
     setStatus('open');
     setSeniority('');
     setRoleFamily('');
@@ -394,7 +394,7 @@ export function JobOsOpportunitiesWorkspace({
     }
     setBusy(true);
     setError(null);
-    const result = await client.createOpportunity(buildInput());
+    const result = await client.createOpportunity(buildInput('create'));
     setBusy(false);
     if (result.status === 'rejected') {
       setError(result.reason);
@@ -415,7 +415,7 @@ export function JobOsOpportunitiesWorkspace({
     try {
       const result = await client.updateOpportunity({
         id: selected.id,
-        ...buildInput(),
+        ...buildInput('update'),
       });
       if (result.status === 'rejected' || result.status === 'not_found') {
         setError(result.status === 'rejected' ? result.reason : copy.errorLabel);
@@ -610,8 +610,7 @@ export function JobOsOpportunitiesWorkspace({
             setEmployerId={setEmployerId}
             title={title}
             setTitle={setTitle}
-            noticedAt={noticedAt}
-            setNoticedAt={setNoticedAt}
+            noticedAtDisplay={formatNoticedAge(selected.noticedAt)}
             status={status}
             setStatus={setStatus}
           />
@@ -1014,6 +1013,7 @@ function OpportunityListingFields({
   setTitle,
   noticedAt,
   setNoticedAt,
+  noticedAtDisplay,
   status,
   setStatus,
 }: {
@@ -1023,8 +1023,9 @@ function OpportunityListingFields({
   setEmployerId: (value: string) => void;
   title: string;
   setTitle: (value: string) => void;
-  noticedAt: string;
-  setNoticedAt: (value: string) => void;
+  noticedAt?: string;
+  setNoticedAt?: (value: string) => void;
+  noticedAtDisplay?: string;
   status: OpportunityStatus;
   setStatus: (value: OpportunityStatus) => void;
 }) {
@@ -1054,12 +1055,16 @@ function OpportunityListingFields({
       </label>
       <label className="block font-body text-sm">
         {copy.noticedAtLabel}
-        <input
-          type="datetime-local"
-          className={jobOsFieldClassName}
-          value={noticedAt}
-          onChange={(event) => setNoticedAt(event.target.value)}
-        />
+        {setNoticedAt && noticedAt != null ? (
+          <input
+            type="datetime-local"
+            className={jobOsFieldClassName}
+            value={noticedAt}
+            onChange={(event) => setNoticedAt(event.target.value)}
+          />
+        ) : (
+          <Text className="mt-1 block">{noticedAtDisplay ?? '—'}</Text>
+        )}
       </label>
       <label className="block font-body text-sm">
         {copy.statusLabel}

--- a/src/lib/job-os.test.ts
+++ b/src/lib/job-os.test.ts
@@ -227,7 +227,6 @@ describe('Job OS facade — Opportunities', () => {
     const closed = await jobOs.updateOpportunity({
       id: created.opportunity.id,
       employerId: employer.employer.id,
-      noticedAt: created.opportunity.noticedAt,
       title: 'ML Engineer',
       status: 'closed',
     });
@@ -240,7 +239,6 @@ describe('Job OS facade — Opportunities', () => {
     const reopened = await jobOs.updateOpportunity({
       id: created.opportunity.id,
       employerId: employer.employer.id,
-      noticedAt: created.opportunity.noticedAt,
       title: 'ML Engineer',
       status: 'open',
     });
@@ -249,6 +247,43 @@ describe('Job OS facade — Opportunities', () => {
       return;
     }
     expect(reopened.opportunity.status).toBe('open');
+  });
+
+  it('preserves noticedAt when an Opportunity is updated', async () => {
+    const { jobOs } = createTestJobOs();
+    const employer = await jobOs.createEmployer({
+      name: 'Northwind',
+      sizeTier: 'enterprise',
+      prestigeTier: 'high',
+      sector: 'law',
+    });
+    expect(employer.status).toBe('created');
+    if (employer.status !== 'created') {
+      return;
+    }
+
+    const created = await jobOs.createOpportunity({
+      employerId: employer.employer.id,
+      noticedAt: '2026-07-21T10:00:00.000Z',
+      title: 'ML Engineer',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const updated = await jobOs.updateOpportunity({
+      id: created.opportunity.id,
+      employerId: employer.employer.id,
+      title: 'Staff ML Engineer',
+      status: 'open',
+    });
+    expect(updated.status).toBe('updated');
+    if (updated.status !== 'updated') {
+      return;
+    }
+    expect(updated.opportunity.noticedAt).toBe('2026-07-21T10:00:00.000Z');
+    expect(updated.opportunity.title).toBe('Staff ML Engineer');
   });
 
   it('rejects Opportunity Body update when body storage fails', async () => {
@@ -874,7 +909,6 @@ describe('Job OS facade — Fit Insight', () => {
     await jobOs.updateOpportunity({
       id: created.opportunity.id,
       employerId: anon.id,
-      noticedAt: created.opportunity.noticedAt,
       title: 'Staff platform engineer',
       seniority: 'senior',
     });

--- a/src/lib/job-os.ts
+++ b/src/lib/job-os.ts
@@ -330,7 +330,7 @@ export type CreateOpportunityInput = {
   technologies?: string[];
 };
 
-export type UpdateOpportunityInput = CreateOpportunityInput & {
+export type UpdateOpportunityInput = Omit<CreateOpportunityInput, 'noticedAt'> & {
   id: string;
 };
 
@@ -1052,11 +1052,17 @@ export function createJobOs(deps: JobOsDeps) {
     }
 
     await ensureVocabularyDefaults();
-    const shape = validateOpportunityShape(input);
+    const shape = validateOpportunityShape({
+      ...input,
+      noticedAt: existing.noticedAt,
+    });
     if (shape.status === 'rejected') {
       return shape;
     }
-    const validation = await validateOpportunityVocabulary(input);
+    const validation = await validateOpportunityVocabulary({
+      ...input,
+      noticedAt: existing.noticedAt,
+    });
     if (validation.status === 'rejected') {
       return validation;
     }
@@ -1066,11 +1072,15 @@ export function createJobOs(deps: JobOsDeps) {
       return { status: 'rejected', reason: 'Employer not found' };
     }
 
-    const fields = buildOpportunityFields(input);
+    const fields = buildOpportunityFields({
+      ...input,
+      noticedAt: existing.noticedAt,
+    });
     const opportunity: OpportunityRecord = {
       ...existing,
       employerId: input.employerId,
       ...fields,
+      noticedAt: existing.noticedAt,
       contentUpdatedAt: now(),
     };
     await deps.store.persistOpportunity(opportunity);


### PR DESCRIPTION
﻿## Summary
- Keep `noticedAt` immutable after opportunity creation (domain + read-only edit UI), and fix datetime-local UTC/local conversion that shifted the timestamp by about an hour on each save.
- Switch analyse-fit to Meta Llama 3.3 70B via US inference profile (no Marketplace subscription), with Cognito L1 property and Bedrock IAM cleanup for sandbox deploy.
- Ignore nested `node_modules` and lock analyse-fit function dependencies.

## Test plan
- [ ] Create an opportunity; confirm Noticed shows just now or minutes
- [ ] Edit and save the opportunity several times; Noticed age must not jump by an hour
- [ ] Confirm Noticed is read-only on the detail form and only editable during capture
- [ ] Run fit analysis; Bedrock call succeeds with Llama (no Marketplace access-denied)
- [ ] `npm run test -- src/lib/job-os.test.ts src/components/sections/labs/job-os/job-os-ledger.test.ts`
