### PR TITLE
Link wiki product changelogs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run build
 
 | Doc | Purpose |
 |-----|---------|
-| [Wiki changelogs](https://github.com/hashadar/hashadar_website/wiki) | Product history (Site + per Lab) |
+| [Wiki changelogs](https://github.com/hashadar/hashadar_website/wiki) | Product changelogs (Site + per Lab), ASD-STE100 |
 | [CONTEXT-MAP.md](CONTEXT-MAP.md) | Domain contexts (Site, Job OS) |
 | [Codebase conventions](docs/CODEBASE-CONVENTIONS.md) | Imports, data layer, design system, Next.js |
 | [Branching](docs/BRANCHING.md) | `develop` / `main`, hotfixes, sync |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm run build
 
 | Doc | Purpose |
 |-----|---------|
+| [Wiki changelogs](https://github.com/hashadar/hashadar_website/wiki) | Product history (Site + per Lab) |
 | [CONTEXT-MAP.md](CONTEXT-MAP.md) | Domain contexts (Site, Job OS) |
 | [Codebase conventions](docs/CODEBASE-CONVENTIONS.md) | Imports, data layer, design system, Next.js |
 | [Branching](docs/BRANCHING.md) | `develop` / `main`, hotfixes, sync |


### PR DESCRIPTION
## Summary
- Point the README docs table at the wiki Home (Site + Job OS product changelogs).
- Wiki itself was rewritten separately: stale Job Signal Lab page removed; Site and Job OS changelogs seeded.

## Type
Docs

## Base branch
develop

## Test plan
- [x] CI green
- [x] Open https://github.com/hashadar/hashadar_website/wiki and confirm Site / Job OS pages

## Notes
Wiki content lives outside this repo (`*.wiki.git`); only the README link is in this PR.