### PR TITLE
Bump the amplify-backend group with 6 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "hashadar_website",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hashadar_website",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1104.0",
         "@fontsource/zalando-sans-expanded": "^5.2.1",
-        "aws-amplify": "^6.18.0",
+        "aws-amplify": "^6.20.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "framer-motion": "^12.23.24",
@@ -31,8 +31,8 @@
         "unified": "^11.0.4"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^1.23.0",
-        "@aws-amplify/backend-cli": "^1.8.3",
+        "@aws-amplify/backend": "^1.24.0",
+        "@aws-amplify/backend-cli": "^1.9.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.2.0",
@@ -42,10 +42,10 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4.3.4",
-        "aws-cdk": "^2.1130.0",
-        "aws-cdk-lib": "^2.261.0",
+        "aws-cdk": "^2.1135.0",
+        "aws-cdk-lib": "^2.263.0",
         "babel-plugin-react-compiler": "1.0.0",
-        "constructs": "^10.6.0",
+        "constructs": "^10.8.1",
         "esbuild": "^0.28.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.12",
@@ -493,12 +493,12 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.3.28",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.28.tgz",
-      "integrity": "sha512-Q6r3X9sfqUnIZS0RiG4q9pRtPXEO4iUDVN36uwo3g7qbT8MIx2AztJfYvP0B9RV6EfesYCDoD5suTs40SgRnJA==",
+      "version": "6.3.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.29.tgz",
+      "integrity": "sha512-4LJv/toJYuZ2nsnhkS7yOc6iKtgpcBKzZzC1p4hlwkVVehSzEIuhZUflvaigBR4Y3MoH9SBbeOCzjssxYvhBGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.8.9",
+        "@aws-amplify/api-graphql": "4.8.10",
         "@aws-amplify/api-rest": "4.6.4",
         "@aws-amplify/data-schema": "^1.7.0",
         "rxjs": "^7.8.1",
@@ -509,13 +509,13 @@
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.8.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.8.9.tgz",
-      "integrity": "sha512-vGYNxLrL+uaUpWJ9vWVkRJfsB75cvg4eb1aBS/vscfGY5XtkR/yePhR5u4qi/2qLSTjFc2KDkoXupmt6izi/rA==",
+      "version": "4.8.10",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.8.10.tgz",
+      "integrity": "sha512-gUk1AF8NOulV4RF91IAdfACqg77iASFZkH+68/7wQ2q8fwaPrW7W/popFWFIa/786hCyQMyo1ZR1gKjdyDiTRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/api-rest": "4.6.4",
-        "@aws-amplify/core": "6.17.0",
+        "@aws-amplify/core": "6.18.0",
         "@aws-amplify/data-schema": "^1.7.0",
         "@aws-sdk/types": "^3.973.6",
         "graphql": "15.8.0",
@@ -585,23 +585,23 @@
       }
     },
     "node_modules/@aws-amplify/backend": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.23.0.tgz",
-      "integrity": "sha512-gW/TnDtQ64LXSfR6+NsTdnyN+EAo+znZ/X/1L482JVbWE6VNTVy5UvM4YkJXCgSfQpbHuhd1Q7OSwdQKoqyJIg==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.24.0.tgz",
+      "integrity": "sha512-jkm/5Zc+Akr/rUVxOjxI7gX3/2C1D+MKlIudZrMa6+9k/HO6IXBUswfqb7GpaDUCQCaVHpDkbAxzz6IimouvEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.9.4",
-        "@aws-amplify/backend-data": "^1.7.0",
-        "@aws-amplify/backend-function": "^1.18.1",
+        "@aws-amplify/backend-data": "^1.8.0",
+        "@aws-amplify/backend-function": "^1.18.2",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/backend-secret": "^1.4.2",
         "@aws-amplify/backend-storage": "^1.5.0",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/data-schema": "^1.13.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-amplify": "^3.936.0"
       },
       "peerDependencies": {
@@ -627,26 +627,26 @@
       }
     },
     "node_modules/@aws-amplify/backend-cli": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.8.3.tgz",
-      "integrity": "sha512-xd294zC7znO9aHlUK04+HBpjXGWupVIKcGmaxxODzixNgnhbfwL7gYLwfb1R4BvLwEbfzw3KoG1g2o7inVRObA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.9.0.tgz",
+      "integrity": "sha512-vy1RqB8Bdqy42yWI02StfqGvBqZd7DoFHhj2Y5xtj9VEcgnlEFsuXRimK4bKMflU3s7ieaOuHzLc1Owufiqv7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.7",
+        "@aws-amplify/backend-deployer": "^2.2.0",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.5",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/cli-core": "^2.2.6",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/form-generator": "^1.2.7",
-        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/model-generator": "^1.2.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
-        "@aws-amplify/sandbox": "^2.2.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
+        "@aws-amplify/sandbox": "^2.3.0",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.936.0",
-        "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudformation": "^3.1078.0",
         "@aws-sdk/client-s3": "^3.936.0",
         "@aws-sdk/client-sts": "^3.936.0",
         "@aws-sdk/credential-provider-ini": "^3.936.0",
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/@aws-amplify/backend-data": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.7.0.tgz",
-      "integrity": "sha512-u8fDN7a2BOxqmDSlgQgTfgsjXuLU7HOhP8yZp2zAJhFXY2vQAWAZK4XwTbjUUGJH2Anl1/w3qD0jnCb9OZv5WQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.8.0.tgz",
+      "integrity": "sha512-EUtKlrn+XittMvOy/MVN4y2dX+I4kUeedejVmQTwY7LipNrZepKckkjnfMHVODhnWVSvkki8HFDXBCvmkFDAnw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
-        "@aws-amplify/data-construct": "^1.15.1",
-        "@aws-amplify/data-schema-types": "^1.2.0",
+        "@aws-amplify/data-construct": "^1.17.7",
+        "@aws-amplify/data-schema-types": "^1.3.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "graphql": "^15.8.0"
       },
       "peerDependencies": {
@@ -698,15 +698,15 @@
       }
     },
     "node_modules/@aws-amplify/backend-deployer": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-deployer/-/backend-deployer-2.1.7.tgz",
-      "integrity": "sha512-OtVPxyQekxJ9k8cBSjl5YrHZkCG31RvCJcobIvr/XyXYSy5KGask1wJGXdqlDoVq5HvnraooxaP4gJIh3AXbgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-deployer/-/backend-deployer-2.2.0.tgz",
+      "integrity": "sha512-XdSaOZ5wlmmwVB/FCNu4KFiHB+3Ibc74TNL7ZflPKnt+OMdzfnTau+sa2vY7xSBFhLrOMLwVJtke8AQ3XNgSwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
-        "@aws-cdk/toolkit-lib": "1.19.0",
+        "@aws-amplify/plugin-types": "^1.12.2",
+        "@aws-cdk/toolkit-lib": "1.32.0",
         "execa": "^9.5.1",
         "minimatch": "10.2.3",
         "strip-ansi": "^7.1.0",
@@ -715,6 +715,83 @@
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
         "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.6.tgz",
+      "integrity": "sha512-lw+Z5JT4e5rAMMR8tvj2yKSIQTvlxpBeYMUjfSgpJ4RN9d94vF6CpnvPqq6LsfO37n6jw0ufQrDNrR8ZHWKkuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/@aws-cdk/toolkit-lib": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.32.0.tgz",
+      "integrity": "sha512-gZ/gWngRa3ZKwPOcw4zw2+NkJe73mG5XK1/FOEiz6yERJqI+s0QpXCnnOnsDr6l9o6w3Uexpfhd7wueho33hww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/cdk-assets-lib": "^1",
+        "@aws-cdk/cloud-assembly-api": "2.2.6",
+        "@aws-cdk/cloud-assembly-schema": ">=54.7.0",
+        "@aws-cdk/cloudformation-diff": "^2",
+        "@aws-cdk/cx-api": "^2",
+        "@aws-sdk/client-appsync": "^3",
+        "@aws-sdk/client-bedrock-agentcore-control": "^3",
+        "@aws-sdk/client-cloudcontrol": "^3",
+        "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudwatch-logs": "^3",
+        "@aws-sdk/client-codebuild": "^3",
+        "@aws-sdk/client-ec2": "^3",
+        "@aws-sdk/client-ecr": "^3",
+        "@aws-sdk/client-ecs": "^3",
+        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
+        "@aws-sdk/client-iam": "^3",
+        "@aws-sdk/client-kms": "^3",
+        "@aws-sdk/client-lambda": "^3",
+        "@aws-sdk/client-route-53": "^3",
+        "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/client-secrets-manager": "^3",
+        "@aws-sdk/client-sfn": "^3",
+        "@aws-sdk/client-ssm": "^3",
+        "@aws-sdk/client-sts": "^3",
+        "@aws-sdk/credential-providers": "^3",
+        "@aws-sdk/ec2-metadata-service": "^3",
+        "@aws-sdk/lib-storage": "^3",
+        "@smithy/middleware-endpoint": "^4",
+        "@smithy/property-provider": "^4",
+        "@smithy/shared-ini-file-loader": "^4",
+        "@smithy/util-retry": "^4",
+        "@smithy/util-waiter": "^4",
+        "cdk-from-cfn": "^0.304.0",
+        "chalk": "^4",
+        "chokidar": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11",
+        "p-limit": "^3",
+        "picomatch": "^4",
+        "semver": "^7.8.4",
+        "split2": "^4.2.0",
+        "wrap-ansi": "^7",
+        "yaml": "^1",
+        "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cli-plugin-contract": "^2"
       }
     },
     "node_modules/@aws-amplify/backend-deployer/node_modules/@esbuild/aix-ppc64": {
@@ -1159,6 +1236,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/cdk-from-cfn": {
+      "version": "0.304.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.304.0.tgz",
+      "integrity": "sha512-OLw/T42SqnlU3DERX0R1e9R/VaLVDuMwKAFONm9nzIineHANqnXRg9u83FAyEzaf9sOvN4qCCDlsjAp29WnTHw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@aws-amplify/backend-deployer/node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1201,6 +1302,34 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/@aws-amplify/backend-deployer/node_modules/tsx": {
       "version": "4.19.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
@@ -1221,16 +1350,67 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws-amplify/backend-deployer/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@aws-amplify/backend-function": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.18.1.tgz",
-      "integrity": "sha512-7BZdcDShy/5nADapmOs32unKpeNJwTTUjyHGQanjPzZqp2Kg/8VI+dl6sz+bfWphEn8RirFY367avWNjVj6kTQ==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.18.2.tgz",
+      "integrity": "sha512-0AQ4ozzn+pl0aw01B1osTZnW/ClfcJ4QwWkBfcxSbDhA0ygxRiK7L0SbbSOyXafh2aCdq4cW6VF1lMO7mKmnSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-s3": "^3.936.0",
         "execa": "^9.5.1"
       },
@@ -1293,14 +1473,14 @@
       }
     },
     "node_modules/@aws-amplify/cli-core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cli-core/-/cli-core-2.2.5.tgz",
-      "integrity": "sha512-nddjsjbtuUD38R1tfPKqK/gKX9ZkPlDdA96iCewgj8OF/t7Gmj/rdFEVoqij/gV41DlTul+IxRyu2hPigVva+g==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cli-core/-/cli-core-2.2.6.tgz",
+      "integrity": "sha512-0zYNXSGIItymz6IsvP8OpAyoYrXaXef5L+Aae0UvZuzBqdlrCmFJ3UhB6ti98mf1POaI7BgBapdGBvJtwL0Okw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudformation": "^3.1078.0",
         "@inquirer/prompts": "^7.3.2",
         "@opentelemetry/api": "^1.9.0",
         "execa": "^9.5.1",
@@ -1313,17 +1493,17 @@
       }
     },
     "node_modules/@aws-amplify/client-config": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.10.2.tgz",
-      "integrity": "sha512-R71Y6pFJStIDm1PQ7tPPRpjKHZXHPIQzJCsQ4FB9CHUUG2YjazhS9sbyCDwmKz8RBuf0T8WAOYtMpErBRIA89A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.11.0.tgz",
+      "integrity": "sha512-vQDkcAxrPSFmkkzzalgZ1TDkcoSES08mMaD40eWsriNoV0i7cV3owtZK7Oy9KPLbWZfQuhttzOubwoqGfal9Uw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
-        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/model-generator": "^1.2.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "zod": "3.25.17"
       },
       "peerDependencies": {
@@ -1344,9 +1524,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.17.0.tgz",
-      "integrity": "sha512-Obp6Aeg3gv3haO7FI5eXeZfnqetB9reWEPba3NBrrbuOarvxpAZA3Nz4laE6y59eJatGnmwcu0MsvqBFQV7sEg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.18.0.tgz",
+      "integrity": "sha512-u1nuT1YAdGHr+0LZ4fsBwBfnSwTAAIMc6BgiDjVWaKxf1VvNhD+3PL9+FHRKfqhzY4PppEM3E/ecGH7mTDh6lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -4643,13 +4823,13 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.1.9.tgz",
-      "integrity": "sha512-5qH+93y4nsnttJzH4Oy6s5TQDox/5+1BYYQgS36mgj8i5A1desFTnBQzK/pbBqYjn7E0DfDyEV39C420/2LMoQ==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.1.10.tgz",
+      "integrity": "sha512-BZOmOcSolGuEit3eKIfAstTboVB83bzlztPXVujhN8PBDb/wRf7JSTbBo9pVaIsBUhjq/HVWSEISwsqiRYcQ0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api": "6.3.28",
-        "@aws-amplify/api-graphql": "4.8.9",
+        "@aws-amplify/api": "6.3.29",
+        "@aws-amplify/api-graphql": "4.8.10",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "^11.1.9",
@@ -8790,9 +8970,9 @@
       }
     },
     "node_modules/@aws-amplify/model-generator": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.2.3.tgz",
-      "integrity": "sha512-NqoSw8DROnrVpY8PutPx28JyQQTiNkeWDVlAMqtwoVK5Ay0qCjnYx/pQBRuk/gOHoJQD80/F+H/KWrmj5o9svQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.2.4.tgz",
+      "integrity": "sha512-IkizLD4r+4X4HDXesys59FJTUBCbfyUjI1N1ShTMa7jZOoIFLwtksc7FJ2O5j8ibgR6yICtKRnN99nxhoz96Qg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8801,7 +8981,7 @@
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-appsync": "^3.936.0",
         "@aws-sdk/client-s3": "^3.937.0",
         "@aws-sdk/credential-providers": "^3.936.0",
@@ -8814,9 +8994,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.94",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.94.tgz",
-      "integrity": "sha512-SFROWgXVWRoaO4vKXoQV/rDIS3gb7+LQT2W6HSpLsuVuNgHjvR1fUnOeGiZq0x3FhSJnHi9nlqZLtgQZ1aUYkQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.1.0.tgz",
+      "integrity": "sha512-3NpjCVUwV/9jvcl5WRBeK7vMDSgZgM3mo0vQ7m+qdlktqEhgT4qCiIHN1gJcEExuKjsTz0kRgpcmCypZsKWmGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.6",
@@ -8852,13 +9032,13 @@
       }
     },
     "node_modules/@aws-amplify/plugin-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.12.1.tgz",
-      "integrity": "sha512-EV1C56vWawHBwbOS2Klq5Nup7+1ul6UOdy6xH1ZctZugFehrIgqlx9D7t/Q5NOp7SUN3Bq9gvEx+Cz3W/AcpRA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.12.2.tgz",
+      "integrity": "sha512-ILaZgh/VTBX+k9q2wD+K+RYNqoYVRXoCGWks2z7Fly/nKvEsF8I1B58I2I9HNm5AuP/2UhMykzf6Q3v+SOqe1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/toolkit-lib": "1.19.0"
+        "@aws-cdk/toolkit-lib": "1.32.0"
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
@@ -8866,20 +9046,200 @@
         "constructs": "^10.0.0"
       }
     },
-    "node_modules/@aws-amplify/sandbox": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-2.2.1.tgz",
-      "integrity": "sha512-Cw3tvOzGhcHgJyBaJjnex02TwXsYWSrT/Bt35fc3vSNJhHxs9CLV7MHVkHuxYLCCWg8hfAwdnEeBrKb2WqihjQ==",
+    "node_modules/@aws-amplify/plugin-types/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.6.tgz",
+      "integrity": "sha512-lw+Z5JT4e5rAMMR8tvj2yKSIQTvlxpBeYMUjfSgpJ4RN9d94vF6CpnvPqq6LsfO37n6jw0ufQrDNrR8ZHWKkuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.7",
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/@aws-cdk/toolkit-lib": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.32.0.tgz",
+      "integrity": "sha512-gZ/gWngRa3ZKwPOcw4zw2+NkJe73mG5XK1/FOEiz6yERJqI+s0QpXCnnOnsDr6l9o6w3Uexpfhd7wueho33hww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/cdk-assets-lib": "^1",
+        "@aws-cdk/cloud-assembly-api": "2.2.6",
+        "@aws-cdk/cloud-assembly-schema": ">=54.7.0",
+        "@aws-cdk/cloudformation-diff": "^2",
+        "@aws-cdk/cx-api": "^2",
+        "@aws-sdk/client-appsync": "^3",
+        "@aws-sdk/client-bedrock-agentcore-control": "^3",
+        "@aws-sdk/client-cloudcontrol": "^3",
+        "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudwatch-logs": "^3",
+        "@aws-sdk/client-codebuild": "^3",
+        "@aws-sdk/client-ec2": "^3",
+        "@aws-sdk/client-ecr": "^3",
+        "@aws-sdk/client-ecs": "^3",
+        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
+        "@aws-sdk/client-iam": "^3",
+        "@aws-sdk/client-kms": "^3",
+        "@aws-sdk/client-lambda": "^3",
+        "@aws-sdk/client-route-53": "^3",
+        "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/client-secrets-manager": "^3",
+        "@aws-sdk/client-sfn": "^3",
+        "@aws-sdk/client-ssm": "^3",
+        "@aws-sdk/client-sts": "^3",
+        "@aws-sdk/credential-providers": "^3",
+        "@aws-sdk/ec2-metadata-service": "^3",
+        "@aws-sdk/lib-storage": "^3",
+        "@smithy/middleware-endpoint": "^4",
+        "@smithy/property-provider": "^4",
+        "@smithy/shared-ini-file-loader": "^4",
+        "@smithy/util-retry": "^4",
+        "@smithy/util-waiter": "^4",
+        "cdk-from-cfn": "^0.304.0",
+        "chalk": "^4",
+        "chokidar": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11",
+        "p-limit": "^3",
+        "picomatch": "^4",
+        "semver": "^7.8.4",
+        "split2": "^4.2.0",
+        "wrap-ansi": "^7",
+        "yaml": "^1",
+        "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cli-plugin-contract": "^2"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/cdk-from-cfn": {
+      "version": "0.304.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.304.0.tgz",
+      "integrity": "sha512-OLw/T42SqnlU3DERX0R1e9R/VaLVDuMwKAFONm9nzIineHANqnXRg9u83FAyEzaf9sOvN4qCCDlsjAp29WnTHw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@aws-amplify/plugin-types/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-amplify/sandbox": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-2.3.0.tgz",
+      "integrity": "sha512-Sdq9+S8C5j6uCOexJj/+ZVuwlFuj5GFCveNsxy5qadMGvTSVUK2sKcmSdtlUR5neHSlkYk/plrmaojlmCsWzcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/backend-deployer": "^2.2.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.5",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/cli-core": "^2.2.6",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",
@@ -14530,6 +14890,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14551,6 +14914,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14572,6 +14938,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14593,6 +14962,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14614,6 +14986,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14635,6 +15010,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17430,17 +17808,17 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.19.0.tgz",
-      "integrity": "sha512-8REKoYp7PtELJ8cRl/zWiUwNjFgR65XjCs/hxODEa32OG1T1+berj6k017CYkv4fjc43sK8if8YgonG3iLzfLw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.20.0.tgz",
+      "integrity": "sha512-VXf7IODV1Sil+DTGU7AFccFlD7VMg671o3s9frH/FSRr6/P9PjWydvdFUZFtbzlI0Ow0RT0/7O76kmIdEirPSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/analytics": "7.1.0",
-        "@aws-amplify/api": "6.3.28",
+        "@aws-amplify/api": "6.3.29",
         "@aws-amplify/auth": "6.20.0",
-        "@aws-amplify/core": "6.17.0",
-        "@aws-amplify/datastore": "5.1.9",
-        "@aws-amplify/notifications": "2.0.94",
+        "@aws-amplify/core": "6.18.0",
+        "@aws-amplify/datastore": "5.1.10",
+        "@aws-amplify/notifications": "2.1.0",
         "@aws-amplify/storage": "6.16.0",
         "tslib": "^2.5.0"
       }
@@ -17478,9 +17856,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1133.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
-      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
+      "version": "2.1135.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.0.tgz",
+      "integrity": "sha512-Vfz2kllheB+8y9audOtcw0qo0v6EnjxfO2pK7x6eSulHmD0GaAvkqrg6MF+20wxE2KTyuY1UDBzICO+nHUaFtA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17491,9 +17869,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.262.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
-      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
+      "version": "2.263.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
+      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -17515,7 +17893,7 @@
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.5.1-beta",
+        "@aws/cloudformation-validate": "1.6.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -17551,7 +17929,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.5.1-beta",
+      "version": "1.6.0-beta",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -17575,7 +17953,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17583,7 +17961,7 @@
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -18666,9 +19044,9 @@
       }
     },
     "node_modules/constructs": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.1.tgz",
-      "integrity": "sha512-ulK25Sg2Nv1jW+A9VeV7fu9GFN9KdVTNWdXMoapNRwqkQzSdToro/Tttk3Ak5BGI80NRA/d2nSzKnoZ27LizLw==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
+      "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -21549,9 +21927,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "11.1.15",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
-      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "version": "11.1.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
+      "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1104.0",
     "@fontsource/zalando-sans-expanded": "^5.2.1",
-    "aws-amplify": "^6.18.0",
+    "aws-amplify": "^6.20.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
     "framer-motion": "^12.23.24",
@@ -39,8 +39,8 @@
     "unified": "^11.0.4"
   },
   "devDependencies": {
-    "@aws-amplify/backend": "^1.23.0",
-    "@aws-amplify/backend-cli": "^1.8.3",
+    "@aws-amplify/backend": "^1.24.0",
+    "@aws-amplify/backend-cli": "^1.9.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.2.0",
@@ -50,10 +50,10 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.3.4",
-    "aws-cdk": "^2.1130.0",
-    "aws-cdk-lib": "^2.261.0",
+    "aws-cdk": "^2.1135.0",
+    "aws-cdk-lib": "^2.263.0",
     "babel-plugin-react-compiler": "1.0.0",
-    "constructs": "^10.6.0",
+    "constructs": "^10.8.1",
     "esbuild": "^0.28.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.12",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recreates Dependabot #146 on current `develop` after the force-sync left the original PR conflicting.

Same grouped bump:
- `@aws-amplify/backend` ^1.23.0 → ^1.24.0
- `@aws-amplify/backend-cli` ^1.8.3 → ^1.9.0
- `aws-amplify` ^6.18.0 → ^6.20.0
- `aws-cdk` ^2.1130.0 → ^2.1135.0
- `aws-cdk-lib` ^2.261.0 → ^2.263.0
- `constructs` ^10.6.0 → ^10.8.1

Closes #146 (superseded).

## Test plan

- [ ] CI `quality` green
- [ ] Squash-merge into `develop`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd885-196a-78dd-b0db-d9dc9db34b83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd885-196a-78dd-b0db-d9dc9db34b83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

