### PR TITLE
Promote CI/CD Amplify optimisations to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,25 @@
-# CI only: lint, typecheck, tests, build. Deploy stays on AWS Amplify (amplify.yml).
+# CI only: lint, typecheck, tests; next build on main pushes. Deploy stays on AWS Amplify (amplify.yml).
 # Pin app Node via .nvmrc (kept in sync with Amplify amplify.yml); see docs/CI-AND-DEPLOYMENT.md.
 name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.cursor/**'
+      - '.agents/**'
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.cursor/**'
+      - '.agents/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality:
@@ -26,4 +40,6 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run test
-      - run: npm run build
+      - name: Build (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npm run build

--- a/amplify.yml
+++ b/amplify.yml
@@ -7,7 +7,16 @@ backend:
         # Local npm cache speeds reinstalls; keep path relative for Amplify cache.
         - npm config set cache .npm
         - npm ci
-        - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+        # Skip pipeline-deploy when amplify/ and Amplify/CDK deps are unchanged.
+        # Script exit 0 = redeploy; exit 1 = generate outputs only.
+        - |
+          if npx tsx scripts/amplify-backend-changed.ts; then
+            echo "Backend changed; running pipeline-deploy"
+            npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+          else
+            echo "Backend unchanged; generating amplify_outputs.json only"
+            npx ampx generate outputs --branch $AWS_BRANCH --app-id $AWS_APP_ID
+          fi
 frontend:
   phases:
     preBuild:
@@ -34,3 +43,4 @@ frontend:
     paths:
       - .npm/**/*
       - node_modules/**/*
+      - .next/cache/**/*

--- a/amplify.yml.test.ts
+++ b/amplify.yml.test.ts
@@ -19,8 +19,10 @@ describe('amplify.yml Hosting contract', () => {
     expect(amplifyYml).toMatch(/nvm use 22/);
   });
 
-  it('deploys the Gen 2 backend via pipeline-deploy before the frontend build', () => {
+  it('gates Gen 2 backend deploy and falls back to generate outputs', () => {
+    expect(amplifyYml).toMatch(/scripts\/amplify-backend-changed\.ts/);
     expect(amplifyYml).toMatch(/ampx pipeline-deploy/);
+    expect(amplifyYml).toMatch(/ampx generate outputs/);
     expect(amplifyYml).toMatch(/\$AWS_BRANCH/);
     expect(amplifyYml).toMatch(/\$AWS_APP_ID/);
   });
@@ -29,5 +31,9 @@ describe('amplify.yml Hosting contract', () => {
     expect(amplifyYml).toMatch(/Reusing node_modules from backend phase/);
     expect(amplifyYml).toMatch(/npm config set cache \.npm/);
     expect(amplifyYml).toMatch(/\.npm\/\*\*\/\*/);
+  });
+
+  it('caches the Next.js build cache on Amplify', () => {
+    expect(amplifyYml).toMatch(/\.next\/cache\/\*\*\/\*/);
   });
 });

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -4,22 +4,38 @@
 
 | Concern | Where | Notes |
 |---------|--------|--------|
-| **PR and push checks** | [GitHub Actions](https://docs.github.com/en/actions) | Workflow: `.github/workflows/ci.yml` — `npm ci`, production `npm audit` (critical), lint, typecheck, tests, `next build`. **Does not deploy.** Does not require live AWS or `amplify_outputs.json`. |
-| **Production build and deploy** | **AWS Amplify** autobuild | On push to connected branches: runs `amplify.yml` (Gen 2 `ampx pipeline-deploy`, reuse or `npm ci`, `npm run build`), publishes `.next`. **This is the only CD path** unless the team explicitly changes strategy. |
+| **PR checks** | [GitHub Actions](https://docs.github.com/en/actions) | Workflow: `.github/workflows/ci.yml` — `npm ci`, production `npm audit` (critical), lint, typecheck, tests. **No `next build` on PRs.** Does not deploy. Does not require live AWS or `amplify_outputs.json`. |
+| **Push to `main`** | GitHub Actions | Same quality suite **plus** `next build` as a cheap safety net. Still does not deploy. |
+| **Production build and deploy** | **AWS Amplify** autobuild | On push to connected branches: runs `amplify.yml` (conditional Gen 2 `ampx pipeline-deploy` or `ampx generate outputs`, reuse or `npm ci`, `npm run build`), publishes `.next`. **This is the only CD path** unless the team explicitly changes strategy. |
 
 There is **no accidental double-deploy** from GitHub Actions: Actions do not push artefacts or run Amplify CLI deploy in the baseline setup.
 
+### Actions concurrency and path filters
+
+- **Concurrency:** new pushes to the same PR/ref cancel in-progress CI runs (`cancel-in-progress: true`).
+- **Path filters:** the quality job is skipped when the diff is only docs/agent paths (`docs/**`, `**/*.md`, `.cursor/**`, `.agents/**`). Pure documentation or agent-config commits run **no** Actions checks. Changes to product code, `amplify/`, workflows, `package*.json`, or other config still run the full suite.
+
 ## Amplify Gen 2 backend
 
-Backend definitions live in `amplify/` (Cognito Site Admin auth, Job OS data/storage, and **Site Content** storage for Posts/Photos). Hosting deploys them via `npx ampx pipeline-deploy` in the `backend` phase of `amplify.yml`, then runs the frontend `preBuild` and `build`.
+Backend definitions live in `amplify/` (Cognito Site Admin auth, Job OS data/storage, and **Site Content** storage for Posts/Photos). Hosting deploys them via `npx ampx pipeline-deploy` in the `backend` phase of `amplify.yml` **when the backend changed**, then runs the frontend `preBuild` and `build`.
+
+### Conditional backend deploy
+
+`scripts/amplify-backend-changed.ts` compares the current commit to its parent (deepening Amplify’s shallow clone when needed). A backend redeploy runs when:
+
+- anything under `amplify/` changed, or
+- root `package.json` / `package-lock.json` changed for Amplify/CDK-related deps (`@aws-amplify/*`, `aws-amplify`, `aws-cdk`, `aws-cdk-lib`, `constructs`, `@aws-sdk/*`).
+
+When those are unchanged, Amplify skips `pipeline-deploy` and runs `npx ampx generate outputs --branch $AWS_BRANCH --app-id $AWS_APP_ID` so the frontend still gets a valid `amplify_outputs.json`.
 
 | Environment | Outputs file |
 |-------------|----------------|
 | **GitHub Actions / marketing-only local** | `amplify_outputs.json` is absent (gitignored). `readAmplifyOutputs()` returns null; `configureSiteAmplify` no-ops so public pages stay up (empty Site Content lists). |
 | **Local sandbox** | `npm run sandbox` (`npx ampx sandbox`) writes `amplify_outputs.json` at the repo root. |
-| **Amplify Hosting** | `pipeline-deploy` generates outputs for the frontend build. |
+| **Amplify Hosting (backend changed)** | `pipeline-deploy` generates outputs for the frontend build. |
+| **Amplify Hosting (frontend-only)** | `ampx generate outputs` writes outputs without redeploying CloudFormation. |
 
-Contract tests in `amplify.yml.test.ts` lock Gen 2 `pipeline-deploy` into CI and assert the retired blog-repo sync is absent.
+Contract tests in `amplify.yml.test.ts` lock the gated Gen 2 deploy / generate-outputs paths into CI and assert the retired blog-repo sync is absent.
 
 ## Node.js versions
 
@@ -27,18 +43,20 @@ Contract tests in `amplify.yml.test.ts` lock Gen 2 `pipeline-deploy` into CI and
 |--------|----------------|
 | **Local / CI** | Repository root **`.nvmrc`** (`22`). GitHub Actions uses `actions/setup-node` with `node-version-file: '.nvmrc'`. |
 | **`package.json`** | `"engines": { "node": ">=22" }` — run `npm ci` on Node 22 or newer. |
-| **Amplify** | **`amplify.yml`** runs **`nvm use 22`** at the start of backend `build` and frontend `preBuild` so `ampx pipeline-deploy`, install, and `npm run build` all use Node 22. |
+| **Amplify** | **`amplify.yml`** runs **`nvm use 22`** at the start of backend `build` and frontend `preBuild` so `ampx`, install, and `npm run build` all use Node 22. |
 
 ### Amplify install and cache
 
-- Backend `npm ci` installs the lockfile (needed for `ampx pipeline-deploy`).
+- Backend `npm ci` installs the lockfile (needed for `ampx pipeline-deploy` / `generate outputs`).
 - Frontend reuses that `node_modules` when the backend phase left it in place; otherwise it runs `npm ci` (frontend-only rebuilds).
-- Cache paths: `.npm/**/*` (npm download cache), `node_modules/**/*`.
+- Cache paths: `.npm/**/*` (npm download cache), `node_modules/**/*`, `.next/cache/**/*` (Next.js build cache). Stay on the **Standard** Amplify build instance.
 
 **Check in the AWS Amplify console**
 
 1. **Build image:** Prefer **Amazon Linux 2023** (AL2023). AL2 does not ship modern Node by default; migrate to AL2023 or a custom image per [AWS guidance](https://docs.aws.amazon.com/amplify/latest/userguide/troubleshooting-general.html).
 2. **Live package updates:** If you set Node there, remember that **`nvm use` in `amplify.yml` overrides** live package updates for the shell that runs your commands.
+3. **Autobuild branches:** Prefer connecting **`main` only** so Dependabot/feature branches do not burn Amplify build minutes. Disable PR/branch preview builds unless deliberately kept.
+4. **`AMPLIFY_DIFF_DEPLOY`:** optional after the in-repo backend gate lands; do not enable blindly if it conflicts with Gen 2 outputs generation.
 
 If `nvm use 22` fails on the build image (version not installed), add a line before it: `nvm install 22` (then keep `nvm use 22`).
 
@@ -68,7 +86,9 @@ AI agents cannot apply this in the UI; use the checklist above.
 ## Related
 
 - `amplify.yml` — Amplify build phases
+- `scripts/amplify-backend-changed.ts` — backend redeploy gate
 - `.github/workflows/ci.yml` — GitHub Actions quality checks
 - `.github/dependabot.yml` — weekly npm / monthly Actions update PRs
 - [docs/adr/0003-site-content-and-admin.md](./adr/0003-site-content-and-admin.md) — Site Content + Admin vs Labs
 - [#113](https://github.com/hashadar/hashadar_website/issues/113) — re-enable Next image optimisation with sharp
+- [#136](https://github.com/hashadar/hashadar_website/issues/136) — CI/CD speed and Amplify cost

--- a/scripts/amplify-backend-changed.test.ts
+++ b/scripts/amplify-backend-changed.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  backendNeedsDeploy,
+  isBackendDep,
+  packageFilesForceRedeploy,
+  relevantDepVersions,
+  relevantLockVersions,
+  versionsDiffer,
+} from './amplify-backend-changed';
+
+describe('amplify-backend-changed matchers', () => {
+  it('matches Amplify, CDK, and AWS SDK packages', () => {
+    expect(isBackendDep('@aws-amplify/backend')).toBe(true);
+    expect(isBackendDep('aws-amplify')).toBe(true);
+    expect(isBackendDep('aws-cdk')).toBe(true);
+    expect(isBackendDep('aws-cdk-lib')).toBe(true);
+    expect(isBackendDep('constructs')).toBe(true);
+    expect(isBackendDep('@aws-sdk/client-bedrock-runtime')).toBe(true);
+    expect(isBackendDep('next')).toBe(false);
+    expect(isBackendDep('react')).toBe(false);
+  });
+
+  it('extracts relevant versions from package.json', () => {
+    expect(
+      relevantDepVersions({
+        dependencies: { next: '16.0.0', 'aws-amplify': '6.1.0' },
+        devDependencies: { '@aws-amplify/backend': '1.2.0', eslint: '9.0.0' },
+      }),
+    ).toEqual({
+      'aws-amplify': '6.1.0',
+      '@aws-amplify/backend': '1.2.0',
+    });
+  });
+
+  it('extracts top-level lockfile package versions only', () => {
+    expect(
+      relevantLockVersions({
+        packages: {
+          '': {},
+          'node_modules/aws-amplify': { version: '6.1.0' },
+          'node_modules/next': { version: '16.0.0' },
+          'node_modules/aws-amplify/node_modules/foo': { version: '1.0.0' },
+        },
+      }),
+    ).toEqual({ 'aws-amplify': '6.1.0' });
+  });
+
+  it('detects version map differences', () => {
+    expect(versionsDiffer({ a: '1' }, { a: '1' })).toBe(false);
+    expect(versionsDiffer({ a: '1' }, { a: '2' })).toBe(true);
+    expect(versionsDiffer({ a: '1' }, {})).toBe(true);
+  });
+});
+
+describe('backendNeedsDeploy', () => {
+  it('redeploys when there is no parent commit', () => {
+    expect(backendNeedsDeploy({ parentRef: null })).toBe(true);
+  });
+
+  it('redeploys when amplify/ paths change', () => {
+    expect(
+      backendNeedsDeploy({
+        parentRef: 'PARENT',
+        changedPaths: ['amplify/backend.ts', 'src/app/page.tsx'],
+      }),
+    ).toBe(true);
+  });
+
+  it('skips when only frontend paths change', () => {
+    expect(
+      backendNeedsDeploy({
+        parentRef: 'PARENT',
+        changedPaths: ['src/app/page.tsx', 'docs/CI-AND-DEPLOYMENT.md'],
+      }),
+    ).toBe(false);
+  });
+
+  it('redeploys when Amplify deps change in package.json', () => {
+    expect(
+      backendNeedsDeploy({
+        parentRef: 'PARENT',
+        changedPaths: ['package.json'],
+        headPkg: {
+          dependencies: { 'aws-amplify': '6.2.0' },
+        },
+        parentPkg: {
+          dependencies: { 'aws-amplify': '6.1.0' },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('skips when package files change but only non-backend deps', () => {
+    expect(
+      backendNeedsDeploy({
+        parentRef: 'PARENT',
+        changedPaths: ['package.json', 'package-lock.json'],
+        headPkg: {
+          dependencies: { next: '16.1.0', 'aws-amplify': '6.1.0' },
+        },
+        parentPkg: {
+          dependencies: { next: '16.0.0', 'aws-amplify': '6.1.0' },
+        },
+        headLock: {
+          packages: {
+            'node_modules/next': { version: '16.1.0' },
+            'node_modules/aws-amplify': { version: '6.1.0' },
+          },
+        },
+        parentLock: {
+          packages: {
+            'node_modules/next': { version: '16.0.0' },
+            'node_modules/aws-amplify': { version: '6.1.0' },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('redeploys when lockfile Amplify package versions change', () => {
+    expect(
+      packageFilesForceRedeploy({
+        headPkg: { dependencies: { 'aws-amplify': '^6.1.0' } },
+        parentPkg: { dependencies: { 'aws-amplify': '^6.1.0' } },
+        headLock: {
+          packages: { 'node_modules/aws-amplify': { version: '6.1.1' } },
+        },
+        parentLock: {
+          packages: { 'node_modules/aws-amplify': { version: '6.1.0' } },
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/scripts/amplify-backend-changed.ts
+++ b/scripts/amplify-backend-changed.ts
@@ -1,0 +1,220 @@
+/**
+ * Exit 0 when the Amplify Gen 2 backend should redeploy; exit 1 when
+ * frontend-only (generate outputs instead of pipeline-deploy).
+ *
+ * Triggers: amplify/**, or root package.json / package-lock.json changes
+ * to Amplify/CDK/@aws-sdk packages used by the backend.
+ */
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+/** Package names / prefixes that must force pipeline-deploy. */
+export const BACKEND_DEP_MATCHERS = [
+  /^@aws-amplify\//,
+  /^aws-amplify$/,
+  /^aws-cdk(-lib)?$/,
+  /^constructs$/,
+  /^@aws-sdk\//,
+];
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+type Lockfile = {
+  packages?: Record<string, { version?: string }>;
+};
+
+export type BackendNeedsDeployOptions = {
+  parentRef: string | null;
+  headRef?: string;
+  changedPaths?: string[];
+  headPkg?: PackageManifest | null;
+  parentPkg?: PackageManifest | null;
+  headLock?: Lockfile | null;
+  parentLock?: Lockfile | null;
+};
+
+export function isBackendDep(name: string): boolean {
+  return BACKEND_DEP_MATCHERS.some((re) => re.test(name));
+}
+
+export function relevantDepVersions(
+  pkg: PackageManifest,
+): Record<string, string> {
+  const all = {
+    ...(pkg.dependencies ?? {}),
+    ...(pkg.devDependencies ?? {}),
+    ...(pkg.optionalDependencies ?? {}),
+  };
+  const out: Record<string, string> = {};
+  for (const [name, version] of Object.entries(all)) {
+    if (isBackendDep(name)) out[name] = version;
+  }
+  return out;
+}
+
+export function relevantLockVersions(
+  lock: Lockfile,
+): Record<string, string | null> {
+  const packages = lock.packages ?? {};
+  const out: Record<string, string | null> = {};
+  for (const [key, meta] of Object.entries(packages)) {
+    if (!key.startsWith('node_modules/')) continue;
+    const name = key.slice('node_modules/'.length);
+    // Skip nested deps under another package's node_modules.
+    if (name.includes('/node_modules/')) continue;
+    if (!isBackendDep(name)) continue;
+    out[name] = meta.version ?? null;
+  }
+  return out;
+}
+
+export function versionsDiffer(
+  a: Record<string, string | null>,
+  b: Record<string, string | null>,
+): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (a[key] !== b[key]) return true;
+  }
+  return false;
+}
+
+function git(
+  args: string[],
+  { allowFailure = false }: { allowFailure?: boolean } = {},
+): string | null {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (allowFailure) return null;
+    throw error;
+  }
+}
+
+export function ensureParentCommit(): string | null {
+  const parent = git(['rev-parse', '--verify', 'HEAD^'], { allowFailure: true });
+  if (parent) return parent;
+
+  const shallow = git(['rev-parse', '--is-shallow-repository'], {
+    allowFailure: true,
+  });
+  if (shallow === 'true') {
+    git(['fetch', '--deepen', '2']);
+  }
+
+  return git(['rev-parse', '--verify', 'HEAD^'], { allowFailure: true });
+}
+
+function showJson(ref: string, file: string): unknown {
+  const raw = git(['show', `${ref}:${file}`], { allowFailure: true });
+  if (raw == null || raw === '') return null;
+  return JSON.parse(raw) as unknown;
+}
+
+export function packageFilesForceRedeploy({
+  headPkg,
+  parentPkg,
+  headLock,
+  parentLock,
+}: {
+  headPkg?: PackageManifest | null;
+  parentPkg?: PackageManifest | null;
+  headLock?: Lockfile | null;
+  parentLock?: Lockfile | null;
+}): boolean {
+  if (
+    headPkg &&
+    parentPkg &&
+    versionsDiffer(relevantDepVersions(headPkg), relevantDepVersions(parentPkg))
+  ) {
+    return true;
+  }
+  if (
+    headLock &&
+    parentLock &&
+    versionsDiffer(
+      relevantLockVersions(headLock),
+      relevantLockVersions(parentLock),
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function backendNeedsDeploy({
+  parentRef,
+  headRef = 'HEAD',
+  changedPaths,
+  headPkg,
+  parentPkg,
+  headLock,
+  parentLock,
+}: BackendNeedsDeployOptions): boolean {
+  if (!parentRef) return true;
+
+  const paths =
+    changedPaths ??
+    (git(['diff', '--name-only', parentRef, headRef]) ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+  if (paths.some((p) => p === 'amplify' || p.startsWith('amplify/'))) {
+    return true;
+  }
+
+  const packageTouched = paths.some(
+    (p) => p === 'package.json' || p === 'package-lock.json',
+  );
+  if (!packageTouched) return false;
+
+  return packageFilesForceRedeploy({
+    headPkg:
+      headPkg ?? (showJson(headRef, 'package.json') as PackageManifest | null),
+    parentPkg:
+      parentPkg ??
+      (showJson(parentRef, 'package.json') as PackageManifest | null),
+    headLock:
+      headLock ?? (showJson(headRef, 'package-lock.json') as Lockfile | null),
+    parentLock:
+      parentLock ??
+      (showJson(parentRef, 'package-lock.json') as Lockfile | null),
+  });
+}
+
+function main(): void {
+  const parentRef = ensureParentCommit();
+  if (!parentRef) {
+    console.log(
+      'amplify-backend-changed: no parent commit; treating backend as changed',
+    );
+    process.exit(0);
+  }
+
+  const needsDeploy = backendNeedsDeploy({ parentRef });
+  if (needsDeploy) {
+    console.log('amplify-backend-changed: backend redeploy required');
+    process.exit(0);
+  }
+
+  console.log(
+    'amplify-backend-changed: backend unchanged; skip pipeline-deploy',
+  );
+  process.exit(1);
+}
+
+const entryPath = process.argv[1];
+const isDirectRun =
+  Boolean(entryPath) && import.meta.url === pathToFileURL(entryPath).href;
+
+if (isDirectRun) {
+  main();
+}


### PR DESCRIPTION
﻿## Summary
- Promote the CI/CD Amplify cost and PR speed work from develop to main (#136 / #138)
- Conditional backend deploy, Next build cache, Actions concurrency/path filters, and PR vs main build rules

## Test plan
- [ ] CI green on this PR
- [ ] After merge, confirm Amplify build on main behaves as documented (skip `pipeline-deploy` when backend unchanged)
- [ ] Human console checklist from #138 still applies (autobuild `main` only, etc.)
