### PR TITLE
WMW: Net Worth + Paired Accounts calculations (#184)

### DIFF
--- a/src/lib/wmw/calendar-month.ts
+++ b/src/lib/wmw/calendar-month.ts
@@ -1,0 +1,26 @@
+import type { CalendarMonth } from '@/lib/wmw/types';
+
+const MONTH_KEY = /^(\d{4})-(\d{2})$/;
+const DATE_KEY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/** Extract `YYYY-MM` from a calendar date `YYYY-MM-DD`. */
+export function calendarMonthFromDate(date: string): CalendarMonth {
+  const match = DATE_KEY.exec(date);
+  if (!match) {
+    throw new Error(`Expected calendar date YYYY-MM-DD, got: ${date}`);
+  }
+  return `${match[1]}-${match[2]}`;
+}
+
+/** Lexicographic compare for `YYYY-MM` / `YYYY-MM-DD` ISO keys. */
+export function compareIsoKeys(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+export function isCalendarMonth(value: string): value is CalendarMonth {
+  if (!MONTH_KEY.test(value)) return false;
+  const month = Number(value.slice(5, 7));
+  return month >= 1 && month <= 12;
+}

--- a/src/lib/wmw/fixtures/sample-snapshot.ts
+++ b/src/lib/wmw/fixtures/sample-snapshot.ts
@@ -1,0 +1,208 @@
+import type { WmwSnapshot } from '@/lib/wmw/types';
+
+/** Minimal categories covering cash, vehicle, loan, and investables. */
+export const SAMPLE_CATEGORIES: WmwSnapshot['categories'] = [
+  {
+    categoryId: 'CAT_CASH',
+    type: 'Asset',
+    class: 'Cash & Savings',
+    sign: 1,
+  },
+  {
+    categoryId: 'CAT_BROKERAGE',
+    type: 'Asset',
+    class: 'Brokerage',
+    sign: 1,
+  },
+  {
+    categoryId: 'CAT_VEHICLE',
+    type: 'Asset',
+    class: 'Cars',
+    sign: 1,
+  },
+  {
+    categoryId: 'CAT_LOAN',
+    type: 'Liability',
+    class: 'Loans',
+    sign: -1,
+  },
+  {
+    categoryId: 'CAT_CRYPTO',
+    type: 'Asset',
+    class: 'Cryptocurrency',
+    sign: 1,
+  },
+];
+
+/** Taycan-style financed pair plus cash / brokerage / exited crypto. */
+export const SAMPLE_ACCOUNTS: WmwSnapshot['accounts'] = [
+  {
+    accountId: 'CASH_HSBC',
+    accountName: 'HSBC Current',
+    platform: 'HSBC',
+    categoryId: 'CAT_CASH',
+    currency: 'GBP',
+    pairId: null,
+  },
+  {
+    accountId: 'IBKR_ISA',
+    accountName: 'IBKR ISA',
+    platform: 'IBKR',
+    categoryId: 'CAT_BROKERAGE',
+    currency: 'GBP',
+    pairId: null,
+  },
+  {
+    accountId: 'CAR_PORSCHE',
+    accountName: 'Porsche Taycan',
+    platform: 'Private',
+    categoryId: 'CAT_VEHICLE',
+    currency: 'GBP',
+    pairId: 'PAIR_TAYCAN',
+  },
+  {
+    accountId: 'LOAN_MOTONOVO',
+    accountName: 'Motonovo',
+    platform: 'Motonovo',
+    categoryId: 'CAT_LOAN',
+    currency: 'GBP',
+    pairId: 'PAIR_TAYCAN',
+  },
+  {
+    accountId: 'CB_ETH',
+    accountName: 'Coinbase ETH',
+    platform: 'Coinbase',
+    categoryId: 'CAT_CRYPTO',
+    currency: 'GBP',
+    pairId: null,
+  },
+];
+
+/**
+ * Multi-month Balances:
+ * - Jan: cash + ISA + Taycan pair
+ * - Feb: multi-Balance same month on ISA; crypto still open
+ * - Mar: crypto exited at £0; cash omitted (missing ⇒ £0)
+ */
+export const SAMPLE_BALANCES: WmwSnapshot['balances'] = [
+  {
+    date: '2026-01-15',
+    accountId: 'CASH_HSBC',
+    balance: 5_000,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-01-20',
+    accountId: 'IBKR_ISA',
+    balance: 20_000,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-01-28',
+    accountId: 'CAR_PORSCHE',
+    balance: 80_000,
+    units: null,
+    mileage: 12_000,
+  },
+  {
+    date: '2026-01-28',
+    accountId: 'LOAN_MOTONOVO',
+    balance: 50_000,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-01-10',
+    accountId: 'CB_ETH',
+    balance: 2_000,
+    units: 1.2,
+    mileage: null,
+  },
+  // February — two ISA rows; latest in-month wins
+  {
+    date: '2026-02-01',
+    accountId: 'IBKR_ISA',
+    balance: 21_000,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-02-27',
+    accountId: 'IBKR_ISA',
+    balance: 22_500,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-02-15',
+    accountId: 'CASH_HSBC',
+    balance: 4_500,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-02-28',
+    accountId: 'CAR_PORSCHE',
+    balance: 78_000,
+    units: null,
+    mileage: 12_400,
+  },
+  {
+    date: '2026-02-28',
+    accountId: 'LOAN_MOTONOVO',
+    balance: 48_000,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-02-05',
+    accountId: 'CB_ETH',
+    balance: 1_800,
+    units: 1.2,
+    mileage: null,
+  },
+  // March — crypto exited £0; cash omitted; pair + ISA present
+  {
+    date: '2026-03-01',
+    accountId: 'CB_ETH',
+    balance: 0,
+    units: 0,
+    mileage: null,
+  },
+  {
+    date: '2026-03-31',
+    accountId: 'IBKR_ISA',
+    balance: 23_000,
+    units: null,
+    mileage: null,
+  },
+  {
+    date: '2026-03-31',
+    accountId: 'CAR_PORSCHE',
+    balance: 77_000,
+    units: null,
+    mileage: 12_800,
+  },
+  {
+    date: '2026-03-31',
+    accountId: 'LOAN_MOTONOVO',
+    balance: 47_000,
+    units: null,
+    mileage: null,
+  },
+];
+
+export function buildSampleSnapshot(
+  overrides: Partial<WmwSnapshot> = {},
+): WmwSnapshot {
+  return {
+    asOf: '2026-03-31T18:00:00.000Z',
+    accounts: SAMPLE_ACCOUNTS,
+    categories: SAMPLE_CATEGORIES,
+    balances: SAMPLE_BALANCES,
+    cashflows: [],
+    ...overrides,
+  };
+}

--- a/src/lib/wmw/fixtures/sample-snapshot.ts
+++ b/src/lib/wmw/fixtures/sample-snapshot.ts
@@ -203,6 +203,7 @@ export function buildSampleSnapshot(
     categories: SAMPLE_CATEGORIES,
     balances: SAMPLE_BALANCES,
     cashflows: [],
+    warnings: [],
     ...overrides,
   };
 }

--- a/src/lib/wmw/index.ts
+++ b/src/lib/wmw/index.ts
@@ -1,7 +1,18 @@
 ﻿/**
  * WMW pure calculation modules (Net Worth + Paired Accounts).
- * Snapshot types live here for shared use by ingest (#183) and MWR (#185).
+ * Snapshot types are shared with storage (#182), ingest (#183), and MWR (#185).
  */
+
+export {
+  WMW_ACCOUNT_COLUMNS,
+  WMW_BALANCE_COLUMNS,
+  WMW_CASHFLOW_COLUMNS,
+  WMW_CASHFLOW_TRANSACTION_TYPES,
+  WMW_CATEGORY_COLUMNS,
+  WMW_INVESTABLE_CATEGORY_IDS,
+  WMW_SUPPORTED_CURRENCY,
+  WMW_WORKBOOK_TABS,
+} from '@/lib/wmw/types';
 
 export type {
   CalendarMonth,
@@ -11,7 +22,12 @@ export type {
   WmwCashflowTransactionType,
   WmwCashflowType,
   WmwCategory,
+  WmwInvestableCategoryId,
+  WmwRefreshWarning,
+  WmwRefreshWarningCode,
   WmwSnapshot,
+  WmwWorkbookRaw,
+  WmwWorkbookTab,
 } from '@/lib/wmw/types';
 
 export {

--- a/src/lib/wmw/index.ts
+++ b/src/lib/wmw/index.ts
@@ -9,6 +9,7 @@ export type {
   WmwBalance,
   WmwCashflow,
   WmwCashflowTransactionType,
+  WmwCashflowType,
   WmwCategory,
   WmwSnapshot,
 } from '@/lib/wmw/types';

--- a/src/lib/wmw/index.ts
+++ b/src/lib/wmw/index.ts
@@ -1,0 +1,42 @@
+﻿/**
+ * WMW pure calculation modules (Net Worth + Paired Accounts).
+ * Snapshot types live here for shared use by ingest (#183) and MWR (#185).
+ */
+
+export type {
+  CalendarMonth,
+  WmwAccount,
+  WmwBalance,
+  WmwCashflow,
+  WmwCashflowTransactionType,
+  WmwCategory,
+  WmwSnapshot,
+} from '@/lib/wmw/types';
+
+export {
+  calendarMonthFromDate,
+  compareIsoKeys,
+  isCalendarMonth,
+} from '@/lib/wmw/calendar-month';
+
+export {
+  computeNetWorth,
+  computeNetWorthForMonth,
+  type AccountNetWorthRow,
+  type ClassNetWorthRow,
+  type NetWorthMonth,
+  type NetWorthResult,
+} from '@/lib/wmw/net-worth';
+
+export {
+  computePairEquity,
+  type PairEquity,
+  type PairLeg,
+} from '@/lib/wmw/paired-accounts';
+
+export {
+  SAMPLE_ACCOUNTS,
+  SAMPLE_BALANCES,
+  SAMPLE_CATEGORIES,
+  buildSampleSnapshot,
+} from '@/lib/wmw/fixtures/sample-snapshot';

--- a/src/lib/wmw/net-worth.test.ts
+++ b/src/lib/wmw/net-worth.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { buildSampleSnapshot } from '@/lib/wmw/fixtures/sample-snapshot';
+import {
+  computeNetWorth,
+  computeNetWorthForMonth,
+} from '@/lib/wmw/net-worth';
+
+describe('computeNetWorth', () => {
+  it('uses latest in-month Balance when an Account has multiple rows', () => {
+    const result = computeNetWorth(buildSampleSnapshot());
+    const feb = result.months.find((m) => m.month === '2026-02');
+    expect(feb).toBeDefined();
+    const isa = feb!.byAccount.find((a) => a.accountId === 'IBKR_ISA');
+    expect(isa?.balance).toBe(22_500);
+    expect(isa?.contribution).toBe(22_500);
+  });
+
+  it('treats a missing Account month as £0 (no carry-forward)', () => {
+    const result = computeNetWorth(buildSampleSnapshot());
+    const mar = result.months.find((m) => m.month === '2026-03');
+    expect(mar).toBeDefined();
+    expect(
+      mar!.byAccount.find((a) => a.accountId === 'CASH_HSBC'),
+    ).toBeUndefined();
+
+    // Jan cash 5_000 must not carry into March total
+    const expectedWithoutCash =
+      23_000 + // ISA
+      77_000 + // car
+      -47_000 + // loan
+      0; // exited crypto
+    expect(mar!.total).toBe(expectedWithoutCash);
+  });
+
+  it('includes explicit £0 exit Balances in the month breakdown', () => {
+    const result = computeNetWorth(buildSampleSnapshot());
+    const mar = result.months.find((m) => m.month === '2026-03');
+    const eth = mar!.byAccount.find((a) => a.accountId === 'CB_ETH');
+    expect(eth).toEqual(
+      expect.objectContaining({
+        balance: 0,
+        contribution: 0,
+        class: 'Cryptocurrency',
+      }),
+    );
+  });
+
+  it('headline is the latest month that has any Balances', () => {
+    const result = computeNetWorth(buildSampleSnapshot());
+    expect(result.headline?.month).toBe('2026-03');
+    expect(result.months.map((m) => m.month)).toEqual([
+      '2026-01',
+      '2026-02',
+      '2026-03',
+    ]);
+  });
+
+  it('applies Category Sign to contributions and Class roll-up', () => {
+    const result = computeNetWorth(buildSampleSnapshot());
+    const jan = result.months.find((m) => m.month === '2026-01')!;
+
+    expect(jan.total).toBe(
+      5_000 + 20_000 + 80_000 + -50_000 + 2_000,
+    );
+
+    const loan = jan.byAccount.find((a) => a.accountId === 'LOAN_MOTONOVO');
+    expect(loan?.sign).toBe(-1);
+    expect(loan?.contribution).toBe(-50_000);
+
+    const cars = jan.byClass.find((c) => c.class === 'Cars');
+    const loans = jan.byClass.find((c) => c.class === 'Loans');
+    expect(cars?.contribution).toBe(80_000);
+    expect(loans?.contribution).toBe(-50_000);
+  });
+
+  it('returns null headline and empty series when there are no Balances', () => {
+    const result = computeNetWorth(
+      buildSampleSnapshot({ balances: [] }),
+    );
+    expect(result.months).toEqual([]);
+    expect(result.headline).toBeNull();
+  });
+});
+
+describe('computeNetWorthForMonth', () => {
+  it('returns £0 total for a calendar month with no Balances', () => {
+    const month = computeNetWorthForMonth(buildSampleSnapshot(), '2025-12');
+    expect(month).toEqual({
+      month: '2025-12',
+      total: 0,
+      byAccount: [],
+      byClass: [],
+    });
+  });
+});

--- a/src/lib/wmw/net-worth.ts
+++ b/src/lib/wmw/net-worth.ts
@@ -1,0 +1,155 @@
+/**
+ * Monthly Net Worth from a Snapshot.
+ * Missing Account that month ⇒ £0 (no carry-forward). Headline = latest month with Balances.
+ */
+
+import {
+  calendarMonthFromDate,
+  compareIsoKeys,
+} from '@/lib/wmw/calendar-month';
+import type {
+  CalendarMonth,
+  WmwAccount,
+  WmwBalance,
+  WmwCategory,
+  WmwSnapshot,
+} from '@/lib/wmw/types';
+
+export type AccountNetWorthRow = {
+  accountId: string;
+  accountName: string;
+  categoryId: string;
+  class: string;
+  balance: number;
+  sign: number;
+  /** Balance × Category Sign. */
+  contribution: number;
+};
+
+export type ClassNetWorthRow = {
+  class: string;
+  contribution: number;
+};
+
+export type NetWorthMonth = {
+  month: CalendarMonth;
+  total: number;
+  byAccount: AccountNetWorthRow[];
+  byClass: ClassNetWorthRow[];
+};
+
+export type NetWorthResult = {
+  /** Ascending by month. */
+  months: NetWorthMonth[];
+  /** Latest month that has any Balances; null when Snapshot has none. */
+  headline: NetWorthMonth | null;
+};
+
+type CategoryLookup = Map<string, WmwCategory>;
+type AccountLookup = Map<string, WmwAccount>;
+
+function categoryLookup(categories: WmwCategory[]): CategoryLookup {
+  return new Map(categories.map((c) => [c.categoryId, c]));
+}
+
+function accountLookup(accounts: WmwAccount[]): AccountLookup {
+  return new Map(accounts.map((a) => [a.accountId, a]));
+}
+
+/** Latest in-month Balance per Account (by date, then last row wins). */
+function latestBalancesByAccount(
+  balances: WmwBalance[],
+): Map<string, WmwBalance> {
+  const sorted = [...balances].sort((a, b) => compareIsoKeys(a.date, b.date));
+  const latest = new Map<string, WmwBalance>();
+  for (const row of sorted) {
+    latest.set(row.accountId, row);
+  }
+  return latest;
+}
+
+function buildMonth(
+  month: CalendarMonth,
+  monthBalances: WmwBalance[],
+  accounts: AccountLookup,
+  categories: CategoryLookup,
+): NetWorthMonth {
+  const latest = latestBalancesByAccount(monthBalances);
+  const byAccount: AccountNetWorthRow[] = [];
+
+  for (const [accountId, balanceRow] of latest) {
+    const account = accounts.get(accountId);
+    if (!account) continue;
+    const category = categories.get(account.categoryId);
+    if (!category) continue;
+
+    const contribution = balanceRow.balance * category.sign;
+    byAccount.push({
+      accountId,
+      accountName: account.accountName,
+      categoryId: account.categoryId,
+      class: category.class,
+      balance: balanceRow.balance,
+      sign: category.sign,
+      contribution,
+    });
+  }
+
+  byAccount.sort((a, b) => a.accountId.localeCompare(b.accountId));
+
+  const classTotals = new Map<string, number>();
+  for (const row of byAccount) {
+    classTotals.set(
+      row.class,
+      (classTotals.get(row.class) ?? 0) + row.contribution,
+    );
+  }
+
+  const byClass: ClassNetWorthRow[] = [...classTotals.entries()]
+    .map(([className, contribution]) => ({
+      class: className,
+      contribution,
+    }))
+    .sort((a, b) => a.class.localeCompare(b.class));
+
+  const total = byAccount.reduce((sum, row) => sum + row.contribution, 0);
+
+  return { month, total, byAccount, byClass };
+}
+
+/**
+ * Compute Net Worth for every calendar month that has at least one Balance.
+ * Accounts with no Balance in a month contribute £0 (omitted from that month’s rows).
+ */
+export function computeNetWorth(snapshot: WmwSnapshot): NetWorthResult {
+  const accounts = accountLookup(snapshot.accounts);
+  const categories = categoryLookup(snapshot.categories);
+
+  const byMonth = new Map<CalendarMonth, WmwBalance[]>();
+  for (const balance of snapshot.balances) {
+    const month = calendarMonthFromDate(balance.date);
+    const list = byMonth.get(month);
+    if (list) list.push(balance);
+    else byMonth.set(month, [balance]);
+  }
+
+  const months = [...byMonth.keys()]
+    .sort(compareIsoKeys)
+    .map((month) =>
+      buildMonth(month, byMonth.get(month)!, accounts, categories),
+    );
+
+  const headline = months.length > 0 ? months[months.length - 1]! : null;
+  return { months, headline };
+}
+
+/** Net Worth for one calendar month; £0 total when the month has no Balances. */
+export function computeNetWorthForMonth(
+  snapshot: WmwSnapshot,
+  month: CalendarMonth,
+): NetWorthMonth {
+  const result = computeNetWorth(snapshot);
+  const found = result.months.find((m) => m.month === month);
+  if (found) return found;
+  return { month, total: 0, byAccount: [], byClass: [] };
+}

--- a/src/lib/wmw/paired-accounts.test.ts
+++ b/src/lib/wmw/paired-accounts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildSampleSnapshot } from '@/lib/wmw/fixtures/sample-snapshot';
+import { computePairEquity } from '@/lib/wmw/paired-accounts';
+
+describe('computePairEquity', () => {
+  it('computes Taycan-style pair equity as asset Balance minus liability Balance', () => {
+    const pairs = computePairEquity(buildSampleSnapshot(), '2026-01');
+    expect(pairs).toHaveLength(1);
+
+    const taycan = pairs[0]!;
+    expect(taycan.pairId).toBe('PAIR_TAYCAN');
+    expect(taycan.asset?.accountId).toBe('CAR_PORSCHE');
+    expect(taycan.liability?.accountId).toBe('LOAN_MOTONOVO');
+    expect(taycan.asset?.balance).toBe(80_000);
+    expect(taycan.liability?.balance).toBe(50_000);
+    expect(taycan.equity).toBe(30_000);
+    expect(taycan.netWorthContribution).toBe(30_000);
+  });
+
+  it('defaults to the headline Net Worth month', () => {
+    const pairs = computePairEquity(buildSampleSnapshot());
+    expect(pairs[0]?.month).toBe('2026-03');
+    expect(pairs[0]?.equity).toBe(77_000 - 47_000);
+  });
+
+  it('treats a missing pair leg that month as £0 Balance', () => {
+    const snapshot = buildSampleSnapshot({
+      balances: [
+        {
+          date: '2026-04-15',
+          accountId: 'CAR_PORSCHE',
+          balance: 76_000,
+          units: null,
+          mileage: 13_000,
+        },
+        // LOAN_MOTONOVO omitted in April
+      ],
+    });
+
+    const pairs = computePairEquity(snapshot, '2026-04');
+    expect(pairs[0]?.asset?.balance).toBe(76_000);
+    expect(pairs[0]?.liability?.balance).toBe(0);
+    expect(pairs[0]?.equity).toBe(76_000);
+  });
+
+  it('ignores unpaired Accounts', () => {
+    const pairs = computePairEquity(buildSampleSnapshot(), '2026-02');
+    expect(pairs.map((p) => p.pairId)).toEqual(['PAIR_TAYCAN']);
+  });
+
+  it('returns an empty list when the Snapshot has no Balances and no month is given', () => {
+    expect(
+      computePairEquity(buildSampleSnapshot({ balances: [] })),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/wmw/paired-accounts.ts
+++ b/src/lib/wmw/paired-accounts.ts
@@ -1,0 +1,138 @@
+/**
+ * Financed pair equity from Paired Accounts sharing a Pair ID.
+ * Equity = asset leg Balance − liability leg Balance (legs via Category Type / Sign).
+ */
+
+import { computeNetWorth, type NetWorthMonth } from '@/lib/wmw/net-worth';
+import type {
+  CalendarMonth,
+  WmwAccount,
+  WmwCategory,
+  WmwSnapshot,
+} from '@/lib/wmw/types';
+
+export type PairLeg = {
+  accountId: string;
+  accountName: string;
+  categoryId: string;
+  type: WmwCategory['type'];
+  sign: number;
+  balance: number;
+  /** Balance × Sign (pair’s contribution to Net Worth). */
+  contribution: number;
+};
+
+export type PairEquity = {
+  pairId: string;
+  month: CalendarMonth;
+  /** Asset Balance − liability Balance (raw legs). */
+  equity: number;
+  /** Sum of signed contributions for the pair (equals equity when signs are ±1). */
+  netWorthContribution: number;
+  asset: PairLeg | null;
+  liability: PairLeg | null;
+};
+
+function categoryById(snapshot: WmwSnapshot): Map<string, WmwCategory> {
+  return new Map(snapshot.categories.map((c) => [c.categoryId, c]));
+}
+
+function accountsByPair(snapshot: WmwSnapshot): Map<string, WmwAccount[]> {
+  const groups = new Map<string, WmwAccount[]>();
+  for (const account of snapshot.accounts) {
+    const pairId = account.pairId?.trim();
+    if (!pairId) continue;
+    const list = groups.get(pairId);
+    if (list) list.push(account);
+    else groups.set(pairId, [account]);
+  }
+  return groups;
+}
+
+function legFromMonth(
+  account: WmwAccount,
+  category: WmwCategory,
+  month: NetWorthMonth,
+): PairLeg {
+  const row = month.byAccount.find((a) => a.accountId === account.accountId);
+  const balance = row?.balance ?? 0;
+  const contribution = balance * category.sign;
+  return {
+    accountId: account.accountId,
+    accountName: account.accountName,
+    categoryId: account.categoryId,
+    type: category.type,
+    sign: category.sign,
+    balance,
+    contribution,
+  };
+}
+
+function isAssetCategory(category: WmwCategory): boolean {
+  if (category.type === 'Asset') return true;
+  if (category.type === 'Liability') return false;
+  return category.sign >= 0;
+}
+
+/**
+ * Pair equity for every non-empty Pair ID in the Snapshot, for the given month
+ * (defaults to headline Net Worth month). Missing legs contribute £0 Balance.
+ */
+export function computePairEquity(
+  snapshot: WmwSnapshot,
+  month?: CalendarMonth,
+): PairEquity[] {
+  const netWorth = computeNetWorth(snapshot);
+  const targetMonth =
+    month ??
+    netWorth.headline?.month ??
+    null;
+  if (!targetMonth) return [];
+
+  const monthResult =
+    netWorth.months.find((m) => m.month === targetMonth) ??
+    ({
+      month: targetMonth,
+      total: 0,
+      byAccount: [],
+      byClass: [],
+    } satisfies NetWorthMonth);
+
+  const categories = categoryById(snapshot);
+  const pairs = accountsByPair(snapshot);
+  const results: PairEquity[] = [];
+
+  for (const pairId of [...pairs.keys()].sort()) {
+    const members = pairs.get(pairId)!;
+    let asset: PairLeg | null = null;
+    let liability: PairLeg | null = null;
+
+    for (const account of members) {
+      const category = categories.get(account.categoryId);
+      if (!category) continue;
+      const leg = legFromMonth(account, category, monthResult);
+      if (isAssetCategory(category)) {
+        asset = leg;
+      } else {
+        liability = leg;
+      }
+    }
+
+    const assetBalance = asset?.balance ?? 0;
+    const liabilityBalance = liability?.balance ?? 0;
+    const equity = assetBalance - liabilityBalance;
+    const netWorthContribution =
+      (asset?.contribution ?? 0) + (liability?.contribution ?? 0);
+
+    results.push({
+      pairId,
+      month: targetMonth,
+      equity,
+      netWorthContribution,
+      asset,
+      liability,
+    });
+  }
+
+  return results;
+}

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -1,15 +1,88 @@
 /**
- * WMW Snapshot domain types — mirror the frozen Workbook contract from epic #179 /
- * ADR 0010. Dates are ISO calendar days (YYYY-MM-DD) after ingest parses Sheet serials.
- * Amounts are GBP; Cashflow Amounts are account-perspective (into Account positive).
+ * WMW Snapshot domain types — frozen Workbook contract from epic #179 /
+ * ADR 0009 / ADR 0010. Shared across storage (#182), ingest (#183), Net Worth
+ * (#184), and MWR (#185). Dates are ISO calendar days (YYYY-MM-DD) after ingest
+ * parses Sheet serials. Amounts are GBP; Cashflow Amounts are account-perspective
+ * (into Account positive).
  */
+
+export const WMW_WORKBOOK_TABS = [
+  'dim_Accounts',
+  'dim_Categories',
+  'fact_Balances',
+  'fact_Cashflows',
+] as const;
+
+export type WmwWorkbookTab = (typeof WMW_WORKBOOK_TABS)[number];
+
+export const WMW_ACCOUNT_COLUMNS = [
+  'Account_ID',
+  'Account_Name',
+  'Platform',
+  'Category_ID',
+  'Currency',
+  'Pair_ID',
+] as const;
+
+export const WMW_CATEGORY_COLUMNS = [
+  'Category_ID',
+  'Type',
+  'Class',
+  'Sign',
+] as const;
+
+export const WMW_BALANCE_COLUMNS = [
+  'Date',
+  'Account_ID',
+  'Balance',
+  'Units',
+  'Mileage',
+] as const;
+
+export const WMW_CASHFLOW_COLUMNS = [
+  'Date',
+  'Account_ID',
+  'Amount',
+  'Transaction_Type',
+  'Description',
+] as const;
+
+/** v1 known Transaction_Type values (epic #179 / ADR 0010). */
+export const WMW_CASHFLOW_TRANSACTION_TYPES = [
+  'Contribution',
+  'Withdrawal',
+  'Loan Repayment',
+] as const;
+
+/**
+ * Open union: known Types plus unknown Sheet strings. MWR ignores unknowns;
+ * ingest may filter before Snapshot persist and warn on Refresh.
+ */
+export type WmwCashflowTransactionType =
+  | (typeof WMW_CASHFLOW_TRANSACTION_TYPES)[number]
+  | (string & {});
+
+/** Alias so MWR and Net Worth call sites share one vocabulary. */
+export type WmwCashflowType = WmwCashflowTransactionType;
+
+/** Category allow-list for Investable Accounts (MWR). */
+export const WMW_INVESTABLE_CATEGORY_IDS = [
+  'CAT_BROKERAGE',
+  'CAT_PENSION',
+  'CAT_CRYPTO',
+] as const;
+
+export type WmwInvestableCategoryId =
+  (typeof WMW_INVESTABLE_CATEGORY_IDS)[number];
+
+export const WMW_SUPPORTED_CURRENCY = 'GBP' as const;
 
 export type WmwAccount = {
   accountId: string;
   accountName: string;
   platform: string;
   categoryId: string;
-  /** v1 is GBP-only. */
+  /** v1 is GBP-only; ingest excludes non-GBP Accounts. */
   currency: string;
   /** Empty / null means unpaired. */
   pairId: string | null;
@@ -33,19 +106,6 @@ export type WmwBalance = {
   mileage: number | null;
 };
 
-/**
- * v1 known Transaction_Type values. Unknown strings are allowed (open union) but
- * ignored for MWR; ingest may filter before Snapshot persist.
- */
-export type WmwCashflowTransactionType =
-  | 'Contribution'
-  | 'Withdrawal'
-  | 'Loan Repayment'
-  | (string & {});
-
-/** Alias kept so MWR and Net Worth call sites share one vocabulary. */
-export type WmwCashflowType = WmwCashflowTransactionType;
-
 export type WmwCashflow = {
   /** Calendar date YYYY-MM-DD. */
   date: string;
@@ -56,7 +116,24 @@ export type WmwCashflow = {
   description: string;
 };
 
-/** Point-in-time copy of Workbook facts held for the lab. */
+export type WmwRefreshWarningCode =
+  | 'unknown_transaction_type'
+  | 'non_gbp_account'
+  | 'invalid_row'
+  | 'orphan_fact';
+
+export type WmwRefreshWarning = {
+  code: WmwRefreshWarningCode;
+  message: string;
+  tab?: WmwWorkbookTab;
+  row?: number;
+  details?: Record<string, unknown>;
+};
+
+/**
+ * Point-in-time Workbook copy for the lab (private storage, not Site Content).
+ * Ingest retains Refresh warnings on last-good; calc fixtures use [].
+ */
 export type WmwSnapshot = {
   /** ISO timestamp when the Snapshot was taken (as-of). */
   asOf: string;
@@ -64,7 +141,11 @@ export type WmwSnapshot = {
   categories: WmwCategory[];
   balances: WmwBalance[];
   cashflows: WmwCashflow[];
+  warnings: WmwRefreshWarning[];
 };
+
+/** Unformatted Sheets matrices (header row + data rows). */
+export type WmwWorkbookRaw = Record<WmwWorkbookTab, unknown[][]>;
 
 /** Calendar month key YYYY-MM. */
 export type CalendarMonth = string;

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -1,6 +1,7 @@
-﻿/**
- * Normalised WMW Snapshot contract (Workbook tabs after ingest).
- * Column sets match epic #179 / ADR 0010; dates are calendar ISO strings.
+/**
+ * WMW Snapshot domain types — mirror the frozen Workbook contract from epic #179 /
+ * ADR 0010. Dates are ISO calendar days (YYYY-MM-DD) after ingest parses Sheet serials.
+ * Amounts are GBP; Cashflow Amounts are account-perspective (into Account positive).
  */
 
 export type WmwAccount = {
@@ -19,7 +20,7 @@ export type WmwCategory = {
   /** Workbook Type, e.g. Asset | Liability. */
   type: string;
   class: string;
-  /** +1 asset, -1 liability when rolling into Net Worth. */
+  /** +1 asset, −1 liability when rolling into Net Worth. */
   sign: number;
 };
 
@@ -32,25 +33,32 @@ export type WmwBalance = {
   mileage: number | null;
 };
 
-/** v1 known Types; unknown strings may appear before ingest filtering. */
+/**
+ * v1 known Transaction_Type values. Unknown strings are allowed (open union) but
+ * ignored for MWR; ingest may filter before Snapshot persist.
+ */
 export type WmwCashflowTransactionType =
   | 'Contribution'
   | 'Withdrawal'
-  | 'Loan Repayment';
+  | 'Loan Repayment'
+  | (string & {});
+
+/** Alias kept so MWR and Net Worth call sites share one vocabulary. */
+export type WmwCashflowType = WmwCashflowTransactionType;
 
 export type WmwCashflow = {
   /** Calendar date YYYY-MM-DD. */
   date: string;
   accountId: string;
-  /** Account-perspective signed Amount. */
+  /** Account-perspective: into Account positive, out negative. */
   amount: number;
-  transactionType: WmwCashflowTransactionType | string;
+  transactionType: WmwCashflowTransactionType;
   description: string;
 };
 
 /** Point-in-time copy of Workbook facts held for the lab. */
 export type WmwSnapshot = {
-  /** ISO timestamp when the Snapshot was taken. */
+  /** ISO timestamp when the Snapshot was taken (as-of). */
   asOf: string;
   accounts: WmwAccount[];
   categories: WmwCategory[];

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -1,0 +1,62 @@
+﻿/**
+ * Normalised WMW Snapshot contract (Workbook tabs after ingest).
+ * Column sets match epic #179 / ADR 0010; dates are calendar ISO strings.
+ */
+
+export type WmwAccount = {
+  accountId: string;
+  accountName: string;
+  platform: string;
+  categoryId: string;
+  /** v1 is GBP-only. */
+  currency: string;
+  /** Empty / null means unpaired. */
+  pairId: string | null;
+};
+
+export type WmwCategory = {
+  categoryId: string;
+  /** Workbook Type, e.g. Asset | Liability. */
+  type: string;
+  class: string;
+  /** +1 asset, -1 liability when rolling into Net Worth. */
+  sign: number;
+};
+
+export type WmwBalance = {
+  /** Calendar date YYYY-MM-DD. */
+  date: string;
+  accountId: string;
+  balance: number;
+  units: number | null;
+  mileage: number | null;
+};
+
+/** v1 known Types; unknown strings may appear before ingest filtering. */
+export type WmwCashflowTransactionType =
+  | 'Contribution'
+  | 'Withdrawal'
+  | 'Loan Repayment';
+
+export type WmwCashflow = {
+  /** Calendar date YYYY-MM-DD. */
+  date: string;
+  accountId: string;
+  /** Account-perspective signed Amount. */
+  amount: number;
+  transactionType: WmwCashflowTransactionType | string;
+  description: string;
+};
+
+/** Point-in-time copy of Workbook facts held for the lab. */
+export type WmwSnapshot = {
+  /** ISO timestamp when the Snapshot was taken. */
+  asOf: string;
+  accounts: WmwAccount[];
+  categories: WmwCategory[];
+  balances: WmwBalance[];
+  cashflows: WmwCashflow[];
+};
+
+/** Calendar month key YYYY-MM. */
+export type CalendarMonth = string;


### PR DESCRIPTION
## Summary
- Add pure `src/lib/wmw` modules for monthly Net Worth (no carry-forward), Class/Account breakdown, and `Pair_ID` equity from a Snapshot.
- Introduce a shared Snapshot type contract aligned with epic #179 / ADR 0010 column sets (calendar ISO dates post-ingest).
- Vitest fixtures cover missing-month = £0, multi-Balance same month, Taycan-style pair equity, and exited £0 rows. No UI.

## Snapshot shape (assumption for parallel issues)
Normalised `WmwSnapshot` with `accounts`, `categories`, `balances`, `cashflows`, and `asOf`. Field names are camelCase mirrors of Workbook columns (`accountId`, `pairId`, `sign`, etc.); Balance dates are `YYYY-MM-DD`. Ingest (#183) and MWR (#185) should reuse `@/lib/wmw` types rather than inventing a divergent schema.

## Test plan
- [x] `npx vitest run src/lib/wmw/net-worth.test.ts src/lib/wmw/paired-accounts.test.ts` (12 passed)
- [ ] Confirm Overview (#186) can import `computeNetWorth` / `computePairEquity` without UI changes here
- [ ] Reconcile Snapshot types if #183 lands a stricter ingest contract first

Closes #184.

Made with [Cursor](https://cursor.com)