### PR TITLE
fix(wmw): seed shared Amplify SSM secret for Refresh SSR

### DIFF
--- a/docs/wmw/snapshot-storage.md
+++ b/docs/wmw/snapshot-storage.md
@@ -67,4 +67,6 @@ Amplify loads console env vars and Hosting secrets into the **build** environmen
 
 without logging values. Redeploy after changing Hosting secrets or env vars.
 
+**Shared vs branch secrets:** Amplify’s build loader only reads SSM under `/amplify/{appId}/{branch}/`. Secrets created for all branches live under `/amplify/shared/{appId}/` and often yield an empty `process.env.secrets` (`{}`). The write script then seeds `wmw.google-service-account` from shared (or branch) SSM via `aws ssm get-parameter` so Refresh can resolve the Google SA. BUILD should log `seeded wmw.google-service-account from SSM /amplify/shared/...` when that path runs.
+
 Do not commit spreadsheet IDs or service account JSON.

--- a/scripts/write-amplify-ssr-env.test.ts
+++ b/scripts/write-amplify-ssr-env.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { buildAmplifySsrEnvLines } from './write-amplify-ssr-env';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  amplifyBranchSecretParamName,
+  amplifySharedSecretParamName,
+  buildAmplifySsrEnvLines,
+  ensureWmwSecretInAmplifySecretsEnv,
+  parseAmplifySecretsMap,
+} from './write-amplify-ssr-env';
 
 describe('buildAmplifySsrEnvLines', () => {
   it('writes present keys as JSON-stringified dotenv lines', () => {
@@ -38,5 +44,90 @@ describe('buildAmplifySsrEnvLines', () => {
     expect(JSON.parse(JSON.parse(valueLiteral))).toEqual({
       'wmw.google-service-account': '{"client_email":"a@b.com"}',
     });
+  });
+});
+
+describe('ensureWmwSecretInAmplifySecretsEnv', () => {
+  const saJson = JSON.stringify({
+    type: 'service_account',
+    client_email: 'wmw-reader@example.iam.gserviceaccount.com',
+    private_key: '-----BEGIN PRIVATE KEY-----\\nMIIE\\n-----END PRIVATE KEY-----\\n',
+  });
+
+  it('leaves secrets untouched when the named leaf is already present', () => {
+    const secrets = JSON.stringify({
+      'wmw.google-service-account': saJson,
+    });
+    const fetchParameter = vi.fn();
+    const result = ensureWmwSecretInAmplifySecretsEnv(
+      {
+        WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
+        secrets,
+        AWS_APP_ID: 'd3j7dgxx3prj17',
+        AWS_BRANCH: 'main',
+      },
+      { fetchParameter },
+    );
+
+    expect(result.seededFrom).toBeNull();
+    expect(result.env.secrets).toBe(secrets);
+    expect(fetchParameter).not.toHaveBeenCalled();
+  });
+
+  it('seeds from shared SSM when build injects an empty secrets map', () => {
+    const sharedName = amplifySharedSecretParamName(
+      'd3j7dgxx3prj17',
+      'wmw.google-service-account',
+    );
+    const fetchParameter = vi.fn((name: string) =>
+      name === sharedName ? saJson : null,
+    );
+
+    const result = ensureWmwSecretInAmplifySecretsEnv(
+      {
+        WMW_SPREADSHEET_ID: 'sheet-id',
+        WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
+        secrets: JSON.stringify({}),
+        AWS_APP_ID: 'd3j7dgxx3prj17',
+        AWS_BRANCH: 'main',
+      },
+      { fetchParameter },
+    );
+
+    expect(result.seededFrom).toBe(sharedName);
+    expect(parseAmplifySecretsMap(result.env.secrets)).toEqual({
+      'wmw.google-service-account': saJson,
+    });
+    expect(fetchParameter).toHaveBeenCalledWith(
+      amplifyBranchSecretParamName(
+        'd3j7dgxx3prj17',
+        'main',
+        'wmw.google-service-account',
+      ),
+    );
+    expect(fetchParameter).toHaveBeenCalledWith(sharedName);
+  });
+
+  it('prefers branch SSM over shared when both could resolve', () => {
+    const branchName = amplifyBranchSecretParamName(
+      'd3j7dgxx3prj17',
+      'main',
+      'wmw.google-service-account',
+    );
+    const fetchParameter = vi.fn((name: string) =>
+      name === branchName ? saJson : 'SHOULD_NOT_USE',
+    );
+
+    const result = ensureWmwSecretInAmplifySecretsEnv(
+      {
+        secrets: '{}',
+        AWS_APP_ID: 'd3j7dgxx3prj17',
+        AWS_BRANCH: 'main',
+      },
+      { fetchParameter },
+    );
+
+    expect(result.seededFrom).toBe(branchName);
+    expect(fetchParameter).toHaveBeenCalledTimes(1);
   });
 });

--- a/scripts/write-amplify-ssr-env.ts
+++ b/scripts/write-amplify-ssr-env.ts
@@ -3,8 +3,15 @@
  * environment, but Next.js SSR (Server Actions) does not see them unless
  * they are written to `.env.production` before `next build`.
  *
+ * Amplify's build-time SSM loader only reads `/amplify/{appId}/{branch}/`.
+ * Hosting secrets created for all branches live under
+ * `/amplify/shared/{appId}/` and often arrive as an empty `process.env.secrets`
+ * map (`{}`). This script seeds the WMW Google SA from shared/branch SSM when
+ * missing so Refresh Server Actions can resolve credentials.
+ *
  * @see https://docs.aws.amazon.com/amplify/latest/userguide/ssr-environment-variables.html
  */
+import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
@@ -15,9 +22,20 @@ export const AMPLIFY_SSR_ENV_KEYS = [
   'secrets',
 ] as const;
 
+/** Default Amplify Hosting secret leaf name (must match `[a-zA-Z0-9_.-]+`). */
+export const DEFAULT_WMW_GOOGLE_SA_SECRET_NAME = 'wmw.google-service-account';
+
 export type WriteAmplifySsrEnvResult = {
   writtenKeys: string[];
   skipped: boolean;
+  seededFrom: string | null;
+};
+
+export type FetchSsmSecureString = (name: string) => string | null;
+
+export type WriteAmplifySsrEnvOptions = {
+  /** Override SSM fetch (tests). Defaults to `aws ssm get-parameter`. */
+  fetchParameter?: FetchSsmSecureString;
 };
 
 /**
@@ -37,14 +55,147 @@ export function buildAmplifySsrEnvLines(
   return lines;
 }
 
+export function parseAmplifySecretsMap(
+  raw: string | undefined,
+): Record<string, string> {
+  if (!raw?.trim()) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'string' && value.trim()) {
+        out[key] = value;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function amplifySharedSecretParamName(
+  appId: string,
+  secretName: string,
+): string {
+  return `/amplify/shared/${appId}/${secretName}`;
+}
+
+export function amplifyBranchSecretParamName(
+  appId: string,
+  branch: string,
+  secretName: string,
+): string {
+  return `/amplify/${appId}/${branch}/${secretName}`;
+}
+
+export function fetchSsmSecureStringViaAwsCli(
+  name: string,
+  exec: typeof execFileSync = execFileSync,
+  region =
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION ||
+    'eu-west-2',
+): string | null {
+  try {
+    const out = exec(
+      'aws',
+      [
+        'ssm',
+        'get-parameter',
+        '--name',
+        name,
+        '--with-decryption',
+        '--query',
+        'Parameter.Value',
+        '--output',
+        'text',
+        '--region',
+        region,
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    const value = String(out).trim();
+    return value && value !== 'None' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * If `process.env.secrets` lacks the WMW SA leaf, pull it from Amplify SSM
+ * (branch path first, then shared / all-branches).
+ */
+export function ensureWmwSecretInAmplifySecretsEnv(
+  env: Record<string, string | undefined>,
+  options?: WriteAmplifySsrEnvOptions,
+): {
+  env: Record<string, string | undefined>;
+  seededFrom: string | null;
+  secretName: string;
+} {
+  const secretName =
+    env.WMW_GOOGLE_SA_SECRET_NAME?.trim() || DEFAULT_WMW_GOOGLE_SA_SECRET_NAME;
+  const map = parseAmplifySecretsMap(env.secrets);
+  if (map[secretName]?.trim()) {
+    return { env, seededFrom: null, secretName };
+  }
+
+  const appId = env.AWS_APP_ID?.trim();
+  const branch = env.AWS_BRANCH?.trim();
+  const fetchParameter =
+    options?.fetchParameter ?? fetchSsmSecureStringViaAwsCli;
+
+  const candidates: string[] = [];
+  if (appId && branch) {
+    candidates.push(amplifyBranchSecretParamName(appId, branch, secretName));
+  }
+  if (appId) {
+    candidates.push(amplifySharedSecretParamName(appId, secretName));
+  }
+
+  for (const paramName of candidates) {
+    const value = fetchParameter(paramName)?.trim();
+    if (!value) continue;
+    map[secretName] = value;
+    return {
+      env: { ...env, secrets: JSON.stringify(map) },
+      seededFrom: paramName,
+      secretName,
+    };
+  }
+
+  return { env, seededFrom: null, secretName };
+}
+
 export function writeAmplifySsrEnvFile(
   env: Record<string, string | undefined> = process.env,
   filePath = '.env.production',
+  options?: WriteAmplifySsrEnvOptions,
 ): WriteAmplifySsrEnvResult {
-  const lines = buildAmplifySsrEnvLines(env);
+  const {
+    env: resolvedEnv,
+    seededFrom,
+    secretName,
+  } = ensureWmwSecretInAmplifySecretsEnv(env, options);
+
+  if (seededFrom) {
+    console.log(
+      `write-amplify-ssr-env: seeded ${secretName} from SSM ${seededFrom}`,
+    );
+  } else {
+    const hasSa = Boolean(
+      parseAmplifySecretsMap(resolvedEnv.secrets)[secretName]?.trim(),
+    );
+    console.log(
+      `write-amplify-ssr-env: secrets map ${hasSa ? 'already has' : 'missing'} ${secretName}`,
+    );
+  }
+
+  const lines = buildAmplifySsrEnvLines(resolvedEnv);
   if (lines.length === 0) {
     console.log('write-amplify-ssr-env: no SSR env vars present; skipping');
-    return { writtenKeys: [], skipped: true };
+    return { writtenKeys: [], skipped: true, seededFrom };
   }
 
   appendFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
@@ -52,7 +203,7 @@ export function writeAmplifySsrEnvFile(
   console.log(
     `write-amplify-ssr-env: wrote ${writtenKeys.join(', ')} to ${filePath}`,
   );
-  return { writtenKeys, skipped: false };
+  return { writtenKeys, skipped: false, seededFrom };
 }
 
 const isMain =


### PR DESCRIPTION
## Summary
- Amplify build loads SSM only from `/amplify/{appId}/{branch}/`, so all-branches Hosting secrets under `/amplify/shared/{appId}/` yield an empty `process.env.secrets` map and WMW Refresh Server Actions 500.
- `write-amplify-ssr-env` now seeds `wmw.google-service-account` from branch then shared SSM when missing, so `.env.production` includes a usable secrets map for Next SSR.
- Documents the shared-vs-branch quirk and adds regression tests for empty-map seeding.

## Test plan
- [ ] CI `quality` passes
- [ ] Amplify BUILD logs `seeded wmw.google-service-account from SSM /amplify/shared/...`
- [ ] On https://www.hashadar.com/labs/wmw, Refresh succeeds (no POST `/labs/wmw` 500)
- [ ] After a successful Refresh, `snapshots/last-good.json` / `.meta.json` 404s stop appearing
