### PR TITLE
Remove leftover release docs and tidy docs index

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,11 @@
 
 ## Type
 
-<!-- Feature | Bugfix | Hotfix | Release | Chore -->
+<!-- Feature | Bugfix | Hotfix | Chore | Docs -->
 
 ## Base branch
 
-<!-- develop (default) | main (hotfix / release only) -->
+<!-- develop (default) | main (hotfix only) -->
 
 ## Test plan
 

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -67,7 +67,7 @@ jobs:
             "Main: \`$(git rev-parse --short origin/main)\`" \
             "Develop: \`$(git rev-parse --short origin/develop)\`" \
             '' \
-            'Resolve locally, then push \`develop\`, or reset \`develop\` to \`main\` if the release already included all develop work. See \`docs/BRANCHING.md\`.' \
+            'Resolve locally, then push \`develop\`, or reset \`develop\` to \`main\` if the promote already included all develop work. See \`docs/BRANCHING.md\`.' \
             '' \
             "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")"
           gh issue create \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Five canonical roles mapped to matching GitHub label strings (`needs-triage`, `n
 
 ### Domain docs
 
-Single-context layout — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+Multi-context — start at `CONTEXT-MAP.md`. See `docs/agents/domain.md`.
 
 ### Branching
 
-Feature work targets **`develop`**; production is **`main`**; hotfixes branch from `main`. See `docs/BRANCHING.md` and `docs/RELEASES.md`.
+Feature work targets **`develop`**; production is **`main`**; hotfixes branch from `main`. See `docs/BRANCHING.md`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ npm run build
 
 ## Docs
 
-- [CI and deployment](docs/CI-AND-DEPLOYMENT.md)
-- [Codebase conventions](docs/CODEBASE-CONVENTIONS.md)
-- Site domain language: `docs/site/CONTEXT.md`
-- Job OS domain language: `CONTEXT.md` + `docs/adr/`
+| Doc | Purpose |
+|-----|---------|
+| [CONTEXT-MAP.md](CONTEXT-MAP.md) | Domain contexts (Site, Job OS) |
+| [Codebase conventions](docs/CODEBASE-CONVENTIONS.md) | Imports, data layer, design system, Next.js |
+| [Branching](docs/BRANCHING.md) | `develop` / `main`, hotfixes, sync |
+| [CI and deployment](docs/CI-AND-DEPLOYMENT.md) | GitHub Actions + Amplify |
+| [AGENTS.md](AGENTS.md) | Agent entry: issues, triage, domain, branching |
+| `docs/adr/` | Architectural decisions |
+| `docs/research/` | Parked research notes (not product docs) |
+| `docs/agents/` | Issue tracker and triage label detail |

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,4 +1,4 @@
-# Branching, releases, and hotfixes
+# Branching and hotfixes
 
 Simple two-branch flow. Linear history via **squash-only** merges.
 
@@ -13,7 +13,7 @@ Simple two-branch flow. Linear history via **squash-only** merges.
 
 Default GitHub branch is **`main`**. Day-to-day PRs target **`develop`**.
 
-There is **no** intermediate `release/*` branch. When `develop` looks good, open a PR **`develop` → `main`**.
+When `develop` looks good, open a PR **`develop` → `main`**. There is no intermediate branch.
 
 ## Flow
 
@@ -26,8 +26,8 @@ There is **no** intermediate `release/*` branch. When `develop` looks good, open
 ### Promote to prod
 
 1. Open PR **`develop` → `main`**.
-2. Squash-merge as `Release: …`.
-3. Amplify deploys from `main` — that is the ship (no tags / GitHub Releases; see [RELEASES.md](./RELEASES.md)).
+2. Squash-merge.
+3. Amplify deploys from `main`.
 4. Sync workflow aligns `develop` to `main` (same tree after a full promote; see below).
 
 ### Hotfix
@@ -57,7 +57,7 @@ Squash merges rewrite history, so graphs diverge even when trees match. The job:
 
 1. If `develop` is missing → recreate from `main`.
 2. If trees match → reset `develop` to `main`.
-3. If `develop` has unreleased commits → rebase onto `main`.
+3. If `develop` has commits not yet on `main` → rebase onto `main`.
 4. If rebase conflicts → open a `ready-for-human` issue.
 
 After a sync locally:
@@ -74,7 +74,6 @@ Targets **`develop`** (see `.github/dependabot.yml`).
 
 ## Related
 
-- [RELEASES.md](./RELEASES.md) — why we skip tags / GitHub Releases
 - [CI-AND-DEPLOYMENT.md](./CI-AND-DEPLOYMENT.md) — Actions vs Amplify
 - `.github/workflows/sync-develop.yml`
 - `.github/workflows/ci.yml`

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -60,12 +60,11 @@ Contract tests in `amplify.yml.test.ts` lock the gated Gen 2 deploy / generate-o
 
 If `nvm use 22` fails on the build image (version not installed), add a line before it: `nvm install 22` (then keep `nvm use 22`).
 
-## Branching and releases
+## Branching
 
 - Day-to-day integration branch: **`develop`**. Production: **`main`**.
 - Squash-only merges; hotfixes branch from `main`. Details: [BRANCHING.md](./BRANCHING.md).
 - After every push to `main`, `.github/workflows/sync-develop.yml` resets or rebases `develop` onto `main` (force-with-lease).
-- No GitHub Releases / tags as ship process: [RELEASES.md](./RELEASES.md).
 
 ## Dependency updates
 
@@ -95,7 +94,6 @@ Minimum for CI:
 ## Related
 
 - [BRANCHING.md](./BRANCHING.md) — `develop` / `main`, hotfixes, sync
-- [RELEASES.md](./RELEASES.md) — why we skip tags / GitHub Releases
 - `amplify.yml` — Amplify build phases
 - `scripts/amplify-backend-changed.ts` — backend redeploy gate
 - `.github/workflows/ci.yml` — GitHub Actions quality checks

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,9 +1,0 @@
-# Releases
-
-This repo does **not** use GitHub Releases, semver tags, or a changelog as part of shipping.
-
-**Production ship** = squash-merge to `main` → Amplify deploys. That is the release.
-
-Existing tags (`v2.0.0`, `v2.0.1`, …) are historical only; do not create new ones unless you have a concrete reason.
-
-`package.json` `version` is informational and need not track every promote.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -10,7 +10,7 @@ Prefer the **Task** issue form (`.github/ISSUE_TEMPLATE/task.yml`) so acceptance
 |------|------------------|
 | Normal implementation | `develop` |
 | Production hotfix | `main` (`hotfix/*` branch) |
-| Ship to production | PR `develop` → `main` (Amplify deploys; no tag required) |
+| Ship to production | PR `develop` → `main` (Amplify deploys) |
 
 Do not open feature PRs against `main`. Details: `docs/BRANCHING.md`.
 


### PR DESCRIPTION
## Summary
- Delete `docs/RELEASES.md` and scrub remaining release language from branching, CI, agents, PR template, and sync-develop.
- Order the README docs index and point AGENTS at the multi-context map.

## Type
Docs

## Base branch
develop

## Test plan
- [ ] CI green
- [x] Spot-check README / BRANCHING / AGENTS links resolve

## Notes
Docs and workflow copy only; no Amplify/backend impact.