### PR TITLE
Close Opportunity on terminal Application status

### DIFF
--- a/src/lib/job-os.test.ts
+++ b/src/lib/job-os.test.ts
@@ -451,6 +451,87 @@ describe('Job OS facade — Applications', () => {
     expect(interviewing.event.toStatus).toBe('interviewing');
   });
 
+  it('closes the Opportunity when Application moves to withdrawn', async () => {
+    const { jobOs, store } = createTestJobOs();
+    const anon = await jobOs.ensureAnonEmployer();
+    const created = await jobOs.createOpportunity({
+      employerId: anon.id,
+      noticedAt: '2026-07-25T13:00:00.000Z',
+      title: 'Staff Engineer',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const pursued = await jobOs.pursueOpportunity(created.opportunity.id);
+    expect(pursued.status).toBe('pursued');
+    if (pursued.status !== 'pursued') {
+      return;
+    }
+
+    const interviewing = await jobOs.updateApplicationStatus(
+      pursued.application.id,
+      'interviewing',
+    );
+    expect(interviewing.status).toBe('updated');
+    if (interviewing.status !== 'updated') {
+      return;
+    }
+
+    const stillOpen = await store.getOpportunity(created.opportunity.id);
+    expect(stillOpen?.status).toBe('open');
+
+    const withdrawn = await jobOs.updateApplicationStatus(
+      pursued.application.id,
+      'withdrawn',
+    );
+    expect(withdrawn.status).toBe('updated');
+    if (withdrawn.status !== 'updated') {
+      return;
+    }
+    expect(withdrawn.application.status).toBe('withdrawn');
+
+    const opportunity = await store.getOpportunity(created.opportunity.id);
+    expect(opportunity?.status).toBe('closed');
+  });
+
+  it.each(['accepted', 'rejected'] as const)(
+    'closes the Opportunity when Application moves to %s',
+    async (toStatus) => {
+      const { jobOs, store } = createTestJobOs();
+      const anon = await jobOs.ensureAnonEmployer();
+      const created = await jobOs.createOpportunity({
+        employerId: anon.id,
+        noticedAt: '2026-07-25T14:00:00.000Z',
+        title: 'Staff Engineer',
+      });
+      expect(created.status).toBe('created');
+      if (created.status !== 'created') {
+        return;
+      }
+
+      const pursued = await jobOs.pursueOpportunity(created.opportunity.id);
+      expect(pursued.status).toBe('pursued');
+      if (pursued.status !== 'pursued') {
+        return;
+      }
+
+      const updated = await jobOs.updateApplicationStatus(
+        pursued.application.id,
+        toStatus,
+      );
+      expect(updated.status).toBe('updated');
+      if (updated.status !== 'updated') {
+        return;
+      }
+      expect(updated.application.status).toBe(toStatus);
+
+      const opportunity = await store.getOpportunity(created.opportunity.id);
+      expect(opportunity?.status).toBe('closed');
+    },
+  );
+
   it('rejects Pursue when Application persistence fails', async () => {
     const store = createMemoryJobOsStore();
     const bodies = createMemoryJobOsBodyStorage();

--- a/src/lib/job-os.ts
+++ b/src/lib/job-os.ts
@@ -107,6 +107,13 @@ export type CompensationDisclosure = (typeof COMPENSATION_DISCLOSURES)[number];
 export type ApplicationStatus = (typeof APPLICATION_STATUSES)[number];
 export type DecisionEventKind = (typeof DECISION_EVENT_KINDS)[number];
 
+/** Application outcomes that end pursuit of the listing — Opportunity closes. */
+export const APPLICATION_STATUSES_THAT_CLOSE_OPPORTUNITY = [
+  'accepted',
+  'rejected',
+  'withdrawn',
+] as const satisfies ReadonlyArray<ApplicationStatus>;
+
 export type BodyEntityKind =
   | 'employer'
   | 'opportunity'
@@ -1263,6 +1270,21 @@ export function createJobOs(deps: JobOsDeps) {
 
     const application: ApplicationRecord = { ...existing, status: toStatus };
     await deps.store.persistApplication(application);
+
+    if (
+      includesValue(APPLICATION_STATUSES_THAT_CLOSE_OPPORTUNITY, toStatus)
+    ) {
+      const opportunity = await deps.store.getOpportunity(
+        existing.opportunityId,
+      );
+      if (opportunity && opportunity.status !== 'closed') {
+        await deps.store.persistOpportunity({
+          ...opportunity,
+          status: 'closed',
+          contentUpdatedAt: now(),
+        });
+      }
+    }
 
     const event = await deps.store.appendDecisionEvent({
       id: createId(),


### PR DESCRIPTION
## Summary
- Close the linked Opportunity when an Application moves to `accepted`, `rejected`, or `withdrawn`
- `updateApplicationStatus` previously left Opportunity `open` after withdrawal (and other terminal outcomes)
- Adds regression coverage for withdrawn, accepted, and rejected

## Test plan
- [ ] Run `npx vitest run src/lib/job-os.test.ts`
- [ ] In Job OS, move an Application from interviewing to withdrawn and confirm the Opportunity shows closed
- [ ] Repeat for accepted and rejected
- [ ] Confirm intermediate statuses (e.g. interviewing) leave the Opportunity open
