### PR TITLE
Release: branching, sync, and release hygiene (v2.0.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,54 @@
+name: Task
+description: Feature, chore, or bug — shaped for triage and AFK agents
+title: ""
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill this in so triage can move the issue to `ready-for-agent` or `ready-for-human`.
+        See `docs/BRANCHING.md` and `docs/agents/triage-labels.md`.
+  - type: dropdown
+    id: work_type
+    attributes:
+      label: Type
+      options:
+        - Feature
+        - Bug
+        - Chore / docs
+        - Hotfix (prod)
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be true when this is done?
+      placeholder: e.g. Site Admin can close an Opportunity when an Application reaches a terminal status.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist the implementer (human or agent) must satisfy.
+      placeholder: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What this issue explicitly does not include.
+      placeholder: e.g. No Amplify staging branch; no UI redesign.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / pointers
+      description: Relevant paths, ADRs, screenshots, or related issues.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What changed and why. Link the issue: closes #N -->
+
+## Type
+
+<!-- Feature | Bugfix | Hotfix | Release | Chore -->
+
+## Base branch
+
+<!-- develop (default) | main (hotfix / release only) -->
+
+## Test plan
+
+- [ ] CI green
+- [ ] <!-- Manual / local checks if any -->
+
+## Notes
+
+<!-- Risk, follow-ups, Amplify/backend impact -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -20,6 +21,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: monthly
     open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '.cursor/**'
       - '.agents/**'
   push:
-    branches: [main]
+    branches: [main, develop]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,78 @@
+# Keep develop aligned with main after squash merges / hotfixes.
+# Same tree → reset develop to main. Different tree → rebase develop onto main.
+# See docs/BRANCHING.md.
+name: Sync develop from main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-develop
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Align develop with main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main
+          if ! git rev-parse --verify origin/develop >/dev/null 2>&1; then
+            git branch develop origin/main
+            git push -u origin develop
+            echo "Created develop from main."
+            exit 0
+          fi
+          git fetch origin develop
+
+          if [ "$(git rev-parse origin/main)" = "$(git rev-parse origin/develop)" ]; then
+            echo "develop already matches main."
+            exit 0
+          fi
+
+          if git diff --quiet origin/main origin/develop; then
+            echo "Trees match; resetting develop to main."
+            git checkout -B develop origin/main
+            git push --force-with-lease origin develop
+            exit 0
+          fi
+
+          echo "Trees differ; rebasing develop onto main."
+          git checkout -B develop origin/develop
+          if git rebase origin/main; then
+            git push --force-with-lease origin develop
+            exit 0
+          fi
+
+          git rebase --abort || true
+          BODY="$(printf '%s\n' \
+            'Automatic sync of \`develop\` onto \`main\` failed (rebase conflict).' \
+            '' \
+            "Main: \`$(git rev-parse --short origin/main)\`" \
+            "Develop: \`$(git rev-parse --short origin/develop)\`" \
+            '' \
+            'Resolve locally, then push \`develop\`, or reset \`develop\` to \`main\` if the release already included all develop work. See \`docs/BRANCHING.md\`.' \
+            '' \
+            "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")"
+          gh issue create \
+            --title "Sync develop from main failed" \
+            --label "ready-for-human" \
+            --body "$BODY"
+          echo "Opened ready-for-human issue after rebase conflict."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,7 @@ Five canonical roles mapped to matching GitHub label strings (`needs-triage`, `n
 ### Domain docs
 
 Single-context layout — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Branching
+
+Feature work targets **`develop`**; production is **`main`**; hotfixes branch from `main`. See `docs/BRANCHING.md` and `docs/RELEASES.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning follows [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Branching model (`develop` / `main`, hotfixes) and `sync-develop` workflow
+- Issue form and pull request template
+- Release hygiene docs (semver tags + GitHub Releases)
+
+### Changed
+
+- CI runs on pushes to `develop` as well as `main`
+- Dependabot PRs target `develop`
+
+## [2.0.0] - 2026-08-06
+
+Baseline release of the personal site and Job OS as deployed on `main` at tag `v2.0.0`.
+
+[Unreleased]: https://github.com/hashadar/hashadar_website/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/hashadar/hashadar_website/releases/tag/v2.0.0

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,113 @@
+# Branching, releases, and hotfixes
+
+Linear history via **squash-only** merges. Long-lived branches: `develop` (integration) and `main` (production).
+
+## Branch roles
+
+| Branch | Role | Deploy |
+|--------|------|--------|
+| `main` | Production | AWS Amplify only |
+| `develop` | Default integration | No Amplify branch in the baseline setup |
+| `feature/*`, `cursor/*` | Day-to-day work | None |
+| `hotfix/*` | Prod fixes | None until merged to `main` |
+
+Default GitHub branch stays `main`. **Day-to-day PRs target `develop`.**
+
+## Merge style
+
+Repository setting: **allow squash merging only** (disable merge commits and rebase-and-merge). Enable **delete branch on merge**.
+
+| PR | Squash commit title |
+|----|---------------------|
+| Feature → `develop` | Meaningful summary (issue/PR title) |
+| `develop` → `main` | `Release: …` (`vX.Y.Z`) |
+| `hotfix/*` → `main` | `Hotfix: …` (`vX.Y.Z`) |
+
+## Normal flow
+
+1. Branch from **`develop`**.
+2. Open PR → **`develop`** (CI must pass). Prefer `closes #N` in the body.
+3. Squash-merge into `develop`.
+
+## Release flow (`develop` → `main`)
+
+1. Open PR **`develop` → `main`** when ready to ship.
+2. Squash-merge as `Release: …`.
+3. Amplify deploys from `main`.
+4. Cut the GitHub Release / tag (see [RELEASES.md](./RELEASES.md)).
+5. **Sync workflow** aligns `develop` to `main` (see below). Do not merge `main` back into `develop` by hand.
+
+## Hotfix flow
+
+1. Branch `hotfix/…` from **`main`** (not from `develop`).
+2. PR → **`main`** (CI must pass).
+3. Squash-merge; Amplify deploys.
+4. Cut a patch release tag (e.g. `v2.0.1`).
+5. Sync workflow brings the fix onto `develop`.
+
+Never land a prod hotfix on `develop` first.
+
+## Sync: `main` → `develop`
+
+Workflow: `.github/workflows/sync-develop.yml` (runs on every push to `main`).
+
+Because releases are **squashed**, commit graphs diverge even when trees match. The job:
+
+1. If `develop` and `main` have the **same tree** → reset `develop` to `main` (`--force-with-lease`).
+2. If `develop` has **different content** (unreleased work) → rebase `develop` onto `main` and force-with-lease.
+3. If rebase conflicts → open a `ready-for-human` issue; do not push a broken sync.
+
+### After a sync (local clones)
+
+```bash
+git fetch origin
+git checkout develop
+git reset --hard origin/develop
+```
+
+Rebase any open feature branches onto the updated `develop`.
+
+## Agent / cloud base branches
+
+| Work | Base branch | PR target |
+|------|-------------|-----------|
+| Feature / chore / docs | `develop` | `develop` |
+| Prod hotfix | `main` | `main` |
+| Cut a release | open PR `develop` → `main` | `main` |
+
+## Dependabot
+
+Dependabot PRs target **`develop`** (see `.github/dependabot.yml`).
+
+## Owner checklist (GitHub UI)
+
+Agents cannot always apply these. Do once after this model lands:
+
+1. **Settings → General → Pull Requests**
+   - Allow squash merging only
+   - Delete head branches on merge
+2. **Settings → Rules → Rulesets** (or classic branch protection)
+   - **`main`:** PRs required; CI `quality` required; restrict pushes; allow PR heads from `develop` and `hotfix/*` where the UI supports it; no force-push
+   - **`develop`:** PRs required; CI `quality` required; allow force-push for `github-actions[bot]` (sync workflow) or bypass for Actions
+3. **Projects:** one board with columns matching triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`)
+4. **Milestones (optional):** e.g. “Next release”
+
+## Jira → GitHub (thin mapping)
+
+| Jira-ish idea | Here |
+|---------------|------|
+| Backlog item | GitHub Issue |
+| Status | Triage labels + Project columns |
+| In progress | Open PR linked to the issue |
+| Epic / theme | Milestone (or a parent issue) |
+| Release | `develop` → `main` + semver tag |
+| Sprint / points | Not used |
+
+See [agents/triage-labels.md](./agents/triage-labels.md) and [agents/issue-tracker.md](./agents/issue-tracker.md).
+
+## Related
+
+- [RELEASES.md](./RELEASES.md) — tags and GitHub Releases
+- [CI-AND-DEPLOYMENT.md](./CI-AND-DEPLOYMENT.md) — Actions vs Amplify
+- `.github/workflows/sync-develop.yml`
+- `.github/workflows/ci.yml`

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -5,8 +5,9 @@
 | Concern | Where | Notes |
 |---------|--------|--------|
 | **PR checks** | [GitHub Actions](https://docs.github.com/en/actions) | Workflow: `.github/workflows/ci.yml` — `npm ci`, production `npm audit` (critical), lint, typecheck, tests. **No `next build` on PRs.** Does not deploy. Does not require live AWS or `amplify_outputs.json`. |
+| **Push to `develop`** | GitHub Actions | Same quality suite as PRs (no `next build`). Still does not deploy. |
 | **Push to `main`** | GitHub Actions | Same quality suite **plus** `next build` as a cheap safety net. Still does not deploy. |
-| **Production build and deploy** | **AWS Amplify** autobuild | On push to connected branches: runs `amplify.yml` (conditional Gen 2 `ampx pipeline-deploy` or `ampx generate outputs`, reuse or `npm ci`, `npm run build`), publishes `.next`. **This is the only CD path** unless the team explicitly changes strategy. |
+| **Production build and deploy** | **AWS Amplify** autobuild | On push to connected branches: runs `amplify.yml` (conditional Gen 2 `ampx pipeline-deploy` or `ampx generate outputs`, reuse or `npm ci`, `npm run build`), publishes `.next`. **This is the only CD path** unless the team explicitly changes strategy. Prefer **`main` only** for Amplify autobuild. |
 
 There is **no accidental double-deploy** from GitHub Actions: Actions do not push artefacts or run Amplify CLI deploy in the baseline setup.
 
@@ -60,9 +61,16 @@ Contract tests in `amplify.yml.test.ts` lock the gated Gen 2 deploy / generate-o
 
 If `nvm use 22` fails on the build image (version not installed), add a line before it: `nvm install 22` (then keep `nvm use 22`).
 
+## Branching and releases
+
+- Day-to-day integration branch: **`develop`**. Production: **`main`**.
+- Squash-only merges; hotfixes branch from `main`. Details: [BRANCHING.md](./BRANCHING.md).
+- After every push to `main`, `.github/workflows/sync-develop.yml` resets or rebases `develop` onto `main` (force-with-lease).
+- Semver tags + GitHub Releases: [RELEASES.md](./RELEASES.md).
+
 ## Dependency updates
 
-- **Dependabot**: `.github/dependabot.yml` opens weekly npm PRs (grouped production patches and Amplify-related packages) and monthly GitHub Actions PRs.
+- **Dependabot**: `.github/dependabot.yml` opens weekly npm PRs (grouped production patches and Amplify-related packages) and monthly GitHub Actions PRs, targeting **`develop`**.
 - **CI audit gate**: `npm audit --omit=dev --audit-level=critical` fails the quality job on production criticals.
 - Photos stay on `images.unoptimized: true` without a direct `sharp` dependency until an image CDN / optimisation pipeline is added.
 - **Amplify OpenTelemetry `npm ls` warnings:** Nested `@aws-amplify/data-construct` / `graphql-api-construct` trees still report `invalid` peer ranges for `@opentelemetry/core` (mixed `2.0.0` / `2.8.0` / `2.9.0`). Root `overrides` did not unify that tree and were removed; install, typecheck, and `ampx` still succeed. Treat remaining `npm ls` noise as an upstream Amplify limitation until those packages align their OTEL peers.
@@ -77,19 +85,25 @@ GitHub Actions builds without `amplify_outputs.json`. Public blog/portfolio read
 
 ## Branch protection (repository owner)
 
-After CI is merged and green on `main`:
+Full squash / ruleset / sync-bot checklist: [BRANCHING.md — Owner checklist](./BRANCHING.md#owner-checklist-github-ui).
 
-1. GitHub → **Settings** → **Rules** (rulesets) or **Branches** → branch protection for `main`.
+Minimum after CI is green:
+
+1. GitHub → **Settings** → **Rules** (rulesets) or **Branches** → protect `main` and `develop`.
 2. Require the **CI** workflow (job `quality` / check name as shown on PRs) to pass before merge.
+3. Allow `github-actions[bot]` to force-push **`develop`** for the sync workflow.
 
 AI agents cannot apply this in the UI; use the checklist above.
 
 ## Related
 
+- [BRANCHING.md](./BRANCHING.md) — `develop` / `main`, hotfixes, sync
+- [RELEASES.md](./RELEASES.md) — semver tags and GitHub Releases
 - `amplify.yml` — Amplify build phases
 - `scripts/amplify-backend-changed.ts` — backend redeploy gate
 - `.github/workflows/ci.yml` — GitHub Actions quality checks
-- `.github/dependabot.yml` — weekly npm / monthly Actions update PRs
+- `.github/workflows/sync-develop.yml` — align `develop` after `main` updates
+- `.github/dependabot.yml` — weekly npm / monthly Actions update PRs → `develop`
 - [docs/adr/0003-site-content-and-admin.md](./adr/0003-site-content-and-admin.md) — Site Content + Admin vs Labs
 - [#113](https://github.com/hashadar/hashadar_website/issues/113) — re-enable Next image optimisation with sharp
 - [#136](https://github.com/hashadar/hashadar_website/issues/136) — CI/CD speed and Amplify cost (**shipped** via PRs [#138](https://github.com/hashadar/hashadar_website/pull/138)/[#139](https://github.com/hashadar/hashadar_website/pull/139); remaining Amplify console checklist above is still human-owned)

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,56 @@
+# Releases
+
+Light hygiene only: **semver tags** on `main` plus **GitHub Releases**. Amplify remains the deploy mechanism; tags label what is in production.
+
+## Versioning
+
+- Semver: `MAJOR.MINOR.PATCH` (`v2.0.0` on GitHub tags).
+- `package.json` `version` should match the latest released tag (no leading `v`).
+- Baseline: **v2.0.0** — website / Job OS line as of the initial tag on `main`.
+
+| Change on `main` | Bump |
+|------------------|------|
+| `develop` → `main` with user-facing or substantial work | `MINOR` (or `MAJOR` if you intentionally break a published contract) |
+| Hotfix | `PATCH` |
+| Process/docs-only release | `PATCH` is fine |
+
+No conventional-commit enforcement and no semantic-release bot in the baseline setup.
+
+## Cut a release (after squash-merge to `main`)
+
+From a machine with `gh` auth (or use the GitHub UI):
+
+```bash
+# On main, up to date with origin
+git checkout main
+git pull origin main
+
+VERSION=2.0.1   # no leading v — adjust as needed
+npm pkg set version="$VERSION"   # if not already bumped on the release PR
+git add package.json
+git commit -m "chore: bump version to $VERSION"   # only if you bumped here
+# Prefer bumping package.json on the Release / hotfix PR before merge when possible.
+
+git tag -a "v$VERSION" -m "v$VERSION"
+git push origin "v$VERSION"
+
+gh release create "v$VERSION" --title "v$VERSION" --generate-notes --target main
+```
+
+Update [CHANGELOG.md](../CHANGELOG.md): move `[Unreleased]` notes under `[X.Y.Z]` with the date.
+
+The sync workflow will align `develop` after the push to `main` (including a version-bump commit if you made one on `main`).
+
+## Hotfix releases
+
+Same tagging steps after the hotfix squash lands on `main`. Use the next `PATCH`.
+
+## Changelog
+
+[CHANGELOG.md](../CHANGELOG.md) follows a simple Keep a Changelog layout. Keep entries short; link issues/PRs when useful.
+
+## Out of scope (deliberately)
+
+- Release branches other than `hotfix/*`
+- Automatic changelog from commit messages
+- Publishing npm packages

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,6 +2,18 @@
 
 Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
 
+Prefer the **Task** issue form (`.github/ISSUE_TEMPLATE/task.yml`) so acceptance criteria are present before `ready-for-agent`.
+
+## Branch targets for implementation
+
+| Work | Base / PR target |
+|------|------------------|
+| Normal implementation | `develop` |
+| Production hotfix | `main` (`hotfix/*` branch) |
+| Ship to production | PR `develop` → `main`, then tag (see `docs/RELEASES.md`) |
+
+Do not open feature PRs against `main`. Details: `docs/BRANCHING.md`.
+
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hashadar_website",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Promote `develop` into production: branching model (`develop` / `main` + hotfixes), `sync-develop` workflow, Dependabot → `develop`, issue/PR templates, and light semver release docs.

Baseline prod tag remains [v2.0.0](https://github.com/hashadar/hashadar_website/releases/tag/v2.0.0). This release is the process/hygiene follow-up.

## After squash-merge

1. Confirm Amplify deploy from `main` succeeds.
2. Confirm **Sync develop from main** Actions run succeeds (or opens a `ready-for-human` issue).
3. Cut **v2.0.1** per `docs/RELEASES.md`:

```bash
git checkout main && git pull origin main
git tag -a v2.0.1 -m "v2.0.1"
git push origin v2.0.1
gh release create v2.0.1 --title "v2.0.1" --generate-notes --target main
```

Note: `package.json` on this PR is still `2.0.0` (set when hygiene landed on `develop`). Bump to `2.0.1` on `develop` in a small follow-up if you want the file to match the tag.

## Project board

Triage board: https://github.com/users/hashadar/projects/3

## Test plan

- [ ] CI green on this PR
- [ ] Squash-merge as `Release: branching, sync, and release hygiene (v2.0.1)`
- [ ] Amplify prod deploy OK
- [ ] `sync-develop` OK
- [ ] Tag / GitHub Release `v2.0.1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd885-196a-78dd-b0db-d9dc9db34b83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd885-196a-78dd-b0db-d9dc9db34b83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

