### PR TITLE
fix(wmw): statically inline Amplify SSR env for Refresh

### DIFF
--- a/docs/wmw/snapshot-storage.md
+++ b/docs/wmw/snapshot-storage.md
@@ -63,10 +63,11 @@ Amplify loads console env vars and Hosting secrets into the **build** environmen
 
 - `WMW_SPREADSHEET_ID`
 - `WMW_GOOGLE_SA_SECRET_NAME`
+- `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` (flattened from the Hosting secrets map / shared SSM)
 - `secrets` (the Amplify Hosting secrets JSON map)
 
 without logging values. Redeploy after changing Hosting secrets or env vars.
 
-**Shared vs branch secrets:** Amplify’s build loader only reads SSM under `/amplify/{appId}/{branch}/`. Secrets created for all branches live under `/amplify/shared/{appId}/` and often yield an empty `process.env.secrets` (`{}`). The write script then seeds `wmw.google-service-account` from shared (or branch) SSM via `aws ssm get-parameter` so Refresh can resolve the Google SA. BUILD should log `seeded wmw.google-service-account from SSM /amplify/shared/...` when that path runs.
+**Shared vs branch secrets:** Amplify’s build loader only reads SSM under `/amplify/{appId}/{branch}/`. Secrets created for all branches live under `/amplify/shared/{appId}/` and often yield an empty `process.env.secrets` (`{}`). The write script then seeds `wmw.google-service-account` from shared (or branch) SSM via `aws ssm get-parameter`, and also writes `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` so Next can statically inline `process.env.WMW_*` into Server Actions (dynamic `process.env[key]` is not inlined). BUILD should log `seeded wmw.google-service-account from SSM /amplify/shared/...` and `including WMW_GOOGLE_SERVICE_ACCOUNT_JSON...` when that path runs.
 
 Do not commit spreadsheet IDs or service account JSON.

--- a/scripts/write-amplify-ssr-env.test.ts
+++ b/scripts/write-amplify-ssr-env.test.ts
@@ -4,6 +4,7 @@ import {
   amplifySharedSecretParamName,
   buildAmplifySsrEnvLines,
   ensureWmwSecretInAmplifySecretsEnv,
+  flattenWmwServiceAccountJsonEnv,
   parseAmplifySecretsMap,
 } from './write-amplify-ssr-env';
 
@@ -12,15 +13,18 @@ describe('buildAmplifySsrEnvLines', () => {
     const secrets = JSON.stringify({
       'wmw.google-service-account': '{"type":"service_account"}',
     });
+    const saJson = '{"type":"service_account"}';
     const lines = buildAmplifySsrEnvLines({
       WMW_SPREADSHEET_ID: 'sheet-id',
       WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
+      WMW_GOOGLE_SERVICE_ACCOUNT_JSON: saJson,
       secrets,
     });
 
     expect(lines).toEqual([
       'WMW_SPREADSHEET_ID="sheet-id"',
       'WMW_GOOGLE_SA_SECRET_NAME="wmw.google-service-account"',
+      `WMW_GOOGLE_SERVICE_ACCOUNT_JSON=${JSON.stringify(saJson)}`,
       `secrets=${JSON.stringify(secrets)}`,
     ]);
   });
@@ -51,7 +55,8 @@ describe('ensureWmwSecretInAmplifySecretsEnv', () => {
   const saJson = JSON.stringify({
     type: 'service_account',
     client_email: 'wmw-reader@example.iam.gserviceaccount.com',
-    private_key: '-----BEGIN PRIVATE KEY-----\\nMIIE\\n-----END PRIVATE KEY-----\\n',
+    private_key:
+      '-----BEGIN PRIVATE KEY-----\\nMIIE\\n-----END PRIVATE KEY-----\\n',
   });
 
   it('leaves secrets untouched when the named leaf is already present', () => {
@@ -129,5 +134,27 @@ describe('ensureWmwSecretInAmplifySecretsEnv', () => {
 
     expect(result.seededFrom).toBe(branchName);
     expect(fetchParameter).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('flattenWmwServiceAccountJsonEnv', () => {
+  it('promotes the secrets-map leaf into WMW_GOOGLE_SERVICE_ACCOUNT_JSON', () => {
+    const saJson =
+      '{"client_email":"a@b.com","private_key":"-----BEGIN PRIVATE KEY-----\\nx\\n-----END PRIVATE KEY-----\\n"}';
+    const flattened = flattenWmwServiceAccountJsonEnv({
+      secrets: JSON.stringify({ 'wmw.google-service-account': saJson }),
+    });
+    expect(flattened.WMW_GOOGLE_SERVICE_ACCOUNT_JSON).toBe(saJson);
+  });
+
+  it('does not overwrite an existing top-level JSON env', () => {
+    const existing = '{"client_email":"keep@b.com"}';
+    const flattened = flattenWmwServiceAccountJsonEnv({
+      WMW_GOOGLE_SERVICE_ACCOUNT_JSON: existing,
+      secrets: JSON.stringify({
+        'wmw.google-service-account': '{"client_email":"other@b.com"}',
+      }),
+    });
+    expect(flattened.WMW_GOOGLE_SERVICE_ACCOUNT_JSON).toBe(existing);
   });
 });

--- a/scripts/write-amplify-ssr-env.ts
+++ b/scripts/write-amplify-ssr-env.ts
@@ -7,7 +7,8 @@
  * Hosting secrets created for all branches live under
  * `/amplify/shared/{appId}/` and often arrive as an empty `process.env.secrets`
  * map (`{}`). This script seeds the WMW Google SA from shared/branch SSM when
- * missing so Refresh Server Actions can resolve credentials.
+ * missing, then also writes `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` as a top-level
+ * env so Next can statically inline `process.env.WMW_*` into Server Actions.
  *
  * @see https://docs.aws.amazon.com/amplify/latest/userguide/ssr-environment-variables.html
  */
@@ -15,10 +16,14 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
-/** Non-secret WMW config + Amplify's injected `secrets` JSON map. */
+/**
+ * WMW SSR keys. Prefer top-level SA JSON — Next inlines static
+ * `process.env.WMW_*` access; nested `secrets` alone is easy to miss at runtime.
+ */
 export const AMPLIFY_SSR_ENV_KEYS = [
   'WMW_SPREADSHEET_ID',
   'WMW_GOOGLE_SA_SECRET_NAME',
+  'WMW_GOOGLE_SERVICE_ACCOUNT_JSON',
   'secrets',
 ] as const;
 
@@ -168,16 +173,32 @@ export function ensureWmwSecretInAmplifySecretsEnv(
   return { env, seededFrom: null, secretName };
 }
 
+/**
+ * Promote the SA leaf into `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` so Server Actions
+ * can use static `process.env.WMW_GOOGLE_SERVICE_ACCOUNT_JSON` (Next inlines it).
+ */
+export function flattenWmwServiceAccountJsonEnv(
+  env: Record<string, string | undefined>,
+  secretName: string = DEFAULT_WMW_GOOGLE_SA_SECRET_NAME,
+): Record<string, string | undefined> {
+  if (env.WMW_GOOGLE_SERVICE_ACCOUNT_JSON?.trim()) return env;
+  const fromMap = parseAmplifySecretsMap(env.secrets)[secretName]?.trim();
+  if (!fromMap) return env;
+  return { ...env, WMW_GOOGLE_SERVICE_ACCOUNT_JSON: fromMap };
+}
+
 export function writeAmplifySsrEnvFile(
   env: Record<string, string | undefined> = process.env,
   filePath = '.env.production',
   options?: WriteAmplifySsrEnvOptions,
 ): WriteAmplifySsrEnvResult {
   const {
-    env: resolvedEnv,
+    env: seededEnv,
     seededFrom,
     secretName,
   } = ensureWmwSecretInAmplifySecretsEnv(env, options);
+
+  const resolvedEnv = flattenWmwServiceAccountJsonEnv(seededEnv, secretName);
 
   if (seededFrom) {
     console.log(
@@ -185,10 +206,17 @@ export function writeAmplifySsrEnvFile(
     );
   } else {
     const hasSa = Boolean(
-      parseAmplifySecretsMap(resolvedEnv.secrets)[secretName]?.trim(),
+      parseAmplifySecretsMap(resolvedEnv.secrets)[secretName]?.trim() ||
+        resolvedEnv.WMW_GOOGLE_SERVICE_ACCOUNT_JSON?.trim(),
     );
     console.log(
       `write-amplify-ssr-env: secrets map ${hasSa ? 'already has' : 'missing'} ${secretName}`,
+    );
+  }
+
+  if (resolvedEnv.WMW_GOOGLE_SERVICE_ACCOUNT_JSON?.trim()) {
+    console.log(
+      'write-amplify-ssr-env: including WMW_GOOGLE_SERVICE_ACCOUNT_JSON for Next static env inline',
     );
   }
 

--- a/src/lib/wmw/config.ts
+++ b/src/lib/wmw/config.ts
@@ -26,7 +26,18 @@ function readTrimmed(env: EnvLike, key: string): string | null {
   return value ? value : null;
 }
 
-export function getWmwConfig(env: EnvLike = process.env): WmwConfig {
+/**
+ * Static `process.env.WMW_*` reads so Next can inline build-time values into
+ * Server Actions (dynamic `env[key]` / `process.env[key]` is not inlined).
+ */
+export function readWmwConfigProcessEnv(): EnvLike {
+  return {
+    WMW_SPREADSHEET_ID: process.env.WMW_SPREADSHEET_ID,
+    WMW_GOOGLE_SA_SECRET_NAME: process.env.WMW_GOOGLE_SA_SECRET_NAME,
+  };
+}
+
+export function getWmwConfig(env: EnvLike = readWmwConfigProcessEnv()): WmwConfig {
   return {
     spreadsheetId: readTrimmed(env, WMW_SPREADSHEET_ID_ENV),
     googleServiceAccountSecretName: readTrimmed(

--- a/src/lib/wmw/google-sa-credentials.ts
+++ b/src/lib/wmw/google-sa-credentials.ts
@@ -79,13 +79,26 @@ function readAmplifySecretsMap(env: EnvLike): Record<string, string> {
 }
 
 /**
+ * Static `process.env.*` reads so Next can inline Amplify `.env.production`
+ * values into Server Actions (dynamic `process.env[key]` is not inlined).
+ */
+export function readGoogleSaProcessEnv(): EnvLike {
+  return {
+    WMW_GOOGLE_SERVICE_ACCOUNT_JSON: process.env.WMW_GOOGLE_SERVICE_ACCOUNT_JSON,
+    WMW_GOOGLE_SERVICE_ACCOUNT_FILE: process.env.WMW_GOOGLE_SERVICE_ACCOUNT_FILE,
+    WMW_GOOGLE_SA_SECRET_NAME: process.env.WMW_GOOGLE_SA_SECRET_NAME,
+    secrets: process.env.secrets,
+  };
+}
+
+/**
  * Resolution order (first hit wins):
- * 1. `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` — raw JSON (local `.env.local`)
+ * 1. `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` — raw JSON (local `.env.local` / Amplify SSR)
  * 2. `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` — path to JSON file
  * 3. Amplify Hosting `process.env.secrets[WMW_GOOGLE_SA_SECRET_NAME]`
  */
 export function resolveGoogleServiceAccountCredentials(
-  env: EnvLike = process.env,
+  env: EnvLike = readGoogleSaProcessEnv(),
 ): GoogleServiceAccountCredentials | null {
   const inline = env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV]?.trim();
   if (inline) {

--- a/src/lib/wmw/pull-workbook-action.test.ts
+++ b/src/lib/wmw/pull-workbook-action.test.ts
@@ -4,9 +4,18 @@ import {
   WMW_SPREADSHEET_ID_ENV,
   WMW_WORKBOOK_NOT_CONFIGURED_REASON,
 } from '@/lib/wmw/config';
-import { WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV } from '@/lib/wmw/google-sa-credentials';
+import {
+  WMW_GOOGLE_SERVICE_ACCOUNT_FILE_ENV,
+  WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV,
+} from '@/lib/wmw/google-sa-credentials';
 
 const ORIGINAL_ENV = { ...process.env };
+
+function clearWmwCredentialEnv() {
+  delete process.env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV];
+  delete process.env[WMW_GOOGLE_SERVICE_ACCOUNT_FILE_ENV];
+  delete process.env.secrets;
+}
 
 afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
@@ -16,8 +25,7 @@ afterEach(() => {
 describe('pullWmwWorkbookTabs', () => {
   it('fails clearly when spreadsheet ID or SA credentials are missing', async () => {
     delete process.env[WMW_SPREADSHEET_ID_ENV];
-    delete process.env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV];
-    delete process.env.secrets;
+    clearWmwCredentialEnv();
 
     await expect(pullWmwWorkbookTabs()).rejects.toThrow(
       WMW_WORKBOOK_NOT_CONFIGURED_REASON,
@@ -26,8 +34,7 @@ describe('pullWmwWorkbookTabs', () => {
 
   it('fails clearly when only spreadsheet ID is set', async () => {
     process.env[WMW_SPREADSHEET_ID_ENV] = 'sheet-id-only';
-    delete process.env[WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV];
-    delete process.env.secrets;
+    clearWmwCredentialEnv();
 
     await expect(pullWmwWorkbookTabs()).rejects.toThrow(
       WMW_WORKBOOK_NOT_CONFIGURED_REASON,


### PR DESCRIPTION
## Summary
- Deployment 80 correctly seeded the shared SSM SA into `.env.production`, but Refresh still 500d because Server Actions used dynamic `process.env[key]` / `env[key]`, which Next does not inline for Amplify SSR runtime.
- Flatten the SA into top-level `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` during the Amplify SSR env write, and read `process.env.WMW_*` / `process.env.secrets` via static property access.
- Keeps shared-SSM seeding from #205; documents the static-inline requirement.

## Test plan
- [ ] CI `quality` passes
- [ ] Amplify BUILD logs both `seeded wmw.google-service-account from SSM /amplify/shared/...` and `including WMW_GOOGLE_SERVICE_ACCOUNT_JSON...`
- [ ] Refresh on `/labs/wmw` succeeds (no POST 500)
- [ ] After Refresh, last-good snapshot 404s stop
