### PR TITLE
WMW: annualised per-Account MWR (#185)

### DIFF
--- a/src/lib/wmw/mwr.test.ts
+++ b/src/lib/wmw/mwr.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeAccountAnnualisedMwr,
+  computeInvestableAccountsAnnualisedMwr,
+  INVESTABLE_CATEGORY_IDS,
+  isInvestableAccount,
+} from '@/lib/wmw/mwr';
+import type {
+  WmwAccount,
+  WmwBalance,
+  WmwCashflow,
+  WmwCategory,
+  WmwSnapshot,
+} from '@/lib/wmw/types';
+
+const CATEGORIES: WmwCategory[] = [
+  { categoryId: 'CAT_BROKERAGE', type: 'Asset', class: 'Investments', sign: 1 },
+  { categoryId: 'CAT_PENSION', type: 'Asset', class: 'Retirement', sign: 1 },
+  { categoryId: 'CAT_CRYPTO', type: 'Asset', class: 'Cryptocurrency', sign: 1 },
+  { categoryId: 'CAT_CASH', type: 'Asset', class: 'Cash & Savings', sign: 1 },
+  { categoryId: 'CAT_VEHICLE', type: 'Asset', class: 'Cars', sign: 1 },
+  { categoryId: 'CAT_LOAN', type: 'Liability', class: 'Loans', sign: -1 },
+];
+
+function account(
+  accountId: string,
+  categoryId: string,
+  name = accountId,
+): WmwAccount {
+  return {
+    accountId,
+    accountName: name,
+    platform: 'Test',
+    categoryId,
+    currency: 'GBP',
+    pairId: null,
+  };
+}
+
+function balance(
+  accountId: string,
+  date: string,
+  value: number,
+): WmwBalance {
+  return {
+    date,
+    accountId,
+    balance: value,
+    units: null,
+    mileage: null,
+  };
+}
+
+function cashflow(
+  accountId: string,
+  date: string,
+  amount: number,
+  transactionType: string,
+  description = '',
+): WmwCashflow {
+  return { date, accountId, amount, transactionType, description };
+}
+
+function snapshot(partial: {
+  accounts: WmwAccount[];
+  balances: WmwBalance[];
+  cashflows?: WmwCashflow[];
+  asOf?: string;
+}): WmwSnapshot {
+  return {
+    asOf: partial.asOf ?? '2025-06-30T12:00:00.000Z',
+    accounts: partial.accounts,
+    categories: CATEGORIES,
+    balances: partial.balances,
+    cashflows: partial.cashflows ?? [],
+  };
+}
+
+/** NPV of investor flows at an annualised rate (same day-count as the module). */
+function npvAt(
+  rate: number,
+  flows: { years: number; amount: number }[],
+): number {
+  return flows.reduce(
+    (sum, flow) => sum + flow.amount / (1 + rate) ** flow.years,
+    0,
+  );
+}
+
+describe('WMW investable allow-list', () => {
+  it('allows only brokerage, pension, and crypto Categories', () => {
+    expect([...INVESTABLE_CATEGORY_IDS]).toEqual([
+      'CAT_BROKERAGE',
+      'CAT_PENSION',
+      'CAT_CRYPTO',
+    ]);
+
+    const snap = snapshot({
+      accounts: [
+        account('isa', 'CAT_BROKERAGE'),
+        account('cash', 'CAT_CASH'),
+        account('car', 'CAT_VEHICLE'),
+        account('loan', 'CAT_LOAN'),
+      ],
+      balances: [balance('isa', '2025-01-01', 1000)],
+    });
+
+    expect(isInvestableAccount(snap, 'isa')).toBe(true);
+    expect(isInvestableAccount(snap, 'cash')).toBe(false);
+    expect(isInvestableAccount(snap, 'car')).toBe(false);
+    expect(isInvestableAccount(snap, 'loan')).toBe(false);
+  });
+
+  it('marks non-investable Accounts as unavailable for MWR', () => {
+    const snap = snapshot({
+      accounts: [account('cash', 'CAT_CASH')],
+      balances: [balance('cash', '2025-01-01', 5000)],
+      cashflows: [cashflow('cash', '2025-02-01', 100, 'Contribution')],
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'cash', 'Max');
+    expect(result).toMatchObject({
+      status: 'unavailable',
+      reason: 'not-investable',
+    });
+  });
+});
+
+describe('WMW annualised per-Account MWR', () => {
+  it('computes annualised MWR for a contribution series (investor IRR orientation)', () => {
+    // Account-perspective: open 1000, contribute +1000 mid-year, close 2200.
+    // Investor: −1000, −1000, +2200 over ~1 year.
+    const snap = snapshot({
+      asOf: '2025-01-01T00:00:00.000Z',
+      accounts: [account('isa', 'CAT_BROKERAGE', 'ISA')],
+      balances: [
+        balance('isa', '2024-01-01', 1000),
+        balance('isa', '2025-01-01', 2200),
+      ],
+      cashflows: [cashflow('isa', '2024-07-01', 1000, 'Contribution')],
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'isa', 'Max');
+    expect(result.status).toBe('available');
+    if (result.status !== 'available') {
+      return;
+    }
+
+    expect(result.label).toBe('annualised');
+    expect(result.period).toBe('Max');
+    expect(result.periodStart).toBe('2024-01-01');
+    expect(result.periodEnd).toBe('2025-01-01');
+
+    const yearsMid = 182 / 365.25; // 2024-01-01 → 2024-07-01
+    const yearsEnd = 366 / 365.25; // leap year span
+    const residual = npvAt(result.annualisedRate, [
+      { years: 0, amount: -1000 },
+      { years: yearsMid, amount: -1000 },
+      { years: yearsEnd, amount: 2200 },
+    ]);
+    expect(Math.abs(residual)).toBeLessThan(1e-4);
+    expect(result.annualisedRate).toBeGreaterThan(0.1);
+    expect(result.annualisedRate).toBeLessThan(0.2);
+  });
+
+  it('treats withdrawals as investor inflows when negating account-perspective Amounts', () => {
+    const snap = snapshot({
+      asOf: '2025-01-01T00:00:00.000Z',
+      accounts: [account('isa', 'CAT_BROKERAGE')],
+      balances: [
+        balance('isa', '2024-01-01', 2000),
+        balance('isa', '2025-01-01', 900),
+      ],
+      cashflows: [cashflow('isa', '2024-07-01', -500, 'Withdrawal')],
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'isa', 'Max');
+    expect(result.status).toBe('available');
+    if (result.status !== 'available') {
+      return;
+    }
+
+    const yearsMid = 182 / 365.25;
+    const yearsEnd = 366 / 365.25;
+    // Withdrawal −500 account → +500 investor
+    const residual = npvAt(result.annualisedRate, [
+      { years: 0, amount: -2000 },
+      { years: yearsMid, amount: 500 },
+      { years: yearsEnd, amount: 900 },
+    ]);
+    expect(Math.abs(residual)).toBeLessThan(1e-4);
+  });
+
+  it('is unavailable when there is no Balance on or before period start (YTD)', () => {
+    const snap = snapshot({
+      asOf: '2025-06-30T12:00:00.000Z',
+      accounts: [account('isa', 'CAT_BROKERAGE')],
+      balances: [
+        balance('isa', '2025-03-01', 1000),
+        balance('isa', '2025-06-01', 1100),
+      ],
+      cashflows: [cashflow('isa', '2025-04-01', 100, 'Contribution')],
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'isa', 'YTD');
+    expect(result).toMatchObject({
+      status: 'unavailable',
+      reason: 'no-opening-balance',
+    });
+  });
+
+  it('uses last Balance on or before period start as opening (1Y)', () => {
+    const snap = snapshot({
+      asOf: '2025-06-30T12:00:00.000Z',
+      accounts: [account('sipp', 'CAT_PENSION')],
+      balances: [
+        balance('sipp', '2024-05-01', 800),
+        balance('sipp', '2024-08-01', 850),
+        balance('sipp', '2025-06-01', 1000),
+      ],
+      cashflows: [cashflow('sipp', '2024-12-01', 100, 'Contribution')],
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'sipp', '1Y', {
+      asOfDate: '2025-06-30',
+    });
+    expect(result.status).toBe('available');
+    if (result.status !== 'available') {
+      return;
+    }
+    expect(result.periodStart).toBe('2024-06-30');
+    expect(result.periodEnd).toBe('2025-06-30');
+    // Opening = 2024-05-01 (last on or before 2024-06-30), not synthesised
+    const yearsCf =
+      (Date.UTC(2024, 11, 1) - Date.UTC(2024, 5, 30)) /
+      (365.25 * 24 * 60 * 60 * 1000);
+    const yearsEnd =
+      (Date.UTC(2025, 5, 1) - Date.UTC(2024, 5, 30)) /
+      (365.25 * 24 * 60 * 60 * 1000);
+    const residual = npvAt(result.annualisedRate, [
+      { years: 0, amount: -800 },
+      { years: yearsCf, amount: -100 },
+      { years: yearsEnd, amount: 1000 },
+    ]);
+    expect(Math.abs(residual)).toBeLessThan(1e-4);
+  });
+
+  it('excludes Cashflows dated before the Account’s first Balance', () => {
+    const snap = snapshot({
+      accounts: [account('btc', 'CAT_CRYPTO')],
+      balances: [
+        balance('btc', '2024-06-01', 5000),
+        balance('btc', '2025-06-01', 6000),
+      ],
+      cashflows: [
+        cashflow('btc', '2024-01-01', 4000, 'Contribution', 'pre-history'),
+        cashflow('btc', '2024-09-01', 200, 'Contribution'),
+      ],
+    });
+
+    const withPreHistoryOnly = snapshot({
+      accounts: [account('btc', 'CAT_CRYPTO')],
+      balances: [
+        balance('btc', '2024-06-01', 5000),
+        balance('btc', '2025-06-01', 6000),
+      ],
+      cashflows: [
+        cashflow('btc', '2024-01-01', 4000, 'Contribution', 'pre-history'),
+      ],
+    });
+
+    expect(computeAccountAnnualisedMwr(withPreHistoryOnly, 'btc', 'Max')).toMatchObject({
+      status: 'unavailable',
+      reason: 'no-usable-cashflows',
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'btc', 'Max');
+    expect(result.status).toBe('available');
+  });
+
+  it('ignores Loan Repayment and unknown Types for MWR', () => {
+    const snap = snapshot({
+      accounts: [account('isa', 'CAT_BROKERAGE')],
+      balances: [
+        balance('isa', '2024-01-01', 1000),
+        balance('isa', '2025-01-01', 1100),
+      ],
+      cashflows: [
+        cashflow('isa', '2024-06-01', -50, 'Loan Repayment'),
+        cashflow('isa', '2024-07-01', 25, 'Transfer'),
+        cashflow('isa', '2024-08-01', 10, 'Dividend'),
+      ],
+    });
+
+    expect(computeAccountAnnualisedMwr(snap, 'isa', 'Max')).toMatchObject({
+      status: 'unavailable',
+      reason: 'no-usable-cashflows',
+    });
+  });
+
+  it('is unavailable when Balances exist but there are no usable Cashflows in the period', () => {
+    const snap = snapshot({
+      accounts: [account('legacy', 'CAT_CRYPTO')],
+      balances: [
+        balance('legacy', '2023-01-01', 100),
+        balance('legacy', '2024-01-01', 400),
+        balance('legacy', '2025-01-01', 900),
+      ],
+      cashflows: [],
+    });
+
+    expect(computeAccountAnnualisedMwr(snap, 'legacy', 'Max')).toMatchObject({
+      status: 'unavailable',
+      reason: 'no-usable-cashflows',
+    });
+  });
+
+  it('does not invent a synthetic £0 opening', () => {
+    const snap = snapshot({
+      asOf: '2025-12-31T00:00:00.000Z',
+      accounts: [account('isa', 'CAT_BROKERAGE')],
+      balances: [balance('isa', '2025-06-01', 1000)],
+      cashflows: [cashflow('isa', '2025-07-01', 100, 'Contribution')],
+    });
+
+    expect(computeAccountAnnualisedMwr(snap, 'isa', 'YTD')).toMatchObject({
+      status: 'unavailable',
+      reason: 'no-opening-balance',
+    });
+  });
+
+  it('computes Max from first Balance through latest Balance', () => {
+    const snap = snapshot({
+      asOf: '2026-01-01T00:00:00.000Z',
+      accounts: [account('isa', 'CAT_BROKERAGE')],
+      balances: [
+        balance('isa', '2022-03-15', 1000),
+        balance('isa', '2023-03-15', 1200),
+        balance('isa', '2024-03-15', 1500),
+      ],
+      cashflows: [cashflow('isa', '2022-09-01', 100, 'Contribution')],
+    });
+
+    const result = computeAccountAnnualisedMwr(snap, 'isa', 'Max');
+    expect(result.status).toBe('available');
+    if (result.status !== 'available') {
+      return;
+    }
+    expect(result.periodStart).toBe('2022-03-15');
+    expect(result.periodEnd).toBe('2024-03-15');
+    expect(result.label).toBe('annualised');
+  });
+
+  it('lists annualised MWR only for investable Accounts', () => {
+    const snap = snapshot({
+      accounts: [
+        account('isa', 'CAT_BROKERAGE'),
+        account('cash', 'CAT_CASH'),
+        account('sipp', 'CAT_PENSION'),
+      ],
+      balances: [
+        balance('isa', '2024-01-01', 1000),
+        balance('isa', '2025-01-01', 1200),
+        balance('cash', '2024-01-01', 500),
+        balance('sipp', '2024-01-01', 2000),
+        balance('sipp', '2025-01-01', 2100),
+      ],
+      cashflows: [
+        cashflow('isa', '2024-06-01', 50, 'Contribution'),
+        cashflow('sipp', '2024-06-01', 80, 'Contribution'),
+      ],
+    });
+
+    const results = computeInvestableAccountsAnnualisedMwr(snap, 'Max');
+    expect(results.map((row) => row.accountId).sort()).toEqual(['isa', 'sipp']);
+    expect(results.every((row) => row.status === 'available')).toBe(true);
+    expect(
+      results.every(
+        (row) => row.status === 'available' && row.label === 'annualised',
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/lib/wmw/mwr.test.ts
+++ b/src/lib/wmw/mwr.test.ts
@@ -73,6 +73,7 @@ function snapshot(partial: {
     categories: CATEGORIES,
     balances: partial.balances,
     cashflows: partial.cashflows ?? [],
+    warnings: [],
   };
 }
 

--- a/src/lib/wmw/mwr.ts
+++ b/src/lib/wmw/mwr.ts
@@ -1,13 +1,15 @@
-import type { WmwBalance, WmwCashflow, WmwSnapshot } from '@/lib/wmw/types';
+import {
+  WMW_INVESTABLE_CATEGORY_IDS,
+  type WmwBalance,
+  type WmwCashflow,
+  type WmwInvestableCategoryId,
+  type WmwSnapshot,
+} from '@/lib/wmw/types';
 
 /** Investable = Category allow-list only (not cash / vehicle / loan). */
-export const INVESTABLE_CATEGORY_IDS = [
-  'CAT_BROKERAGE',
-  'CAT_PENSION',
-  'CAT_CRYPTO',
-] as const;
+export const INVESTABLE_CATEGORY_IDS = WMW_INVESTABLE_CATEGORY_IDS;
 
-export type InvestableCategoryId = (typeof INVESTABLE_CATEGORY_IDS)[number];
+export type InvestableCategoryId = WmwInvestableCategoryId;
 
 export type MwrPeriod = 'YTD' | '1Y' | 'Max';
 

--- a/src/lib/wmw/mwr.ts
+++ b/src/lib/wmw/mwr.ts
@@ -1,0 +1,357 @@
+import type { WmwBalance, WmwCashflow, WmwSnapshot } from '@/lib/wmw/types';
+
+/** Investable = Category allow-list only (not cash / vehicle / loan). */
+export const INVESTABLE_CATEGORY_IDS = [
+  'CAT_BROKERAGE',
+  'CAT_PENSION',
+  'CAT_CRYPTO',
+] as const;
+
+export type InvestableCategoryId = (typeof INVESTABLE_CATEGORY_IDS)[number];
+
+export type MwrPeriod = 'YTD' | '1Y' | 'Max';
+
+export type MwrUnavailableReason =
+  | 'not-investable'
+  | 'account-not-found'
+  | 'no-opening-balance'
+  | 'no-closing-balance'
+  | 'no-usable-cashflows'
+  | 'invalid-period'
+  | 'irr-failed';
+
+export type AccountAnnualisedMwr =
+  | {
+      status: 'available';
+      accountId: string;
+      period: MwrPeriod;
+      /** Decimal annualised rate (0.12 = 12% p.a.). */
+      annualisedRate: number;
+      /** Headline MWR is always annualised. */
+      label: 'annualised';
+      periodStart: string;
+      periodEnd: string;
+    }
+  | {
+      status: 'unavailable';
+      accountId: string;
+      period: MwrPeriod;
+      reason: MwrUnavailableReason;
+    };
+
+const MWR_CASHFLOW_TYPES = new Set(['Contribution', 'Withdrawal']);
+const DAYS_PER_YEAR = 365.25;
+
+export function isInvestableCategoryId(categoryId: string): boolean {
+  return (INVESTABLE_CATEGORY_IDS as readonly string[]).includes(categoryId);
+}
+
+export function isInvestableAccount(
+  snapshot: WmwSnapshot,
+  accountId: string,
+): boolean {
+  const account = snapshot.accounts.find((row) => row.accountId === accountId);
+  return account != null && isInvestableCategoryId(account.categoryId);
+}
+
+/**
+ * Annualised Money-Weighted Return for one Account over YTD, 1Y, or Max.
+ * Workbook Amounts are account-perspective; converted to investor IRR orientation.
+ */
+export function computeAccountAnnualisedMwr(
+  snapshot: WmwSnapshot,
+  accountId: string,
+  period: MwrPeriod,
+  options?: { asOfDate?: string },
+): AccountAnnualisedMwr {
+  const account = snapshot.accounts.find((row) => row.accountId === accountId);
+  if (!account) {
+    return unavailable(accountId, period, 'account-not-found');
+  }
+  if (!isInvestableCategoryId(account.categoryId)) {
+    return unavailable(accountId, period, 'not-investable');
+  }
+
+  const asOfDate = options?.asOfDate ?? snapshotAsOfDate(snapshot.asOf);
+  const balances = snapshot.balances
+    .filter((row) => row.accountId === accountId)
+    .slice()
+    .sort(byDateThenIndex);
+
+  if (balances.length === 0) {
+    return unavailable(accountId, period, 'no-opening-balance');
+  }
+
+  const firstBalanceDate = balances[0]!.date;
+  const latestBalanceDate = balances[balances.length - 1]!.date;
+  const window = resolvePeriodWindow(
+    period,
+    asOfDate,
+    firstBalanceDate,
+    latestBalanceDate,
+  );
+  if (!window) {
+    return unavailable(accountId, period, 'invalid-period');
+  }
+
+  const opening = lastBalanceOnOrBefore(balances, window.start);
+  if (!opening) {
+    return unavailable(accountId, period, 'no-opening-balance');
+  }
+
+  const closing = lastBalanceOnOrBefore(balances, window.end);
+  if (!closing) {
+    return unavailable(accountId, period, 'no-closing-balance');
+  }
+
+  const usableCashflows = snapshot.cashflows.filter(
+    (cf) =>
+      cf.accountId === accountId &&
+      MWR_CASHFLOW_TYPES.has(cf.transactionType) &&
+      cf.date >= firstBalanceDate &&
+      cf.date >= window.start &&
+      cf.date <= window.end,
+  );
+
+  if (usableCashflows.length === 0) {
+    return unavailable(accountId, period, 'no-usable-cashflows');
+  }
+
+  const investorFlows = buildInvestorFlows(
+    opening,
+    usableCashflows,
+    closing,
+    window.start,
+  );
+  const annualisedRate = solveAnnualisedIrr(investorFlows);
+  if (annualisedRate == null || !Number.isFinite(annualisedRate)) {
+    return unavailable(accountId, period, 'irr-failed');
+  }
+
+  return {
+    status: 'available',
+    accountId,
+    period,
+    annualisedRate,
+    label: 'annualised',
+    periodStart: window.start,
+    periodEnd: window.end,
+  };
+}
+
+export function computeInvestableAccountsAnnualisedMwr(
+  snapshot: WmwSnapshot,
+  period: MwrPeriod,
+  options?: { asOfDate?: string },
+): AccountAnnualisedMwr[] {
+  return snapshot.accounts
+    .filter((account) => isInvestableCategoryId(account.categoryId))
+    .map((account) =>
+      computeAccountAnnualisedMwr(snapshot, account.accountId, period, options),
+    );
+}
+
+function unavailable(
+  accountId: string,
+  period: MwrPeriod,
+  reason: MwrUnavailableReason,
+): AccountAnnualisedMwr {
+  return { status: 'unavailable', accountId, period, reason };
+}
+
+function snapshotAsOfDate(asOf: string): string {
+  return asOf.slice(0, 10);
+}
+
+function resolvePeriodWindow(
+  period: MwrPeriod,
+  asOfDate: string,
+  firstBalanceDate: string,
+  latestBalanceDate: string,
+): { start: string; end: string } | null {
+  if (period === 'Max') {
+    if (firstBalanceDate > latestBalanceDate) {
+      return null;
+    }
+    return { start: firstBalanceDate, end: latestBalanceDate };
+  }
+
+  if (!isIsoDate(asOfDate)) {
+    return null;
+  }
+
+  const end = asOfDate;
+  const start =
+    period === 'YTD' ? `${asOfDate.slice(0, 4)}-01-01` : shiftIsoYears(asOfDate, -1);
+
+  if (!start || start > end) {
+    return null;
+  }
+  return { start, end };
+}
+
+function lastBalanceOnOrBefore(
+  balances: WmwBalance[],
+  date: string,
+): WmwBalance | null {
+  let found: WmwBalance | null = null;
+  for (const balance of balances) {
+    if (balance.date <= date) {
+      found = balance;
+    } else {
+      break;
+    }
+  }
+  return found;
+}
+
+type DatedFlow = { date: string; amount: number; yearsFromStart: number };
+
+function buildInvestorFlows(
+  opening: WmwBalance,
+  cashflows: WmwCashflow[],
+  closing: WmwBalance,
+  periodStart: string,
+): DatedFlow[] {
+  const flows: DatedFlow[] = [
+    {
+      date: periodStart,
+      // Investor IRR: −MV₀
+      amount: -opening.balance,
+      yearsFromStart: 0,
+    },
+  ];
+
+  const sorted = cashflows.slice().sort(byDateThenIndex);
+  for (const cf of sorted) {
+    flows.push({
+      date: cf.date,
+      // Account-perspective → investor: negate
+      amount: -cf.amount,
+      yearsFromStart: yearFraction(periodStart, cf.date),
+    });
+  }
+
+  flows.push({
+    date: closing.date,
+    // Investor IRR: +MV₁
+    amount: closing.balance,
+    yearsFromStart: yearFraction(periodStart, closing.date),
+  });
+
+  return flows;
+}
+
+function yearFraction(start: string, end: string): number {
+  const days =
+    (utcDay(end).getTime() - utcDay(start).getTime()) / (24 * 60 * 60 * 1000);
+  return days / DAYS_PER_YEAR;
+}
+
+function solveAnnualisedIrr(flows: DatedFlow[]): number | null {
+  const npv = (rate: number) =>
+    flows.reduce((sum, flow) => {
+      const base = 1 + rate;
+      if (base <= 0) {
+        return Number.NaN;
+      }
+      return sum + flow.amount / base ** flow.yearsFromStart;
+    }, 0);
+
+  const derivative = (rate: number) =>
+    flows.reduce((sum, flow) => {
+      const base = 1 + rate;
+      if (base <= 0 || flow.yearsFromStart === 0) {
+        return sum;
+      }
+      return (
+        sum -
+        (flow.yearsFromStart * flow.amount) / base ** (flow.yearsFromStart + 1)
+      );
+    }, 0);
+
+  let rate = 0.1;
+  for (let i = 0; i < 50; i += 1) {
+    const y = npv(rate);
+    if (!Number.isFinite(y)) {
+      break;
+    }
+    if (Math.abs(y) < 1e-7) {
+      return rate;
+    }
+    const dy = derivative(rate);
+    if (!Number.isFinite(dy) || Math.abs(dy) < 1e-12) {
+      break;
+    }
+    const next = rate - y / dy;
+    if (!Number.isFinite(next) || next <= -0.999999) {
+      break;
+    }
+    rate = next;
+  }
+
+  // Bisection fallback over a wide annualised band
+  let low = -0.9999;
+  let high = 10;
+  const npvLow = npv(low);
+  const npvHigh = npv(high);
+  if (!Number.isFinite(npvLow) || !Number.isFinite(npvHigh) || npvLow * npvHigh > 0) {
+    // Expand high if same sign
+    for (let h = 20; h <= 100; h *= 2) {
+      const y = npv(h);
+      if (Number.isFinite(y) && npvLow * y <= 0) {
+        high = h;
+        break;
+      }
+    }
+    if (npv(low) * npv(high) > 0) {
+      return null;
+    }
+  }
+
+  for (let i = 0; i < 80; i += 1) {
+    const mid = (low + high) / 2;
+    const y = npv(mid);
+    if (!Number.isFinite(y) || Math.abs(y) < 1e-7) {
+      return mid;
+    }
+    if (npv(low) * y <= 0) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return (low + high) / 2;
+}
+
+function isIsoDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(utcDay(value).getTime());
+}
+
+function utcDay(isoDate: string): Date {
+  const year = Number(isoDate.slice(0, 4));
+  const month = Number(isoDate.slice(5, 7));
+  const day = Number(isoDate.slice(8, 10));
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/** Shift calendar years; clamps 29 Feb to 28 Feb when the target year is not a leap year. */
+function shiftIsoYears(isoDate: string, years: number): string | null {
+  if (!isIsoDate(isoDate)) {
+    return null;
+  }
+  const year = Number(isoDate.slice(0, 4)) + years;
+  const month = Number(isoDate.slice(5, 7));
+  const day = Number(isoDate.slice(8, 10));
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+  if (candidate.getUTCMonth() !== month - 1) {
+    const clamped = new Date(Date.UTC(year, month, 0));
+    return clamped.toISOString().slice(0, 10);
+  }
+  return candidate.toISOString().slice(0, 10);
+}
+
+function byDateThenIndex<T extends { date: string }>(a: T, b: T): number {
+  return a.date < b.date ? -1 : a.date > b.date ? 1 : 0;
+}

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -9,19 +9,23 @@ export type WmwAccount = {
   accountName: string;
   platform: string;
   categoryId: string;
+  /** v1 is GBP-only. */
   currency: string;
-  /** Empty / null = unpaired. */
+  /** Empty / null means unpaired. */
   pairId: string | null;
 };
 
 export type WmwCategory = {
   categoryId: string;
+  /** Workbook Type, e.g. Asset | Liability. */
   type: string;
   class: string;
+  /** +1 asset, −1 liability when rolling into Net Worth. */
   sign: number;
 };
 
 export type WmwBalance = {
+  /** Calendar date YYYY-MM-DD. */
   date: string;
   accountId: string;
   balance: number;
@@ -29,27 +33,38 @@ export type WmwBalance = {
   mileage: number | null;
 };
 
-/** v1 known Types; unknown strings are allowed but ignored for MWR. */
-export type WmwCashflowType =
+/**
+ * v1 known Transaction_Type values. Unknown strings are allowed (open union) but
+ * ignored for MWR; ingest may filter before Snapshot persist.
+ */
+export type WmwCashflowTransactionType =
   | 'Contribution'
   | 'Withdrawal'
   | 'Loan Repayment'
   | (string & {});
 
+/** Alias kept so MWR and Net Worth call sites share one vocabulary. */
+export type WmwCashflowType = WmwCashflowTransactionType;
+
 export type WmwCashflow = {
+  /** Calendar date YYYY-MM-DD. */
   date: string;
   accountId: string;
   /** Account-perspective: into Account positive, out negative. */
   amount: number;
-  transactionType: WmwCashflowType;
+  transactionType: WmwCashflowTransactionType;
   description: string;
 };
 
+/** Point-in-time copy of Workbook facts held for the lab. */
 export type WmwSnapshot = {
-  /** ISO datetime of the Snapshot as-of. */
+  /** ISO timestamp when the Snapshot was taken (as-of). */
   asOf: string;
   accounts: WmwAccount[];
   categories: WmwCategory[];
   balances: WmwBalance[];
   cashflows: WmwCashflow[];
 };
+
+/** Calendar month key YYYY-MM. */
+export type CalendarMonth = string;

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -1,0 +1,55 @@
+/**
+ * WMW Snapshot domain types — mirror the frozen Workbook contract from epic #179 /
+ * ADR 0010. Dates are ISO calendar days (YYYY-MM-DD) after ingest parses Sheet serials.
+ * Amounts are GBP; Cashflow Amounts are account-perspective (into Account positive).
+ */
+
+export type WmwAccount = {
+  accountId: string;
+  accountName: string;
+  platform: string;
+  categoryId: string;
+  currency: string;
+  /** Empty / null = unpaired. */
+  pairId: string | null;
+};
+
+export type WmwCategory = {
+  categoryId: string;
+  type: string;
+  class: string;
+  sign: number;
+};
+
+export type WmwBalance = {
+  date: string;
+  accountId: string;
+  balance: number;
+  units: number | null;
+  mileage: number | null;
+};
+
+/** v1 known Types; unknown strings are allowed but ignored for MWR. */
+export type WmwCashflowType =
+  | 'Contribution'
+  | 'Withdrawal'
+  | 'Loan Repayment'
+  | (string & {});
+
+export type WmwCashflow = {
+  date: string;
+  accountId: string;
+  /** Account-perspective: into Account positive, out negative. */
+  amount: number;
+  transactionType: WmwCashflowType;
+  description: string;
+};
+
+export type WmwSnapshot = {
+  /** ISO datetime of the Snapshot as-of. */
+  asOf: string;
+  accounts: WmwAccount[];
+  categories: WmwCategory[];
+  balances: WmwBalance[];
+  cashflows: WmwCashflow[];
+};

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -1,15 +1,88 @@
 /**
- * WMW Snapshot domain types — mirror the frozen Workbook contract from epic #179 /
- * ADR 0010. Dates are ISO calendar days (YYYY-MM-DD) after ingest parses Sheet serials.
- * Amounts are GBP; Cashflow Amounts are account-perspective (into Account positive).
+ * WMW Snapshot domain types — frozen Workbook contract from epic #179 /
+ * ADR 0009 / ADR 0010. Shared across storage (#182), ingest (#183), Net Worth
+ * (#184), and MWR (#185). Dates are ISO calendar days (YYYY-MM-DD) after ingest
+ * parses Sheet serials. Amounts are GBP; Cashflow Amounts are account-perspective
+ * (into Account positive).
  */
+
+export const WMW_WORKBOOK_TABS = [
+  'dim_Accounts',
+  'dim_Categories',
+  'fact_Balances',
+  'fact_Cashflows',
+] as const;
+
+export type WmwWorkbookTab = (typeof WMW_WORKBOOK_TABS)[number];
+
+export const WMW_ACCOUNT_COLUMNS = [
+  'Account_ID',
+  'Account_Name',
+  'Platform',
+  'Category_ID',
+  'Currency',
+  'Pair_ID',
+] as const;
+
+export const WMW_CATEGORY_COLUMNS = [
+  'Category_ID',
+  'Type',
+  'Class',
+  'Sign',
+] as const;
+
+export const WMW_BALANCE_COLUMNS = [
+  'Date',
+  'Account_ID',
+  'Balance',
+  'Units',
+  'Mileage',
+] as const;
+
+export const WMW_CASHFLOW_COLUMNS = [
+  'Date',
+  'Account_ID',
+  'Amount',
+  'Transaction_Type',
+  'Description',
+] as const;
+
+/** v1 known Transaction_Type values (epic #179 / ADR 0010). */
+export const WMW_CASHFLOW_TRANSACTION_TYPES = [
+  'Contribution',
+  'Withdrawal',
+  'Loan Repayment',
+] as const;
+
+/**
+ * Open union: known Types plus unknown Sheet strings. MWR ignores unknowns;
+ * ingest may filter before Snapshot persist and warn on Refresh.
+ */
+export type WmwCashflowTransactionType =
+  | (typeof WMW_CASHFLOW_TRANSACTION_TYPES)[number]
+  | (string & {});
+
+/** Alias so MWR and Net Worth call sites share one vocabulary. */
+export type WmwCashflowType = WmwCashflowTransactionType;
+
+/** Category allow-list for Investable Accounts (MWR). */
+export const WMW_INVESTABLE_CATEGORY_IDS = [
+  'CAT_BROKERAGE',
+  'CAT_PENSION',
+  'CAT_CRYPTO',
+] as const;
+
+export type WmwInvestableCategoryId =
+  (typeof WMW_INVESTABLE_CATEGORY_IDS)[number];
+
+export const WMW_SUPPORTED_CURRENCY = 'GBP' as const;
 
 export type WmwAccount = {
   accountId: string;
   accountName: string;
   platform: string;
   categoryId: string;
-  /** v1 is GBP-only. */
+  /** v1 is GBP-only; ingest excludes non-GBP Accounts. */
   currency: string;
   /** Empty / null means unpaired. */
   pairId: string | null;
@@ -33,19 +106,6 @@ export type WmwBalance = {
   mileage: number | null;
 };
 
-/**
- * v1 known Transaction_Type values. Unknown strings are allowed (open union) but
- * ignored for MWR; ingest may filter before Snapshot persist.
- */
-export type WmwCashflowTransactionType =
-  | 'Contribution'
-  | 'Withdrawal'
-  | 'Loan Repayment'
-  | (string & {});
-
-/** Alias kept so MWR and Net Worth call sites share one vocabulary. */
-export type WmwCashflowType = WmwCashflowTransactionType;
-
 export type WmwCashflow = {
   /** Calendar date YYYY-MM-DD. */
   date: string;
@@ -56,7 +116,24 @@ export type WmwCashflow = {
   description: string;
 };
 
-/** Point-in-time copy of Workbook facts held for the lab. */
+export type WmwRefreshWarningCode =
+  | 'unknown_transaction_type'
+  | 'non_gbp_account'
+  | 'invalid_row'
+  | 'orphan_fact';
+
+export type WmwRefreshWarning = {
+  code: WmwRefreshWarningCode;
+  message: string;
+  tab?: WmwWorkbookTab;
+  row?: number;
+  details?: Record<string, unknown>;
+};
+
+/**
+ * Point-in-time Workbook copy for the lab (private storage, not Site Content).
+ * Ingest retains Refresh warnings on last-good; calc fixtures use [].
+ */
 export type WmwSnapshot = {
   /** ISO timestamp when the Snapshot was taken (as-of). */
   asOf: string;
@@ -64,7 +141,11 @@ export type WmwSnapshot = {
   categories: WmwCategory[];
   balances: WmwBalance[];
   cashflows: WmwCashflow[];
+  warnings: WmwRefreshWarning[];
 };
+
+/** Unformatted Sheets matrices (header row + data rows). */
+export type WmwWorkbookRaw = Record<WmwWorkbookTab, unknown[][]>;
 
 /** Calendar month key YYYY-MM. */
 export type CalendarMonth = string;


### PR DESCRIPTION
## Summary
- Pure `src/lib/wmw` module computes **annualised** Money-Weighted Return per Investable Account for **YTD**, **1Y**, and **Max**.
- Investable allow-list: `CAT_BROKERAGE`, `CAT_PENSION`, `CAT_CRYPTO`; Contribution/Withdrawal only (Loan Repayment and unknown Types ignored).
- Opening Balance = last Balance on or before period start (no synthetic £0); pre-first-Balance Cashflows excluded; no usable Cashflows in period ⇒ unavailable.
- Account-perspective Amounts converted to investor IRR (−MV₀, negate CFs, +MV₁). Vitest fixtures cover contribution/withdrawal series and unavailable cases.

## Snapshot / cashflow assumptions
- Shared domain types in `src/lib/wmw/types.ts` mirror epic #179 Workbook tabs (camelCase after ingest).
- Dates are ISO `YYYY-MM-DD` (Sheet serials are an ingest concern). Cashflow `amount` is account-perspective GBP.
- `WmwSnapshot.asOf` supplies the default as-of calendar day for YTD/1Y; Max uses first→latest Balance on that Account.

## Test plan
- [x] `npx vitest run src/lib/wmw/mwr.test.ts` (12 passing)
- [ ] Confirm type shape merges cleanly with #182/#183/#184 Snapshot work
- [ ] No UI wiring required in this PR

Closes #185

Made with [Cursor](https://cursor.com)