### PR TITLE
fix(wmw): Amplify-valid Google SA secret name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@
 # Google Sheets spreadsheet ID for the equity Workbook (system of record).
 WMW_SPREADSHEET_ID=
 
-# Host/Amplify secret name that holds the Google service account JSON.
-# The JSON itself must never be committed; only the secret name is referenced here.
-WMW_GOOGLE_SA_SECRET_NAME=wmw/google-service-account
+# Amplify secret name that holds the Google service account JSON (not the JSON itself).
+# Must match [a-zA-Z0-9_.-]+ for sandbox (npx ampx sandbox secret set ...) and Hosting Secrets.
+WMW_GOOGLE_SA_SECRET_NAME=wmw.google-service-account

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -77,7 +77,7 @@ If `nvm use 22` fails on the build image (version not installed), add a line bef
 
 Site Content no longer requires private blog-repo SSH secrets. Remove obsolete `SSH_PRIVATE_KEY` / `BLOG_REPO_*` console variables when convenient.
 
-WMW (What's My Worth) expects `WMW_SPREADSHEET_ID` and `WMW_GOOGLE_SA_SECRET_NAME` (secret name only — not the service account JSON). Placeholders live in `.env.example`; real values are set in [#181](https://github.com/hashadar/hashadar_website/issues/181). See [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md).
+WMW (What's My Worth) expects `WMW_SPREADSHEET_ID` and `WMW_GOOGLE_SA_SECRET_NAME` (secret **name** only — not the service account JSON). The default name is `wmw.google-service-account` (must match `[a-zA-Z0-9_.-]+` for both `ampx sandbox secret set` and Amplify Hosting → Secrets). Placeholders live in `.env.example`; real values are set in [#181](https://github.com/hashadar/hashadar_website/issues/181). See [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md).
 
 ## CI vs Site Content
 

--- a/docs/wmw/snapshot-storage.md
+++ b/docs/wmw/snapshot-storage.md
@@ -30,6 +30,17 @@ Env wiring (placeholders OK until [#181](https://github.com/hashadar/hashadar_we
 | Variable | Role |
 |----------|------|
 | `WMW_SPREADSHEET_ID` | Equity Workbook spreadsheet ID |
-| `WMW_GOOGLE_SA_SECRET_NAME` | Name of the host/Amplify secret that holds the Google service account JSON |
+| `WMW_GOOGLE_SA_SECRET_NAME` | Name of the Amplify secret that holds the Google service account JSON |
 
-See `.env.example`. Do not commit spreadsheet secrets or service account JSON.
+Default secret name (documented in `.env.example`, not a credential): `wmw.google-service-account`.
+
+### Amplify secret naming
+
+Sandbox CLI and Amplify Hosting secrets both store the leaf name in SSM Parameter Store. Use a name that matches `[a-zA-Z0-9_.-]+` (letters, digits, `_`, `.`, `-` only — no `/`).
+
+| Environment | How to set |
+|-------------|------------|
+| Local sandbox | `npx ampx sandbox secret set wmw.google-service-account` |
+| Amplify Hosting | App → Hosting → Secrets → Manage secrets (same leaf name) |
+
+Point `WMW_GOOGLE_SA_SECRET_NAME` at that name in `.env.local` (local) or Hosting environment variables (deployed). Do not commit spreadsheet IDs or service account JSON.

--- a/src/lib/wmw/config.ts
+++ b/src/lib/wmw/config.ts
@@ -11,8 +11,8 @@ export type WmwConfig = {
 export const WMW_SPREADSHEET_ID_ENV = 'WMW_SPREADSHEET_ID';
 export const WMW_GOOGLE_SA_SECRET_NAME_ENV = 'WMW_GOOGLE_SA_SECRET_NAME';
 
-/** Default secret name documented in `.env.example` (not a credential). */
-export const WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER = 'wmw/google-service-account';
+/** Default Amplify secret name in `.env.example` (not a credential). Must match `[a-zA-Z0-9_.-]+`. */
+export const WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER = 'wmw.google-service-account';
 
 type EnvLike = Record<string, string | undefined>;
 


### PR DESCRIPTION
## Summary
- Replace invalid default secret name `wmw/google-service-account` with `wmw.google-service-account` (matches Amplify sandbox CLI `[a-zA-Z0-9_.-]+`).
- Update `.env.example`, `getWmwConfig` placeholder, and WMW/CI docs.
- Document that sandbox and Amplify Hosting secrets share the same leaf-name constraint (SSM Parameter Store).

## Test plan
- [ ] `npx ampx sandbox secret set wmw.google-service-account` accepts the name (paste SA JSON when prompted)
- [ ] Confirm `WMW_GOOGLE_SA_SECRET_NAME=wmw.google-service-account` in `.env.local`
- [ ] `npx vitest run src/lib/wmw/config.test.ts` passes
- [ ] For Hosting: create secret `wmw.google-service-account` under App → Hosting → Secrets (same leaf name)

Made with [Cursor](https://cursor.com)