### PR TITLE
fix(wmw): wire server-side Sheets SA for Refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-﻿# WMW (What's My Worth) - placeholders until secrets are set in #181.
+# WMW (What's My Worth) - placeholders until secrets are set in #181.
 # Copy to .env.local for local development. Never commit real IDs or SA JSON.
 
 # Google Sheets spreadsheet ID for the equity Workbook (system of record).
@@ -7,11 +7,9 @@ WMW_SPREADSHEET_ID=
 # Amplify secret name that holds the Google service account JSON (not the JSON itself).
 # Must match [a-zA-Z0-9_.-]+ for sandbox (npx ampx sandbox secret set ...) and Hosting Secrets.
 WMW_GOOGLE_SA_SECRET_NAME=wmw.google-service-account
-<<<<<<< HEAD
 
 # Server-only Google service account JSON for `next dev` / SSR Refresh.
-# Prefer this (or FILE) locally — `ampx sandbox secret set` alone does not inject into Next.js.
+# Prefer this (or FILE) locally - `ampx sandbox secret set` alone does not inject into Next.js.
 # WMW_GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","client_email":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"}
 # WMW_GOOGLE_SERVICE_ACCOUNT_FILE=.secrets/wmw-google-sa.json
-=======
->>>>>>> origin/develop
+

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,14 @@
-# WMW (What's My Worth) - placeholders until secrets are set in #181.
+﻿# WMW (What's My Worth) - placeholders until secrets are set in #181.
 # Copy to .env.local for local development. Never commit real IDs or SA JSON.
 
 # Google Sheets spreadsheet ID for the equity Workbook (system of record).
 WMW_SPREADSHEET_ID=
 
-# Host/Amplify secret name that holds the Google service account JSON.
-# The JSON itself must never be committed; only the secret name is referenced here.
-WMW_GOOGLE_SA_SECRET_NAME=wmw/google-service-account
+# Amplify secret name that holds the Google service account JSON (not the JSON itself).
+# Must match [a-zA-Z0-9_.-]+ for sandbox (npx ampx sandbox secret set ...) and Hosting Secrets.
+WMW_GOOGLE_SA_SECRET_NAME=wmw.google-service-account
+
+# Server-only Google service account JSON for `next dev` / SSR Refresh.
+# Prefer this (or FILE) locally — `ampx sandbox secret set` alone does not inject into Next.js.
+# WMW_GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","client_email":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"}
+# WMW_GOOGLE_SERVICE_ACCOUNT_FILE=.secrets/wmw-google-sa.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 .env*
 !.env.example
 
+# Local service-account JSON and other secret files (never commit)
+.secrets/
+
 
 # vercel
 .vercel

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -77,7 +77,7 @@ If `nvm use 22` fails on the build image (version not installed), add a line bef
 
 Site Content no longer requires private blog-repo SSH secrets. Remove obsolete `SSH_PRIVATE_KEY` / `BLOG_REPO_*` console variables when convenient.
 
-WMW (What's My Worth) expects `WMW_SPREADSHEET_ID` and `WMW_GOOGLE_SA_SECRET_NAME` (secret name only — not the service account JSON). Placeholders live in `.env.example`; real values are set in [#181](https://github.com/hashadar/hashadar_website/issues/181). See [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md).
+WMW (What's My Worth) expects `WMW_SPREADSHEET_ID`, `WMW_GOOGLE_SA_SECRET_NAME` (default `wmw.google-service-account`, must match `[a-zA-Z0-9_.-]+`), and server-only SA material via `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` / `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` (local) or Amplify Hosting Secrets (`process.env.secrets`). Refresh uses a Server Action so the private key never ships to the browser. Placeholders live in `.env.example`; see [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md) and [#181](https://github.com/hashadar/hashadar_website/issues/181).
 
 ## CI vs Site Content
 

--- a/docs/wmw/snapshot-storage.md
+++ b/docs/wmw/snapshot-storage.md
@@ -25,11 +25,34 @@ Typed ingest store: `createSnapshotStoreFromJsonStorage` / `createDefaultWmwSnap
 
 ## App config / secrets
 
-Env wiring (placeholders OK until [#181](https://github.com/hashadar/hashadar_website/issues/181)):
+Env wiring ([#181](https://github.com/hashadar/hashadar_website/issues/181)):
 
 | Variable | Role |
 |----------|------|
 | `WMW_SPREADSHEET_ID` | Equity Workbook spreadsheet ID |
-| `WMW_GOOGLE_SA_SECRET_NAME` | Name of the host/Amplify secret that holds the Google service account JSON |
+| `WMW_GOOGLE_SA_SECRET_NAME` | Name of the Amplify secret that holds the Google service account JSON |
+| `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` | Server-only raw SA JSON (preferred for `next dev`) |
+| `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` | Server-only path to SA JSON file (e.g. `.secrets/wmw-google-sa.json`) |
 
-See `.env.example`. Do not commit spreadsheet secrets or service account JSON.
+Default Amplify secret name (documented in `.env.example`, not a credential): `wmw.google-service-account`.
+
+Refresh pulls Sheets through a **Server Action** (`pullWmwWorkbookTabs`) so the private key never enters the browser. Credential resolution order: inline JSON → file path → Amplify Hosting `process.env.secrets[name]`.
+
+### Local testing (`npm run sandbox` + `npm run dev`)
+
+1. Share the Workbook read-only with the service account email.
+2. In `.env.local` set `WMW_SPREADSHEET_ID` and `WMW_GOOGLE_SA_SECRET_NAME=wmw.google-service-account`.
+3. Put the SA JSON in `.env.local` as `WMW_GOOGLE_SERVICE_ACCOUNT_JSON=...` **or** on disk and set `WMW_GOOGLE_SERVICE_ACCOUNT_FILE=.secrets/wmw-google-sa.json`.
+4. Restart `npm run dev` after changing env.
+5. Optionally also `npx ampx sandbox secret set wmw.google-service-account` for Hosting/backend parity — that alone does **not** inject the JSON into Next.js.
+
+### Amplify secret naming
+
+Sandbox CLI and Amplify Hosting secrets both store the leaf name in SSM Parameter Store. Use a name that matches `[a-zA-Z0-9_.-]+` (letters, digits, `_`, `.`, `-` only — no `/`).
+
+| Environment | How to set |
+|-------------|------------|
+| Local sandbox | `npx ampx sandbox secret set wmw.google-service-account` (backend/SSM; Next.js still needs JSON/FILE above) |
+| Amplify Hosting | App → Hosting → Secrets → Manage secrets (same leaf name); expose via `process.env.secrets` for SSR |
+
+Do not commit spreadsheet IDs or service account JSON.

--- a/src/lib/wmw-default.test.ts
+++ b/src/lib/wmw-default.test.ts
@@ -1,18 +1,29 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  createServerPullWorkbookSource,
   getDefaultWmw,
   resetDefaultWmwCache,
   resolveDefaultWorkbookSource,
 } from '@/lib/wmw-default';
+import { createSampleWorkbookRaw } from '@/lib/wmw/fixtures/sample-workbook';
+import { WMW_WORKBOOK_NOT_CONFIGURED_REASON } from '@/lib/wmw/pull-workbook-action';
 
 afterEach(() => {
   resetDefaultWmwCache();
 });
 
 describe('WMW default wiring (CI without Google secrets)', () => {
-  it('resolves an unavailable Workbook source when spreadsheet secrets are absent', async () => {
+  it('defaults to a Server Action workbook source', async () => {
     const source = resolveDefaultWorkbookSource();
-    await expect(source.pullTabs()).rejects.toThrow(/not configured/i);
+    await expect(source.pullTabs()).rejects.toThrow(
+      /not configured \(see #181\)/i,
+    );
+  });
+
+  it('allows injecting a pullTabs override for tests', async () => {
+    const raw = createSampleWorkbookRaw();
+    const source = createServerPullWorkbookSource(async () => raw);
+    await expect(source.pullTabs()).resolves.toEqual(raw);
   });
 
   it('builds a facade that loads an empty Snapshot without crashing', async () => {
@@ -21,7 +32,11 @@ describe('WMW default wiring (CI without Google secrets)', () => {
   });
 
   it('Refresh fails clearly when the Workbook source is not configured', async () => {
-    const client = await getDefaultWmw();
+    const client = await getDefaultWmw({
+      pullTabs: async () => {
+        throw new Error(WMW_WORKBOOK_NOT_CONFIGURED_REASON);
+      },
+    });
     await expect(client.refresh()).rejects.toThrow(/not configured/i);
   });
 });

--- a/src/lib/wmw-default.ts
+++ b/src/lib/wmw-default.ts
@@ -1,14 +1,16 @@
 /**
  * Default Amplify-backed WMW facade for client UI (lazy singleton).
- * Sheets SA wiring remains #181 — Refresh fails clearly until configured.
+ * Live Sheets pulls go through a Server Action so the SA key never hits the browser.
  */
 
 import { createWmw, type WmwFacade } from '@/lib/wmw/facade';
 import { getWmwConfig } from '@/lib/wmw/config';
+import { pullWmwWorkbookTabs } from '@/lib/wmw/pull-workbook-action';
 import {
   createDefaultWmwSnapshotStore,
   createMemoryWmwSnapshotStore,
 } from '@/lib/wmw/snapshot-store';
+import type { WmwWorkbookRaw } from '@/lib/wmw/types';
 import type { WmwWorkbookSource } from '@/lib/wmw/workbook-source';
 import { createGoogleSheetsWorkbookSource } from '@/lib/wmw/workbook-source';
 
@@ -25,26 +27,54 @@ export function createUnavailableWorkbookSource(
   };
 }
 
+/** Client-safe source that delegates the Sheets pull to a Server Action. */
+export function createServerPullWorkbookSource(
+  pullTabs: () => Promise<WmwWorkbookRaw> = pullWmwWorkbookTabs,
+): WmwWorkbookSource {
+  return {
+    async pullTabs() {
+      return pullTabs();
+    },
+  };
+}
+
+export type ResolveDefaultWorkbookSourceOptions = {
+  /**
+   * Test/offline override: provide a token provider with spreadsheet ID in env
+   * to exercise the in-process Sheets client (never used by the Overview UI).
+   */
+  getAccessToken?: () => Promise<string>;
+  /** Test override for the Server Action pull. */
+  pullTabs?: () => Promise<WmwWorkbookRaw>;
+};
+
 /**
- * Resolve workbook source. Live Sheets needs spreadsheet ID + token provider
- * (#181). Until then Refresh surfaces last-good + error in the Overview.
+ * Resolve workbook source. Production UI uses the Server Action path so SA JSON
+ * stays server-side. Optional `getAccessToken` remains for direct Sheets tests.
  */
 export function resolveDefaultWorkbookSource(
-  getAccessToken?: () => Promise<string>,
+  options?: ResolveDefaultWorkbookSourceOptions,
 ): WmwWorkbookSource {
+  if (options?.pullTabs) {
+    return createServerPullWorkbookSource(options.pullTabs);
+  }
+
   const config = getWmwConfig();
-  if (config.spreadsheetId && getAccessToken) {
+  if (config.spreadsheetId && options?.getAccessToken) {
     return createGoogleSheetsWorkbookSource({
       spreadsheetId: config.spreadsheetId,
-      getAccessToken,
+      getAccessToken: options.getAccessToken,
     });
   }
-  return createUnavailableWorkbookSource();
+
+  // Overview / Account detail: always delegate to the server pull.
+  return createServerPullWorkbookSource();
 }
 
 /** Default WMW for authenticated Overview (injectable in tests via props). */
 export async function getDefaultWmw(options?: {
   getAccessToken?: () => Promise<string>;
+  pullTabs?: () => Promise<WmwWorkbookRaw>;
 }): Promise<WmwFacade> {
   if (!cached) {
     cached = (async () => {
@@ -52,7 +82,7 @@ export async function getDefaultWmw(options?: {
         (await createDefaultWmwSnapshotStore()) ??
         createMemoryWmwSnapshotStore();
       return createWmw({
-        workbookSource: resolveDefaultWorkbookSource(options?.getAccessToken),
+        workbookSource: resolveDefaultWorkbookSource(options),
         snapshotStore: store,
       });
     })();

--- a/src/lib/wmw/config.ts
+++ b/src/lib/wmw/config.ts
@@ -1,6 +1,7 @@
 /**
  * WMW app config from environment.
- * Spreadsheet ID and SA secret values are supplied in #181; placeholders are fine until then.
+ * Spreadsheet ID + SA secret name (#181). SA JSON itself is resolved server-side
+ * via `resolveGoogleServiceAccountCredentials` (never NEXT_PUBLIC_).
  */
 export type WmwConfig = {
   spreadsheetId: string | null;
@@ -11,8 +12,8 @@ export type WmwConfig = {
 export const WMW_SPREADSHEET_ID_ENV = 'WMW_SPREADSHEET_ID';
 export const WMW_GOOGLE_SA_SECRET_NAME_ENV = 'WMW_GOOGLE_SA_SECRET_NAME';
 
-/** Default secret name documented in `.env.example` (not a credential). */
-export const WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER = 'wmw/google-service-account';
+/** Default Amplify secret name in `.env.example` (not a credential). Must match `[a-zA-Z0-9_.-]+`. */
+export const WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER = 'wmw.google-service-account';
 
 type EnvLike = Record<string, string | undefined>;
 

--- a/src/lib/wmw/google-sa-access-token.test.ts
+++ b/src/lib/wmw/google-sa-access-token.test.ts
@@ -1,0 +1,66 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createGoogleSaAccessTokenProvider,
+  createGoogleSaJwtAssertion,
+} from '@/lib/wmw/google-sa-access-token';
+
+const { privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+
+const credentials = {
+  clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
+  privateKey,
+};
+
+describe('createGoogleSaJwtAssertion', () => {
+  it('builds a three-part RS256 JWT', () => {
+    const jwt = createGoogleSaJwtAssertion(credentials, {
+      nowSeconds: () => 1_700_000_000,
+    });
+    const parts = jwt.split('.');
+    expect(parts).toHaveLength(3);
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, 'base64url').toString('utf8'),
+    ) as { iss: string; scope: string; aud: string };
+    expect(payload.iss).toBe(credentials.clientEmail);
+    expect(payload.scope).toContain('spreadsheets.readonly');
+    expect(payload.aud).toBe('https://oauth2.googleapis.com/token');
+  });
+});
+
+describe('createGoogleSaAccessTokenProvider', () => {
+  it('exchanges a JWT assertion for an access token', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ access_token: 'ya29.test-token', expires_in: 3600 }),
+    );
+
+    const getToken = createGoogleSaAccessTokenProvider({
+      credentials,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowSeconds: () => 1_700_000_000,
+    });
+
+    await expect(getToken()).resolves.toBe('ya29.test-token');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(String(init.body)).toContain('grant_type=');
+  });
+
+  it('caches tokens until near expiry', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ access_token: 'ya29.cached', expires_in: 3600 }),
+    );
+    const getToken = createGoogleSaAccessTokenProvider({
+      credentials,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(getToken()).resolves.toBe('ya29.cached');
+    await expect(getToken()).resolves.toBe('ya29.cached');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/wmw/google-sa-access-token.ts
+++ b/src/lib/wmw/google-sa-access-token.ts
@@ -1,0 +1,123 @@
+/**
+ * Mint a Google OAuth access token from a service-account private key (JWT bearer).
+ * Server-only — do not call from the browser.
+ */
+
+import 'server-only';
+import { createSign } from 'node:crypto';
+import type { GoogleServiceAccountCredentials } from '@/lib/wmw/google-sa-credentials';
+import { WMW_SHEETS_READONLY_SCOPE } from '@/lib/wmw/google-sa-credentials';
+
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const TOKEN_LIFETIME_SECONDS = 3600;
+
+export type CreateGoogleSaAccessTokenProviderOptions = {
+  credentials: GoogleServiceAccountCredentials;
+  scope?: string;
+  fetchImpl?: typeof fetch;
+  /** Injected clock for tests (unix seconds). */
+  nowSeconds?: () => number;
+};
+
+function base64UrlEncode(input: Buffer | string): string {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input, 'utf8');
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function signJwtRs256(
+  unsignedToken: string,
+  privateKey: string,
+): string {
+  const signer = createSign('RSA-SHA256');
+  signer.update(unsignedToken);
+  signer.end();
+  return base64UrlEncode(signer.sign(privateKey));
+}
+
+export function createGoogleSaJwtAssertion(
+  credentials: GoogleServiceAccountCredentials,
+  options?: {
+    scope?: string;
+    nowSeconds?: () => number;
+    lifetimeSeconds?: number;
+  },
+): string {
+  const now = options?.nowSeconds?.() ?? Math.floor(Date.now() / 1000);
+  const lifetime = options?.lifetimeSeconds ?? TOKEN_LIFETIME_SECONDS;
+  const header = base64UrlEncode(
+    JSON.stringify({ alg: 'RS256', typ: 'JWT' }),
+  );
+  const claimSet = base64UrlEncode(
+    JSON.stringify({
+      iss: credentials.clientEmail,
+      scope: options?.scope ?? WMW_SHEETS_READONLY_SCOPE,
+      aud: GOOGLE_TOKEN_URL,
+      iat: now,
+      exp: now + lifetime,
+    }),
+  );
+  const unsigned = `${header}.${claimSet}`;
+  return `${unsigned}.${signJwtRs256(unsigned, credentials.privateKey)}`;
+}
+
+export function createGoogleSaAccessTokenProvider(
+  options: CreateGoogleSaAccessTokenProviderOptions,
+): () => Promise<string> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let cached: { token: string; expiresAtMs: number } | null = null;
+
+  return async () => {
+    const nowMs = Date.now();
+    if (cached && cached.expiresAtMs > nowMs + 60_000) {
+      return cached.token;
+    }
+
+    const assertion = createGoogleSaJwtAssertion(options.credentials, {
+      scope: options.scope,
+      nowSeconds: options.nowSeconds,
+    });
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    });
+
+    const response = await fetchImpl(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(
+        `Google SA token exchange failed (${response.status}): ${text.slice(0, 200)}`,
+      );
+    }
+
+    const json = (await response.json()) as {
+      access_token?: unknown;
+      expires_in?: unknown;
+    };
+    if (typeof json.access_token !== 'string' || !json.access_token) {
+      throw new Error('Google SA token exchange returned no access_token.');
+    }
+
+    const expiresInSeconds =
+      typeof json.expires_in === 'number' && json.expires_in > 0
+        ? json.expires_in
+        : TOKEN_LIFETIME_SECONDS;
+    cached = {
+      token: json.access_token,
+      expiresAtMs: nowMs + expiresInSeconds * 1000,
+    };
+    return cached.token;
+  };
+}

--- a/src/lib/wmw/google-sa-credentials.test.ts
+++ b/src/lib/wmw/google-sa-credentials.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AMPLIFY_SECRETS_ENV,
+  parseGoogleServiceAccountJson,
+  resolveGoogleServiceAccountCredentials,
+  WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV,
+} from '@/lib/wmw/google-sa-credentials';
+import {
+  WMW_GOOGLE_SA_SECRET_NAME_ENV,
+  WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER,
+} from '@/lib/wmw/config';
+
+const SAMPLE_JSON = JSON.stringify({
+  type: 'service_account',
+  client_email: 'wmw-reader@example.iam.gserviceaccount.com',
+  private_key:
+    '-----BEGIN PRIVATE KEY-----\\nMIIE\\n-----END PRIVATE KEY-----\\n',
+});
+
+describe('parseGoogleServiceAccountJson', () => {
+  it('parses client_email and unescapes private_key newlines', () => {
+    expect(parseGoogleServiceAccountJson(SAMPLE_JSON)).toEqual({
+      clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
+      privateKey:
+        '-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n',
+    });
+  });
+
+  it('rejects invalid JSON', () => {
+    expect(() => parseGoogleServiceAccountJson('{')).toThrow(/not valid JSON/i);
+  });
+
+  it('rejects missing key fields', () => {
+    expect(() =>
+      parseGoogleServiceAccountJson(JSON.stringify({ client_email: 'a@b.c' })),
+    ).toThrow(/client_email and private_key/i);
+  });
+});
+
+describe('resolveGoogleServiceAccountCredentials', () => {
+  it('returns null when nothing is configured', () => {
+    expect(resolveGoogleServiceAccountCredentials({})).toBeNull();
+  });
+
+  it('prefers inline JSON env', () => {
+    expect(
+      resolveGoogleServiceAccountCredentials({
+        [WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV]: SAMPLE_JSON,
+        [AMPLIFY_SECRETS_ENV]: JSON.stringify({
+          [WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER]: SAMPLE_JSON,
+        }),
+      }),
+    ).toMatchObject({
+      clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
+    });
+  });
+
+  it('reads Amplify Hosting secrets map by configured name', () => {
+    expect(
+      resolveGoogleServiceAccountCredentials({
+        [WMW_GOOGLE_SA_SECRET_NAME_ENV]: 'wmw.google-service-account',
+        [AMPLIFY_SECRETS_ENV]: JSON.stringify({
+          'wmw.google-service-account': SAMPLE_JSON,
+        }),
+      }),
+    ).toMatchObject({
+      clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
+    });
+  });
+});

--- a/src/lib/wmw/google-sa-credentials.ts
+++ b/src/lib/wmw/google-sa-credentials.ts
@@ -1,0 +1,109 @@
+/**
+ * Resolve Google service-account JSON for server-side Sheets pulls.
+ * Never import this from client components — private key must stay on the server.
+ */
+
+import 'server-only';
+import { readFileSync } from 'node:fs';
+import {
+  WMW_GOOGLE_SA_SECRET_NAME_ENV,
+  WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER,
+} from '@/lib/wmw/config';
+
+export const WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV =
+  'WMW_GOOGLE_SERVICE_ACCOUNT_JSON';
+export const WMW_GOOGLE_SERVICE_ACCOUNT_FILE_ENV =
+  'WMW_GOOGLE_SERVICE_ACCOUNT_FILE';
+
+/** Amplify Hosting injects branch secrets as a JSON map under this env key. */
+export const AMPLIFY_SECRETS_ENV = 'secrets';
+
+export const WMW_SHEETS_READONLY_SCOPE =
+  'https://www.googleapis.com/auth/spreadsheets.readonly';
+
+export type GoogleServiceAccountCredentials = {
+  clientEmail: string;
+  privateKey: string;
+};
+
+type EnvLike = Record<string, string | undefined>;
+
+export function parseGoogleServiceAccountJson(
+  raw: string,
+): GoogleServiceAccountCredentials {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('WMW Google service account JSON is not valid JSON.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('WMW Google service account JSON must be an object.');
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const clientEmail =
+    typeof record.client_email === 'string' ? record.client_email.trim() : '';
+  const privateKey =
+    typeof record.private_key === 'string' ? record.private_key : '';
+
+  if (!clientEmail || !privateKey.includes('BEGIN PRIVATE KEY')) {
+    throw new Error(
+      'WMW Google service account JSON must include client_email and private_key.',
+    );
+  }
+
+  return {
+    clientEmail,
+    privateKey: privateKey.replace(/\\n/g, '\n'),
+  };
+}
+
+function readAmplifySecretsMap(env: EnvLike): Record<string, string> {
+  const raw = env[AMPLIFY_SECRETS_ENV]?.trim();
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'string' && value.trim()) {
+        out[key] = value;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolution order (first hit wins):
+ * 1. `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` — raw JSON (local `.env.local`)
+ * 2. `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` — path to JSON file
+ * 3. Amplify Hosting `process.env.secrets[WMW_GOOGLE_SA_SECRET_NAME]`
+ */
+export function resolveGoogleServiceAccountCredentials(
+  env: EnvLike = process.env,
+): GoogleServiceAccountCredentials | null {
+  const inline = env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV]?.trim();
+  if (inline) {
+    return parseGoogleServiceAccountJson(inline);
+  }
+
+  const filePath = env[WMW_GOOGLE_SERVICE_ACCOUNT_FILE_ENV]?.trim();
+  if (filePath) {
+    return parseGoogleServiceAccountJson(readFileSync(filePath, 'utf8'));
+  }
+
+  const secretName =
+    env[WMW_GOOGLE_SA_SECRET_NAME_ENV]?.trim() ||
+    WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER;
+  const fromAmplify = readAmplifySecretsMap(env)[secretName]?.trim();
+  if (fromAmplify) {
+    return parseGoogleServiceAccountJson(fromAmplify);
+  }
+
+  return null;
+}

--- a/src/lib/wmw/pull-workbook-action.test.ts
+++ b/src/lib/wmw/pull-workbook-action.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  pullWmwWorkbookTabs,
+  WMW_WORKBOOK_NOT_CONFIGURED_REASON,
+} from '@/lib/wmw/pull-workbook-action';
+import { WMW_SPREADSHEET_ID_ENV } from '@/lib/wmw/config';
+import { WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV } from '@/lib/wmw/google-sa-credentials';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+describe('pullWmwWorkbookTabs', () => {
+  it('fails clearly when spreadsheet ID or SA credentials are missing', async () => {
+    delete process.env[WMW_SPREADSHEET_ID_ENV];
+    delete process.env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV];
+    delete process.env.secrets;
+
+    await expect(pullWmwWorkbookTabs()).rejects.toThrow(
+      WMW_WORKBOOK_NOT_CONFIGURED_REASON,
+    );
+  });
+
+  it('fails clearly when only spreadsheet ID is set', async () => {
+    process.env[WMW_SPREADSHEET_ID_ENV] = 'sheet-id-only';
+    delete process.env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV];
+    delete process.env.secrets;
+
+    await expect(pullWmwWorkbookTabs()).rejects.toThrow(
+      WMW_WORKBOOK_NOT_CONFIGURED_REASON,
+    );
+  });
+});

--- a/src/lib/wmw/pull-workbook-action.ts
+++ b/src/lib/wmw/pull-workbook-action.ts
@@ -1,0 +1,34 @@
+'use server';
+
+/**
+ * Server-only Workbook pull. Keeps the Google SA private key off the browser.
+ */
+
+import { getWmwConfig } from '@/lib/wmw/config';
+import { createGoogleSaAccessTokenProvider } from '@/lib/wmw/google-sa-access-token';
+import { resolveGoogleServiceAccountCredentials } from '@/lib/wmw/google-sa-credentials';
+import type { WmwWorkbookRaw } from '@/lib/wmw/types';
+import { createGoogleSheetsWorkbookSource } from '@/lib/wmw/workbook-source';
+
+export const WMW_WORKBOOK_NOT_CONFIGURED_REASON =
+  'WMW Workbook source is not configured (see #181). Set WMW_SPREADSHEET_ID and WMW_GOOGLE_SERVICE_ACCOUNT_JSON (or FILE / Amplify secrets).';
+
+/**
+ * Pull the four frozen Workbook tabs via Sheets (unformatted values).
+ * Called from the client facade Refresh path as a Server Action.
+ */
+export async function pullWmwWorkbookTabs(): Promise<WmwWorkbookRaw> {
+  const config = getWmwConfig();
+  const credentials = resolveGoogleServiceAccountCredentials();
+
+  if (!config.spreadsheetId || !credentials) {
+    throw new Error(WMW_WORKBOOK_NOT_CONFIGURED_REASON);
+  }
+
+  const source = createGoogleSheetsWorkbookSource({
+    spreadsheetId: config.spreadsheetId,
+    getAccessToken: createGoogleSaAccessTokenProvider({ credentials }),
+  });
+
+  return source.pullTabs();
+}

--- a/src/lib/wmw/workbook-source.ts
+++ b/src/lib/wmw/workbook-source.ts
@@ -42,11 +42,9 @@ export type CreateGoogleSheetsWorkbookSourceOptions = {
 
 /**
  * Live Google Sheets pull (read-only).
- * Requires spreadsheet ID + SA token from Amplify secrets (#181).
+ * Requires spreadsheet ID + SA access token (#181).
  * Requests UNFORMATTED_VALUE + SERIAL_NUMBER — never writes.
- *
- * TODO(#181): wire Amplify secret references for SA JSON + spreadsheet ID
- * (config hooks land with #182).
+ * Production UI obtains tabs via `pullWmwWorkbookTabs` (Server Action).
  */
 export function createGoogleSheetsWorkbookSource(
   options: CreateGoogleSheetsWorkbookSourceOptions,


### PR DESCRIPTION
﻿## Summary
- Refresh now pulls Workbook tabs through a Server Action so the Google service-account private key never enters the browser.
- Resolves SA credentials from `WMW_GOOGLE_SERVICE_ACCOUNT_JSON`, `WMW_GOOGLE_SERVICE_ACCOUNT_FILE`, or Amplify Hosting `process.env.secrets`, and documents Amplify-valid secret name `wmw.google-service-account`.
- Closes the gap behind the Overview error when sandbox/dev were running but no token provider was wired (#181).

## Test plan
- [ ] Add to `.env.local`: `WMW_SPREADSHEET_ID`, `WMW_GOOGLE_SA_SECRET_NAME=wmw.google-service-account`, and either `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` or `WMW_GOOGLE_SERVICE_ACCOUNT_FILE`
- [ ] Restart `npm run dev` (with `npm run sandbox` still up)
- [ ] Sign in to `/labs/wmw`, click Refresh; expect success and `snapshots/last-good.json` written (S3 404s stop after first success)
- [ ] Confirm SA JSON is not present in browser network/JS bundles
- [ ] `npx vitest run src/lib/wmw src/lib/wmw-default.test.ts src/components/sections/labs/wmw`
