### PR TITLE
Add private WMW Snapshot storage and config (#182)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# WMW (What's My Worth) - placeholders until secrets are set in #181.
+# Copy to .env.local for local development. Never commit real IDs or SA JSON.
+
+# Google Sheets spreadsheet ID for the equity Workbook (system of record).
+WMW_SPREADSHEET_ID=
+
+# Host/Amplify secret name that holds the Google service account JSON.
+# The JSON itself must never be committed; only the secret name is referenced here.
+WMW_GOOGLE_SA_SECRET_NAME=wmw/google-service-account

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+
 
 # vercel
 .vercel

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -3,13 +3,18 @@ import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { auth } from './auth/resource.js';
 import { data } from './data/resource.js';
 import { analyseFit } from './functions/analyse-fit/resource.js';
-import { siteContentStorage, storage } from './storage/resource.js';
+import {
+  siteContentStorage,
+  storage,
+  wmwSnapshotsStorage,
+} from './storage/resource.js';
 
 const backend = defineBackend({
   auth,
   data,
   storage,
   siteContentStorage,
+  wmwSnapshotsStorage,
   analyseFit,
 });
 

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -46,3 +46,19 @@ export const siteContentStorage = defineStorage({
     ],
   }),
 });
+
+/**
+ * Private WMW lab Snapshots (last-good Workbook copy + as-of metadata).
+ * Authenticated Site Admin only — never guest/public Site Content.
+ *
+ * Amplify requires every defineStorage() call to live in this file
+ * (amplify/storage/resource.ts); subdirectory resources fail assembly.
+ */
+export const wmwSnapshotsStorage = defineStorage({
+  name: 'wmwSnapshots',
+  access: (allow) => ({
+    'snapshots/*': [
+      allow.authenticated.to(['read', 'write', 'delete']),
+    ],
+  }),
+});

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -77,6 +77,8 @@ If `nvm use 22` fails on the build image (version not installed), add a line bef
 
 Site Content no longer requires private blog-repo SSH secrets. Remove obsolete `SSH_PRIVATE_KEY` / `BLOG_REPO_*` console variables when convenient.
 
+WMW (What's My Worth) expects `WMW_SPREADSHEET_ID` and `WMW_GOOGLE_SA_SECRET_NAME` (secret name only — not the service account JSON). Placeholders live in `.env.example`; real values are set in [#181](https://github.com/hashadar/hashadar_website/issues/181). See [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md).
+
 ## CI vs Site Content
 
 GitHub Actions builds without `amplify_outputs.json`. Public blog/portfolio readers return **empty** lists; Vitest covers markdown processing and fixtures. Production Posts/Photos are uploaded via **Admin** after deploy.

--- a/docs/CODEBASE-CONVENTIONS.md
+++ b/docs/CODEBASE-CONVENTIONS.md
@@ -63,6 +63,7 @@ This document defines how to work in this codebase so that new and changed code 
 ### 4.3 Blog and portfolio (Site Content)
 
 - **Source of truth:** Amplify Storage bucket `siteContent` — `blog/index.json` + `blog/posts/{slug}.md` (+ optional hero WebPs), `portfolio/manifest.json` + `portfolio/images/*`, and `home/photography.json` + `home/images/*` for the Home Photo. Readers live under `src/lib/site-content/` (server loaders in `server.ts`). Markdown → HTML remains in `src/lib/blog-markdown.ts` (`processMarkdown`). Filesystem helpers in `src/lib/blog.ts` are for Vitest fixtures only.
+- **WMW Snapshots:** Private Amplify Storage bucket `wmwSnapshots` (authenticated Site Admin only) holds last-good Snapshot JSON + as-of metadata. Keys and env wiring: `docs/wmw/snapshot-storage.md`; facade under `src/lib/wmw/`.
 - **Admin:** Site Admin manages Posts and Photos at `/admin` (not under Labs). Sign-in is site-wide at `/login`.
 - **Types:** Use `BlogPost` / `BlogPostFrontmatter` / `PhotoItem` from `@/data/types`. List metadata for Posts is authoritative in `blog/index.json`.
 - **Sitemap:** `src/lib/sitemap.ts` (`buildSitemap`) derives blog URLs from Site Content readers. `/login` and `/admin` are omitted (noindex).

--- a/docs/wmw/CONTEXT.md
+++ b/docs/wmw/CONTEXT.md
@@ -15,7 +15,7 @@ The Site Admin’s spreadsheet that remains the system of record for Accounts, C
 _Avoid_: CMS, lab editor, dual source of truth, ad-hoc extra tabs as part of the v1 contract, depending on formatted £/date strings from the API
 
 **Snapshot**:
-A point-in-time copy of Workbook data held in private lab storage for the lab to display, with a known as-of time. Used so the dashboard can show last-good data without editing the Workbook and without depending on a live Google call every view.
+A point-in-time copy of Workbook data held in private lab storage for the lab to display, with a known as-of time. Used so the dashboard can show last-good data without editing the Workbook and without depending on a live Google call every view. Object keys and bucket: [snapshot-storage.md](./snapshot-storage.md).
 _Avoid_: backup, export (as the product noun), live-only read with no retained copy, Site Content (public) as the Snapshot home
 
 ### Portfolio structure

--- a/docs/wmw/snapshot-storage.md
+++ b/docs/wmw/snapshot-storage.md
@@ -1,0 +1,33 @@
+# WMW Snapshot storage
+
+Private Amplify Storage for last-good Workbook Snapshots. Distinct from public Site Content (`siteContent`) and Job OS Body storage (`jobOsBodies`).
+
+## Bucket
+
+| `defineStorage` name | Access |
+|----------------------|--------|
+| `wmwSnapshots` | Authenticated Site Admin only (`read` / `write` / `delete`). No guest access. |
+
+Defined in `amplify/storage/resource.ts` and registered in `amplify/backend.ts`.
+
+## Object key layout
+
+Keys are relative to the `wmwSnapshots` bucket:
+
+| Key | Purpose |
+|-----|---------|
+| `snapshots/last-good.json` | Last-good Snapshot payload (normalised Workbook tabs; ingest shape lands in #183). |
+| `snapshots/last-good.meta.json` | As-of metadata for that Snapshot (`asOf` ISO-8601 timestamp, and any small ingest notes). |
+
+Helpers: `src/lib/wmw/paths.ts`. Facade: `src/lib/wmw/snapshot-storage.ts`.
+
+## App config / secrets
+
+Env wiring (placeholders OK until [#181](https://github.com/hashadar/hashadar_website/issues/181)):
+
+| Variable | Role |
+|----------|------|
+| `WMW_SPREADSHEET_ID` | Equity Workbook spreadsheet ID |
+| `WMW_GOOGLE_SA_SECRET_NAME` | Name of the host/Amplify secret that holds the Google service account JSON |
+
+See `.env.example`. Do not commit spreadsheet secrets or service account JSON.

--- a/src/lib/wmw/config.test.ts
+++ b/src/lib/wmw/config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getWmwConfig,
+  WMW_GOOGLE_SA_SECRET_NAME_ENV,
+  WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER,
+  WMW_SPREADSHEET_ID_ENV,
+} from '@/lib/wmw/config';
+
+describe('getWmwConfig', () => {
+  it('returns nulls when env vars are missing', () => {
+    expect(getWmwConfig({})).toEqual({
+      spreadsheetId: null,
+      googleServiceAccountSecretName: null,
+    });
+  });
+
+  it('reads spreadsheet ID and secret name placeholders', () => {
+    expect(
+      getWmwConfig({
+        [WMW_SPREADSHEET_ID_ENV]: '  sheet-id-123  ',
+        [WMW_GOOGLE_SA_SECRET_NAME_ENV]: WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER,
+      }),
+    ).toEqual({
+      spreadsheetId: 'sheet-id-123',
+      googleServiceAccountSecretName: WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER,
+    });
+  });
+
+  it('treats blank values as unset', () => {
+    expect(
+      getWmwConfig({
+        [WMW_SPREADSHEET_ID_ENV]: '   ',
+        [WMW_GOOGLE_SA_SECRET_NAME_ENV]: '',
+      }),
+    ).toEqual({
+      spreadsheetId: null,
+      googleServiceAccountSecretName: null,
+    });
+  });
+});

--- a/src/lib/wmw/config.ts
+++ b/src/lib/wmw/config.ts
@@ -1,0 +1,32 @@
+/**
+ * WMW app config from environment.
+ * Spreadsheet ID and SA secret values are supplied in #181; placeholders are fine until then.
+ */
+export type WmwConfig = {
+  spreadsheetId: string | null;
+  /** Host/Amplify secret name that holds the Google service account JSON. */
+  googleServiceAccountSecretName: string | null;
+};
+
+export const WMW_SPREADSHEET_ID_ENV = 'WMW_SPREADSHEET_ID';
+export const WMW_GOOGLE_SA_SECRET_NAME_ENV = 'WMW_GOOGLE_SA_SECRET_NAME';
+
+/** Default secret name documented in `.env.example` (not a credential). */
+export const WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER = 'wmw/google-service-account';
+
+type EnvLike = Record<string, string | undefined>;
+
+function readTrimmed(env: EnvLike, key: string): string | null {
+  const value = env[key]?.trim();
+  return value ? value : null;
+}
+
+export function getWmwConfig(env: EnvLike = process.env): WmwConfig {
+  return {
+    spreadsheetId: readTrimmed(env, WMW_SPREADSHEET_ID_ENV),
+    googleServiceAccountSecretName: readTrimmed(
+      env,
+      WMW_GOOGLE_SA_SECRET_NAME_ENV,
+    ),
+  };
+}

--- a/src/lib/wmw/paths.ts
+++ b/src/lib/wmw/paths.ts
@@ -1,0 +1,13 @@
+/** Amplify Storage bucket name from defineStorage({ name: 'wmwSnapshots' }). */
+export const WMW_SNAPSHOTS_BUCKET = 'wmwSnapshots';
+
+/** Last-good Snapshot JSON under the private WMW bucket. */
+export const WMW_LAST_GOOD_SNAPSHOT_KEY = 'snapshots/last-good.json';
+
+/** As-of metadata for the last-good Snapshot. */
+export const WMW_LAST_GOOD_META_KEY = 'snapshots/last-good.meta.json';
+
+export type WmwSnapshotMeta = {
+  /** ISO-8601 timestamp when the Snapshot was taken from the Workbook. */
+  asOf: string;
+};

--- a/src/lib/wmw/snapshot-storage.test.ts
+++ b/src/lib/wmw/snapshot-storage.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  WMW_LAST_GOOD_META_KEY,
+  WMW_LAST_GOOD_SNAPSHOT_KEY,
+  WMW_SNAPSHOTS_BUCKET,
+} from '@/lib/wmw/paths';
+import {
+  createMemoryWmwSnapshotStorage,
+  createWmwSnapshotStorage,
+  WMW_SNAPSHOT_CONTENT_TYPE,
+  WMW_SNAPSHOT_FAILED_REASON,
+  WMW_SNAPSHOT_UNAUTHENTICATED_REASON,
+  type WmwDownloadData,
+  type WmwUploadData,
+} from '@/lib/wmw/snapshot-storage';
+
+function createFakeAmplify(files: Record<string, string> = {}): {
+  uploadData: WmwUploadData;
+  downloadData: WmwDownloadData;
+  files: Record<string, string>;
+} {
+  const store = { ...files };
+
+  const uploadData: WmwUploadData = ({ path, data, options }) => ({
+    result: (async () => {
+      expect(options?.bucket).toBe(WMW_SNAPSHOTS_BUCKET);
+      expect(options?.contentType).toBe(WMW_SNAPSHOT_CONTENT_TYPE);
+      const text =
+        typeof data === 'string'
+          ? data
+          : new TextDecoder().decode(data as Uint8Array);
+      store[path] = text;
+    })(),
+  });
+
+  const downloadData: WmwDownloadData = ({ path, options }) => ({
+    result: (async () => {
+      expect(options?.bucket).toBe(WMW_SNAPSHOTS_BUCKET);
+      const text = store[path];
+      if (text === undefined) {
+        throw new Error('NoSuchKey');
+      }
+      return {
+        body: {
+          text: async () => text,
+        },
+      };
+    })(),
+  });
+
+  return { uploadData, downloadData, files: store };
+}
+
+describe('WMW Snapshot storage', () => {
+  it('uses the documented last-good object keys', () => {
+    expect(WMW_LAST_GOOD_SNAPSHOT_KEY).toBe('snapshots/last-good.json');
+    expect(WMW_LAST_GOOD_META_KEY).toBe('snapshots/last-good.meta.json');
+    expect(WMW_SNAPSHOTS_BUCKET).toBe('wmwSnapshots');
+  });
+
+  it('round-trips last-good Snapshot JSON and as-of metadata via fakes', async () => {
+    const fake = createFakeAmplify();
+    const storage = createWmwSnapshotStorage(fake);
+    const snapshotJson = JSON.stringify({ accounts: [{ id: 'A1' }] });
+
+    await storage.putLastGoodSnapshot({
+      snapshotJson,
+      asOf: '2026-08-08T12:00:00.000Z',
+    });
+
+    expect(fake.files[WMW_LAST_GOOD_SNAPSHOT_KEY]).toBe(snapshotJson);
+    expect(JSON.parse(fake.files[WMW_LAST_GOOD_META_KEY]!)).toEqual({
+      asOf: '2026-08-08T12:00:00.000Z',
+    });
+
+    await expect(storage.getLastGoodSnapshot()).resolves.toEqual({
+      snapshotJson,
+      meta: { asOf: '2026-08-08T12:00:00.000Z' },
+    });
+  });
+
+  it('returns null when no last-good Snapshot exists', async () => {
+    const storage = createWmwSnapshotStorage(createFakeAmplify());
+    await expect(storage.getLastGoodSnapshot()).resolves.toBeNull();
+  });
+
+  it('returns null when as-of metadata is invalid', async () => {
+    const storage = createWmwSnapshotStorage(
+      createFakeAmplify({
+        [WMW_LAST_GOOD_SNAPSHOT_KEY]: '{}',
+        [WMW_LAST_GOOD_META_KEY]: '{"asOf":""}',
+      }),
+    );
+    await expect(storage.getLastGoodSnapshot()).resolves.toBeNull();
+  });
+
+  it('maps unauthenticated Amplify errors to British English copy', async () => {
+    const uploadData = vi.fn(() => ({
+      result: Promise.reject(new Error('UserUnAuthenticatedException: No current user')),
+    })) as unknown as WmwUploadData;
+    const storage = createWmwSnapshotStorage({
+      uploadData,
+      downloadData: createFakeAmplify().downloadData,
+    });
+
+    await expect(
+      storage.putLastGoodSnapshot({
+        snapshotJson: '{}',
+        asOf: '2026-08-08T12:00:00.000Z',
+      }),
+    ).rejects.toThrow(WMW_SNAPSHOT_UNAUTHENTICATED_REASON);
+  });
+
+  it('falls back to a generic failure reason when Amplify rejects without a message', async () => {
+    const uploadData = vi.fn(() => ({
+      result: Promise.reject(new Error('   ')),
+    })) as unknown as WmwUploadData;
+    const storage = createWmwSnapshotStorage({
+      uploadData,
+      downloadData: createFakeAmplify().downloadData,
+    });
+
+    await expect(
+      storage.putLastGoodSnapshot({
+        snapshotJson: '{}',
+        asOf: '2026-08-08T12:00:00.000Z',
+      }),
+    ).rejects.toThrow(WMW_SNAPSHOT_FAILED_REASON);
+  });
+
+  it('provides an in-memory fake for Vitest without live AWS', async () => {
+    const storage = createMemoryWmwSnapshotStorage();
+    await storage.putLastGoodSnapshot({
+      snapshotJson: '{"ok":true}',
+      asOf: '2026-08-08T15:30:00.000Z',
+    });
+    await expect(storage.getLastGoodSnapshot()).resolves.toEqual({
+      snapshotJson: '{"ok":true}',
+      meta: { asOf: '2026-08-08T15:30:00.000Z' },
+    });
+  });
+});

--- a/src/lib/wmw/snapshot-storage.ts
+++ b/src/lib/wmw/snapshot-storage.ts
@@ -6,6 +6,8 @@ import {
   type WmwSnapshotMeta,
 } from '@/lib/wmw/paths';
 
+/** JSON body shape for `snapshots/last-good.json` — see `@/lib/wmw/types`. */
+export type { WmwSnapshot } from '@/lib/wmw/types';
 export type { WmwSnapshotMeta };
 
 /** No charset — browsers rewrite string Content-Types and break SigV4. */

--- a/src/lib/wmw/snapshot-storage.ts
+++ b/src/lib/wmw/snapshot-storage.ts
@@ -1,0 +1,181 @@
+import { isAmplifyClientConfigured } from '@/lib/is-amplify-client-configured';
+import {
+  WMW_LAST_GOOD_META_KEY,
+  WMW_LAST_GOOD_SNAPSHOT_KEY,
+  WMW_SNAPSHOTS_BUCKET,
+  type WmwSnapshotMeta,
+} from '@/lib/wmw/paths';
+
+export type { WmwSnapshotMeta };
+
+/** No charset — browsers rewrite string Content-Types and break SigV4. */
+export const WMW_SNAPSHOT_CONTENT_TYPE = 'application/json';
+
+export const WMW_SNAPSHOT_CLIENT_NOT_CONFIGURED_REASON =
+  'WMW Snapshot storage client is not configured';
+
+export const WMW_SNAPSHOT_UNAUTHENTICATED_REASON =
+  'You must be signed in to manage WMW Snapshots.';
+
+export const WMW_SNAPSHOT_FAILED_REASON =
+  'Unable to save the WMW Snapshot. Please try again.';
+
+export type WmwUploadData = (input: {
+  path: string;
+  data: string | Blob | ArrayBuffer | Uint8Array;
+  options?: {
+    contentType?: string;
+    bucket?: string;
+  };
+}) => { result: Promise<unknown> };
+
+export type WmwDownloadData = (input: {
+  path: string;
+  options?: { bucket?: string };
+}) => {
+  result: Promise<{ body: { text: () => Promise<string> } }>;
+};
+
+export type WmwLastGoodSnapshot = {
+  snapshotJson: string;
+  meta: WmwSnapshotMeta;
+};
+
+export type WmwSnapshotStorage = {
+  putLastGoodSnapshot: (input: {
+    snapshotJson: string;
+    asOf: string;
+  }) => Promise<void>;
+  getLastGoodSnapshot: () => Promise<WmwLastGoodSnapshot | null>;
+};
+
+const bucketOptions = { bucket: WMW_SNAPSHOTS_BUCKET };
+
+function isUnauthenticatedError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('no current user') ||
+    lower.includes('not authorized') ||
+    lower.includes('unauthorised') ||
+    lower.includes('unauthorized') ||
+    lower.includes('not authenticated') ||
+    lower.includes('user is not authenticated')
+  );
+}
+
+function encodeJson(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+function parseMeta(text: string): WmwSnapshotMeta | null {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('asOf' in parsed) ||
+      typeof (parsed as { asOf: unknown }).asOf !== 'string' ||
+      !(parsed as { asOf: string }).asOf.trim()
+    ) {
+      return null;
+    }
+    return { asOf: (parsed as { asOf: string }).asOf };
+  } catch {
+    return null;
+  }
+}
+
+export async function putLastGoodViaUploadData(
+  input: { snapshotJson: string; asOf: string },
+  uploadData: WmwUploadData,
+): Promise<void> {
+  const meta: WmwSnapshotMeta = { asOf: input.asOf };
+  await uploadData({
+    path: WMW_LAST_GOOD_SNAPSHOT_KEY,
+    data: encodeJson(input.snapshotJson),
+    options: { ...bucketOptions, contentType: WMW_SNAPSHOT_CONTENT_TYPE },
+  }).result;
+  await uploadData({
+    path: WMW_LAST_GOOD_META_KEY,
+    data: encodeJson(JSON.stringify(meta)),
+    options: { ...bucketOptions, contentType: WMW_SNAPSHOT_CONTENT_TYPE },
+  }).result;
+}
+
+export async function getLastGoodViaDownloadData(
+  downloadData: WmwDownloadData,
+): Promise<WmwLastGoodSnapshot | null> {
+  try {
+    const [{ body: snapshotBody }, { body: metaBody }] = await Promise.all([
+      downloadData({
+        path: WMW_LAST_GOOD_SNAPSHOT_KEY,
+        options: bucketOptions,
+      }).result,
+      downloadData({
+        path: WMW_LAST_GOOD_META_KEY,
+        options: bucketOptions,
+      }).result,
+    ]);
+    const snapshotJson = await snapshotBody.text();
+    const meta = parseMeta(await metaBody.text());
+    if (!meta) {
+      return null;
+    }
+    return { snapshotJson, meta };
+  } catch {
+    return null;
+  }
+}
+
+export function createWmwSnapshotStorage(options: {
+  uploadData: WmwUploadData;
+  downloadData: WmwDownloadData;
+}): WmwSnapshotStorage {
+  return {
+    async putLastGoodSnapshot(input) {
+      try {
+        await putLastGoodViaUploadData(input, options.uploadData);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : '';
+        if (isUnauthenticatedError(message)) {
+          throw new Error(WMW_SNAPSHOT_UNAUTHENTICATED_REASON);
+        }
+        throw new Error(message.trim() || WMW_SNAPSHOT_FAILED_REASON);
+      }
+    },
+    async getLastGoodSnapshot() {
+      return getLastGoodViaDownloadData(options.downloadData);
+    },
+  };
+}
+
+export function createMemoryWmwSnapshotStorage(
+  initial?: WmwLastGoodSnapshot | null,
+): WmwSnapshotStorage {
+  let stored: WmwLastGoodSnapshot | null = initial ?? null;
+
+  return {
+    async putLastGoodSnapshot({ snapshotJson, asOf }) {
+      stored = { snapshotJson, meta: { asOf } };
+    },
+    async getLastGoodSnapshot() {
+      return stored;
+    },
+  };
+}
+
+export async function createDefaultWmwSnapshotStorage(): Promise<WmwSnapshotStorage | null> {
+  if (!isAmplifyClientConfigured()) {
+    return null;
+  }
+
+  try {
+    const { uploadData, downloadData } = await import('aws-amplify/storage');
+    return createWmwSnapshotStorage({
+      uploadData: uploadData as WmwUploadData,
+      downloadData: downloadData as WmwDownloadData,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/wmw/types.ts
+++ b/src/lib/wmw/types.ts
@@ -1,0 +1,151 @@
+/**
+ * WMW Snapshot domain types — frozen Workbook contract from epic #179 /
+ * ADR 0009 / ADR 0010. Shared across storage (#182), ingest (#183), Net Worth
+ * (#184), and MWR (#185). Dates are ISO calendar days (YYYY-MM-DD) after ingest
+ * parses Sheet serials. Amounts are GBP; Cashflow Amounts are account-perspective
+ * (into Account positive).
+ */
+
+export const WMW_WORKBOOK_TABS = [
+  'dim_Accounts',
+  'dim_Categories',
+  'fact_Balances',
+  'fact_Cashflows',
+] as const;
+
+export type WmwWorkbookTab = (typeof WMW_WORKBOOK_TABS)[number];
+
+export const WMW_ACCOUNT_COLUMNS = [
+  'Account_ID',
+  'Account_Name',
+  'Platform',
+  'Category_ID',
+  'Currency',
+  'Pair_ID',
+] as const;
+
+export const WMW_CATEGORY_COLUMNS = [
+  'Category_ID',
+  'Type',
+  'Class',
+  'Sign',
+] as const;
+
+export const WMW_BALANCE_COLUMNS = [
+  'Date',
+  'Account_ID',
+  'Balance',
+  'Units',
+  'Mileage',
+] as const;
+
+export const WMW_CASHFLOW_COLUMNS = [
+  'Date',
+  'Account_ID',
+  'Amount',
+  'Transaction_Type',
+  'Description',
+] as const;
+
+/** v1 known Transaction_Type values (epic #179 / ADR 0010). */
+export const WMW_CASHFLOW_TRANSACTION_TYPES = [
+  'Contribution',
+  'Withdrawal',
+  'Loan Repayment',
+] as const;
+
+/**
+ * Open union: known Types plus unknown Sheet strings. MWR ignores unknowns;
+ * ingest may filter before Snapshot persist and warn on Refresh.
+ */
+export type WmwCashflowTransactionType =
+  | (typeof WMW_CASHFLOW_TRANSACTION_TYPES)[number]
+  | (string & {});
+
+/** Alias so MWR and Net Worth call sites share one vocabulary. */
+export type WmwCashflowType = WmwCashflowTransactionType;
+
+/** Category allow-list for Investable Accounts (MWR). */
+export const WMW_INVESTABLE_CATEGORY_IDS = [
+  'CAT_BROKERAGE',
+  'CAT_PENSION',
+  'CAT_CRYPTO',
+] as const;
+
+export type WmwInvestableCategoryId =
+  (typeof WMW_INVESTABLE_CATEGORY_IDS)[number];
+
+export const WMW_SUPPORTED_CURRENCY = 'GBP' as const;
+
+export type WmwAccount = {
+  accountId: string;
+  accountName: string;
+  platform: string;
+  categoryId: string;
+  /** v1 is GBP-only; ingest excludes non-GBP Accounts. */
+  currency: string;
+  /** Empty / null means unpaired. */
+  pairId: string | null;
+};
+
+export type WmwCategory = {
+  categoryId: string;
+  /** Workbook Type, e.g. Asset | Liability. */
+  type: string;
+  class: string;
+  /** +1 asset, −1 liability when rolling into Net Worth. */
+  sign: number;
+};
+
+export type WmwBalance = {
+  /** Calendar date YYYY-MM-DD. */
+  date: string;
+  accountId: string;
+  balance: number;
+  units: number | null;
+  mileage: number | null;
+};
+
+export type WmwCashflow = {
+  /** Calendar date YYYY-MM-DD. */
+  date: string;
+  accountId: string;
+  /** Account-perspective: into Account positive, out negative. */
+  amount: number;
+  transactionType: WmwCashflowTransactionType;
+  description: string;
+};
+
+export type WmwRefreshWarningCode =
+  | 'unknown_transaction_type'
+  | 'non_gbp_account'
+  | 'invalid_row'
+  | 'orphan_fact';
+
+export type WmwRefreshWarning = {
+  code: WmwRefreshWarningCode;
+  message: string;
+  tab?: WmwWorkbookTab;
+  row?: number;
+  details?: Record<string, unknown>;
+};
+
+/**
+ * Point-in-time Workbook copy for the lab (private storage, not Site Content).
+ * Ingest retains Refresh warnings on last-good; calc fixtures use [].
+ */
+export type WmwSnapshot = {
+  /** ISO timestamp when the Snapshot was taken (as-of). */
+  asOf: string;
+  accounts: WmwAccount[];
+  categories: WmwCategory[];
+  balances: WmwBalance[];
+  cashflows: WmwCashflow[];
+  warnings: WmwRefreshWarning[];
+};
+
+/** Unformatted Sheets matrices (header row + data rows). */
+export type WmwWorkbookRaw = Record<WmwWorkbookTab, unknown[][]>;
+
+/** Calendar month key YYYY-MM. */
+export type CalendarMonth = string;


### PR DESCRIPTION
## Summary
- Add Amplify Storage bucket `wmwSnapshots` (authenticated Site Admin only) for last-good WMW Snapshots — not public Site Content.
- Document object key layout and env/secret-name wiring; ship `.env.example` placeholders (real values stay in #181).
- Add `src/lib/wmw` storage facade + memory/Amplify fakes with Vitest coverage.

Closes #182.

## Test plan
- [x] `npx vitest run src/lib/wmw` (10 tests)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on touched WMW/Amplify paths
- [ ] Confirm Amplify sandbox/backend assemble picks up `wmwSnapshots` after deploy
- [ ] Do not commit real spreadsheet ID or SA JSON

Made with [Cursor](https://cursor.com)