### PR TITLE
Replace Overview stub with attention list UI (#171)

### DIFF
--- a/src/components/sections/labs/job-os/job-os-overview.test.tsx
+++ b/src/components/sections/labs/job-os/job-os-overview.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobOsOverview } from '@/components/sections/labs/job-os/job-os-overview';
+import { jobOs } from '@/data';
+import {
+  createJobOs,
+  createMemoryJobOsBodyStorage,
+  createMemoryJobOsStore,
+} from '@/lib/job-os';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createClient() {
+  return createJobOs({
+    store: createMemoryJobOsStore(),
+    bodies: createMemoryJobOsBodyStorage(),
+    now: () => '2026-08-01T12:00:00.000Z',
+    createId: (() => {
+      let n = 0;
+      return () => `ov-${++n}`;
+    })(),
+  });
+}
+
+describe('JobOsOverview', () => {
+  it('shows empty state with Opportunities link when there are no attention rows', async () => {
+    const jobOsClient = createClient();
+    render(<JobOsOverview jobOsClient={jobOsClient} />);
+
+    expect(
+      await screen.findByRole('heading', { name: jobOs.overview.heading }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(jobOs.overview.emptyList)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: jobOs.overview.emptyOpportunitiesCta }),
+    ).toHaveAttribute('href', '/labs/job-os/opportunities');
+  });
+
+  it('renders attention rows linking to Application detail', async () => {
+    const jobOsClient = createClient();
+    const employer = await jobOsClient.createEmployer({
+      name: 'Acme Analytics',
+      sizeTier: 'scaleup',
+      prestigeTier: 'mid',
+      sector: 'technology',
+    });
+    expect(employer.status).toBe('created');
+    if (employer.status !== 'created') {
+      return;
+    }
+
+    const opportunity = await jobOsClient.createOpportunity({
+      employerId: employer.employer.id,
+      noticedAt: '2026-07-20T09:00:00.000Z',
+      title: 'Senior data scientist',
+    });
+    expect(opportunity.status).toBe('created');
+    if (opportunity.status !== 'created') {
+      return;
+    }
+
+    const pursued = await jobOsClient.pursueOpportunity(
+      opportunity.opportunity.id,
+    );
+    expect(pursued.status).toBe('pursued');
+    if (pursued.status !== 'pursued') {
+      return;
+    }
+    await jobOsClient.updateTrackingNote(
+      pursued.application.id,
+      'Recruiter screen booked',
+    );
+
+    render(<JobOsOverview jobOsClient={jobOsClient} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme Analytics')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Senior data scientist')).toBeInTheDocument();
+    expect(
+      screen.getByText(jobOs.overview.statusOptions.researching),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Recruiter screen booked')).toBeInTheDocument();
+
+    const detailHref = `/labs/job-os/applications/${pursued.application.id}`;
+    expect(screen.getByRole('link', { name: 'Acme Analytics' })).toHaveAttribute(
+      'href',
+      detailHref,
+    );
+    expect(
+      screen.getByRole('link', { name: 'Senior data scientist' }),
+    ).toHaveAttribute('href', detailHref);
+  });
+});

--- a/src/components/sections/labs/job-os/job-os-overview.tsx
+++ b/src/components/sections/labs/job-os/job-os-overview.tsx
@@ -1,39 +1,156 @@
 'use client';
 
 import Link from 'next/link';
-import { Button, Heading, Text } from '@/components/ui';
+import { useEffect, useState } from 'react';
+import { Text } from '@/components/ui';
+import {
+  JobOsLedger,
+  JobOsLedgerCell,
+  JobOsLedgerRow,
+  JobOsPill,
+  JobOsWorkspaceIntro,
+} from '@/components/sections/labs/job-os/job-os-ledger';
 import { jobOs } from '@/data';
+import {
+  type JobOs,
+  type OverviewAttentionRow,
+  type OverviewAttentionStatus,
+} from '@/lib/job-os';
+import { getDefaultJobOs } from '@/lib/job-os-default';
 
-export function JobOsOverview() {
+export type JobOsOverviewProps = {
+  jobOsClient?: JobOs;
+};
+
+function statusPillTone(
+  status: OverviewAttentionStatus,
+): 'open' | 'pursuit' {
+  return status === 'researching' ? 'pursuit' : 'open';
+}
+
+export function JobOsOverview({ jobOsClient }: JobOsOverviewProps = {}) {
   const copy = jobOs.overview;
+  const [rows, setRows] = useState<OverviewAttentionRow[]>([]);
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>(
+    'loading',
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const resolved = jobOsClient ?? (await getDefaultJobOs());
+        if (cancelled) {
+          return;
+        }
+        const listed = await resolved.listOverviewAttention();
+        if (cancelled) {
+          return;
+        }
+        setRows(listed);
+        setLoadState('ready');
+      } catch {
+        if (!cancelled) {
+          setLoadState('error');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [jobOsClient]);
+
+  if (loadState === 'loading') {
+    return <Text variant="muted">{copy.loadingLabel}</Text>;
+  }
+  if (loadState === 'error') {
+    return <Text variant="muted">{copy.errorLabel}</Text>;
+  }
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Heading size="md" as="h2">
-          {copy.heading}
-        </Heading>
-        <Text variant="muted">{copy.description}</Text>
-      </div>
-      <div className="flex flex-wrap gap-3">
-        <Button href="/labs/job-os/employers" variant="primary" size="sm">
-          {copy.employersCta}
-        </Button>
-        <Button href="/labs/job-os/opportunities" variant="outline" size="sm">
-          {copy.opportunitiesCta}
-        </Button>
-        <Button href="/labs/job-os/applications" variant="outline" size="sm">
-          {copy.applicationsCta}
-        </Button>
-      </div>
-      <Text variant="muted">
-        <Link
-          href="/labs"
-          className="underline underline-offset-4 text-[var(--foreground)]"
-        >
-          Labs
-        </Link>
-      </Text>
+      <JobOsWorkspaceIntro
+        heading={copy.heading}
+        description={copy.description}
+      />
+
+      <JobOsLedger
+        caption={copy.heading}
+        columns={[
+          copy.columnEmployer,
+          copy.columnOpportunity,
+          copy.columnStatus,
+          copy.columnTracking,
+        ]}
+        isEmpty={rows.length === 0}
+        empty={
+          <>
+            {copy.emptyList}{' '}
+            <Link
+              href="/labs/job-os/opportunities"
+              className="underline underline-offset-4 text-[var(--foreground)]"
+            >
+              {copy.emptyOpportunitiesCta}
+            </Link>
+          </>
+        }
+      >
+        {rows.map((row) => {
+          const href = `/labs/job-os/applications/${row.applicationId}`;
+          const title =
+            row.opportunityTitle.trim() || copy.untitledOpportunityLabel;
+          const statusLabel =
+            copy.statusOptions[row.status] ?? row.status;
+          const statusTitle =
+            row.status === 'researching'
+              ? copy.statusHints.researching
+              : undefined;
+
+          return (
+            <JobOsLedgerRow key={row.applicationId}>
+              <JobOsLedgerCell>
+                <Link
+                  href={href}
+                  className="underline-offset-4 hover:underline"
+                >
+                  {row.employerName.trim() || copy.noTrackingNoteLabel}
+                </Link>
+              </JobOsLedgerCell>
+              <JobOsLedgerCell>
+                <Link
+                  href={href}
+                  className="font-medium underline-offset-4 hover:underline"
+                >
+                  {title}
+                </Link>
+              </JobOsLedgerCell>
+              <JobOsLedgerCell>
+                <Link href={href} title={statusTitle}>
+                  <JobOsPill tone={statusPillTone(row.status)}>
+                    {statusLabel}
+                  </JobOsPill>
+                </Link>
+              </JobOsLedgerCell>
+              <JobOsLedgerCell>
+                <Link
+                  href={href}
+                  className="block underline-offset-4 hover:underline"
+                >
+                  {row.trackingNote ? (
+                    <Text className="line-clamp-2 text-sm">
+                      {row.trackingNote}
+                    </Text>
+                  ) : (
+                    <span className="text-[var(--mono-500)]">
+                      {copy.noTrackingNoteLabel}
+                    </span>
+                  )}
+                </Link>
+              </JobOsLedgerCell>
+            </JobOsLedgerRow>
+          );
+        })}
+      </JobOsLedger>
     </div>
   );
 }

--- a/src/data/pages/job-os.json
+++ b/src/data/pages/job-os.json
@@ -83,10 +83,26 @@
   },
   "overview": {
     "heading": "Overview",
-    "description": "Start with Employers, capture Opportunities as they appear, then pursue or pass. Applications track pursuit state without overloading listing status.",
-    "employersCta": "Open Employers",
-    "opportunitiesCta": "Open Opportunities",
-    "applicationsCta": "Open Applications"
+    "description": "Active pursuits that need attention next, ordered by urgency.",
+    "loadingLabel": "Loading overview…",
+    "errorLabel": "Overview could not be loaded.",
+    "emptyList": "No active pursuits yet. Pursue an Opportunity to bring it here.",
+    "emptyOpportunitiesCta": "Open Opportunities",
+    "columnEmployer": "Employer",
+    "columnOpportunity": "Opportunity",
+    "columnStatus": "Status",
+    "columnTracking": "Tracking note",
+    "noTrackingNoteLabel": "—",
+    "untitledOpportunityLabel": "Untitled opportunity",
+    "statusOptions": {
+      "researching": "Researching (pre-apply)",
+      "applied": "Applied",
+      "interviewing": "Interviewing",
+      "offer": "Offer"
+    },
+    "statusHints": {
+      "researching": "Active pursuit before a formal application is submitted."
+    }
   },
   "employers": {
     "heading": "Employers",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -170,9 +170,25 @@ export interface JobOsPageData {
   overview: {
     heading: string;
     description: string;
-    employersCta: string;
-    opportunitiesCta: string;
-    applicationsCta: string;
+    loadingLabel: string;
+    errorLabel: string;
+    emptyList: string;
+    emptyOpportunitiesCta: string;
+    columnEmployer: string;
+    columnOpportunity: string;
+    columnStatus: string;
+    columnTracking: string;
+    noTrackingNoteLabel: string;
+    untitledOpportunityLabel: string;
+    statusOptions: {
+      researching: string;
+      applied: string;
+      interviewing: string;
+      offer: string;
+    };
+    statusHints: {
+      researching: string;
+    };
   };
   employers: Record<string, unknown> & {
     heading: string;

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -159,9 +159,37 @@ export function assertValidJobOsPage(data: unknown): void {
   const overview = requireRecord(page.overview, 'job-os.overview');
   requireString(overview, 'heading', 'job-os.overview');
   requireString(overview, 'description', 'job-os.overview');
-  requireString(overview, 'employersCta', 'job-os.overview');
-  requireString(overview, 'opportunitiesCta', 'job-os.overview');
-  requireString(overview, 'applicationsCta', 'job-os.overview');
+  requireString(overview, 'loadingLabel', 'job-os.overview');
+  requireString(overview, 'errorLabel', 'job-os.overview');
+  requireString(overview, 'emptyList', 'job-os.overview');
+  requireString(overview, 'emptyOpportunitiesCta', 'job-os.overview');
+  requireString(overview, 'columnEmployer', 'job-os.overview');
+  requireString(overview, 'columnOpportunity', 'job-os.overview');
+  requireString(overview, 'columnStatus', 'job-os.overview');
+  requireString(overview, 'columnTracking', 'job-os.overview');
+  requireString(overview, 'noTrackingNoteLabel', 'job-os.overview');
+  requireString(overview, 'untitledOpportunityLabel', 'job-os.overview');
+  const overviewStatusOptions = requireRecord(
+    overview.statusOptions,
+    'job-os.overview.statusOptions',
+  );
+  requireString(overviewStatusOptions, 'researching', 'job-os.overview.statusOptions');
+  requireString(overviewStatusOptions, 'applied', 'job-os.overview.statusOptions');
+  requireString(
+    overviewStatusOptions,
+    'interviewing',
+    'job-os.overview.statusOptions',
+  );
+  requireString(overviewStatusOptions, 'offer', 'job-os.overview.statusOptions');
+  const overviewStatusHints = requireRecord(
+    overview.statusHints,
+    'job-os.overview.statusHints',
+  );
+  requireString(
+    overviewStatusHints,
+    'researching',
+    'job-os.overview.statusHints',
+  );
 
   const employers = requireRecord(page.employers, 'job-os.employers');
   requireString(employers, 'heading', 'job-os.employers');


### PR DESCRIPTION
﻿## Summary
- Replaces the Overview stub with a read-only attention ledger driven by `listOverviewAttention()`
- Rows show Employer, Opportunity, Application status, and Tracking note (em dash when empty); each row links to Application detail
- Empty state links to Opportunities; loading/error states match other Job OS workspaces
- Updates British English Overview copy (including researching as pre-apply) plus data types/validation

Depends on #175 (`listOverviewAttention` facade). Stacked on `feat/job-os-list-overview-attention`.

Closes #171

## Test plan
- [x] `npx vitest run src/components/sections/labs/job-os/job-os-overview.test.tsx`
- [x] `npx vitest run src/data/validate.test.ts`
- [ ] Merge/rebase after #175 lands on develop
- [ ] CI `quality` passes
- [ ] Manual: authenticated Overview shows attention rows and empty state
