### PR TITLE
fix(wmw): runtime SSM + SSR compute role for Refresh

### DIFF
--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -77,7 +77,7 @@ If `nvm use 22` fails on the build image (version not installed), add a line bef
 
 Site Content no longer requires private blog-repo SSH secrets. Remove obsolete `SSH_PRIVATE_KEY` / `BLOG_REPO_*` console variables when convenient.
 
-WMW (What's My Worth) expects `WMW_SPREADSHEET_ID`, `WMW_GOOGLE_SA_SECRET_NAME` (default `wmw.google-service-account`, must match `[a-zA-Z0-9_.-]+`), and server-only SA material via `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` / `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` (local) or Amplify Hosting Secrets (`process.env.secrets`). Refresh uses a Server Action so the private key never ships to the browser. Placeholders live in `.env.example`; see [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md) and [#181](https://github.com/hashadar/hashadar_website/issues/181).
+WMW (What's My Worth) expects `WMW_SPREADSHEET_ID` and `WMW_GOOGLE_SA_SECRET_NAME` (default `wmw.google-service-account`, must match `[a-zA-Z0-9_.-]+`) as Amplify env vars, plus the Google SA as an Amplify Hosting secret. Local Refresh uses `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` / `WMW_GOOGLE_SERVICE_ACCOUNT_FILE`; production Refresh reads the Hosting secret from SSM via the app’s **SSR Compute IAM role**. Placeholders live in `.env.example`; see [docs/wmw/snapshot-storage.md](./wmw/snapshot-storage.md) and [#181](https://github.com/hashadar/hashadar_website/issues/181).
 
 ## CI vs Site Content
 

--- a/docs/wmw/snapshot-storage.md
+++ b/docs/wmw/snapshot-storage.md
@@ -29,14 +29,21 @@ Env wiring ([#181](https://github.com/hashadar/hashadar_website/issues/181)):
 
 | Variable | Role |
 |----------|------|
-| `WMW_SPREADSHEET_ID` | Equity Workbook spreadsheet ID |
-| `WMW_GOOGLE_SA_SECRET_NAME` | Name of the Amplify secret that holds the Google service account JSON |
-| `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` | Server-only raw SA JSON (preferred for `next dev`) |
+| `WMW_SPREADSHEET_ID` | Equity Workbook spreadsheet ID (Amplify **env var**, non-secret) |
+| `WMW_GOOGLE_SA_SECRET_NAME` | Leaf name of the Hosting secret (default `wmw.google-service-account`) |
+| `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` | Server-only raw SA JSON for `next dev` |
 | `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` | Server-only path to SA JSON file (e.g. `.secrets/wmw-google-sa.json`) |
 
 Default Amplify secret name (documented in `.env.example`, not a credential): `wmw.google-service-account`.
 
-Refresh pulls Sheets through a **Server Action** (`pullWmwWorkbookTabs`) so the private key never enters the browser. Credential resolution order: inline JSON → file path → Amplify Hosting `process.env.secrets[name]`.
+Refresh pulls Sheets through a **Server Action** (`pullWmwWorkbookTabs`) so the private key never enters the browser.
+
+**Credential resolution (server):**
+
+1. Local: `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` or `WMW_GOOGLE_SERVICE_ACCOUNT_FILE`
+2. Production: Amplify Hosting secret via **SSM** (`/amplify/shared/{appId}/wmw.google-service-account`) using the app’s **SSR Compute IAM role**
+
+**Spreadsheet ID (server):** written into `src/lib/wmw/wmw-ssr-config.ts` at Amplify build time (bundled into `.next/server`). Next does not receive Amplify `.env.production` on WEB_COMPUTE at runtime.
 
 ### Local testing (`npm run sandbox` + `npm run dev`)
 
@@ -53,21 +60,17 @@ Sandbox CLI and Amplify Hosting secrets both store the leaf name in SSM Paramete
 | Environment | How to set |
 |-------------|------------|
 | Local sandbox | `npx ampx sandbox secret set wmw.google-service-account` (backend/SSM; Next.js still needs JSON/FILE above) |
-| Amplify Hosting | App → Hosting → Secrets → Manage secrets (same leaf name); expose via `process.env.secrets` for SSR |
+| Amplify Hosting | App → Hosting → Secrets → Manage secrets (same leaf name) |
 
 ### Amplify Hosting SSR wiring
 
-Amplify loads console env vars and Hosting secrets into the **build** environment (you should see `Setting Up SSM Secrets` in BUILD logs). Next.js Server Actions do **not** see those by default — Amplify only forwards vars written to `.env.production` before `next build`.
+`amplify.yml` runs `npx tsx scripts/write-amplify-ssr-env.ts`, which writes non-secret fields into `wmw-ssr-config.ts` (spreadsheet ID, app id, secret name). The Google SA is **not** written into build artifacts.
 
-`amplify.yml` runs `npx tsx scripts/write-amplify-ssr-env.ts`, which appends:
+Production Refresh requires an **SSR Compute role** on the Amplify app with `ssm:GetParameter` (and decrypt) on:
 
-- `WMW_SPREADSHEET_ID`
-- `WMW_GOOGLE_SA_SECRET_NAME`
-- `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` (flattened from the Hosting secrets map / shared SSM)
-- `secrets` (the Amplify Hosting secrets JSON map)
+- `/amplify/shared/d3j7dgxx3prj17/wmw.google-service-account`
+- optionally `/amplify/d3j7dgxx3prj17/main/wmw.google-service-account`
 
-without logging values. Redeploy after changing Hosting secrets or env vars.
-
-**Shared vs branch secrets:** Amplify’s build loader only reads SSM under `/amplify/{appId}/{branch}/`. Secrets created for all branches live under `/amplify/shared/{appId}/` and often yield an empty `process.env.secrets` (`{}`). The write script then seeds `wmw.google-service-account` from shared (or branch) SSM via `aws ssm get-parameter`, and also writes `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` so Next can statically inline `process.env.WMW_*` into Server Actions (dynamic `process.env[key]` is not inlined). BUILD should log `seeded wmw.google-service-account from SSM /amplify/shared/...` and `including WMW_GOOGLE_SERVICE_ACCOUNT_JSON...` when that path runs.
+Attach under Amplify Console → App settings → IAM roles → Compute role. Trust principal: `amplify.amazonaws.com`.
 
 Do not commit spreadsheet IDs or service account JSON.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29218,6 +29218,74 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1104.0",
+        "@aws-sdk/client-ssm": "^3.1106.0",
         "@fontsource/zalando-sans-expanded": "^5.2.1",
         "aws-amplify": "^6.20.0",
         "clsx": "^2.1.1",
@@ -3823,23 +3824,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -3855,23 +3839,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -7269,23 +7236,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "dev": true,
@@ -7301,23 +7251,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/semantic-conventions": {
@@ -10318,18 +10251,17 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1095.0.tgz",
-      "integrity": "sha512-0A88Y+mFdsHGHInTC0xLiKkrIrVz7uzDImOv50zIFb189oo4oTStOd9Ht1gw4Il5nXnLd2qokfVxePnZwaIoFg==",
-      "dev": true,
+      "version": "3.1106.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1106.0.tgz",
+      "integrity": "sha512-jPGMnYT+XtpXnnXzOBm9zBg+o4+vGQClj8TtDKZzX6sGFVcEunQEL1dZHn5iRy3z5vaGN+T7ch4zgI9A2WJkfA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1104.0",
+    "@aws-sdk/client-ssm": "^3.1106.0",
     "@fontsource/zalando-sans-expanded": "^5.2.1",
     "aws-amplify": "^6.20.0",
     "clsx": "^2.1.1",

--- a/scripts/write-amplify-ssr-env.test.ts
+++ b/scripts/write-amplify-ssr-env.test.ts
@@ -1,160 +1,41 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
-  amplifyBranchSecretParamName,
-  amplifySharedSecretParamName,
-  buildAmplifySsrEnvLines,
-  ensureWmwSecretInAmplifySecretsEnv,
-  flattenWmwServiceAccountJsonEnv,
-  parseAmplifySecretsMap,
+  buildWmwSsrConfigModuleSource,
+  resolveWmwSsrConfigValues,
 } from './write-amplify-ssr-env';
 
-describe('buildAmplifySsrEnvLines', () => {
-  it('writes present keys as JSON-stringified dotenv lines', () => {
-    const secrets = JSON.stringify({
-      'wmw.google-service-account': '{"type":"service_account"}',
-    });
-    const saJson = '{"type":"service_account"}';
-    const lines = buildAmplifySsrEnvLines({
-      WMW_SPREADSHEET_ID: 'sheet-id',
-      WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
-      WMW_GOOGLE_SERVICE_ACCOUNT_JSON: saJson,
-      secrets,
-    });
-
-    expect(lines).toEqual([
-      'WMW_SPREADSHEET_ID="sheet-id"',
-      'WMW_GOOGLE_SA_SECRET_NAME="wmw.google-service-account"',
-      `WMW_GOOGLE_SERVICE_ACCOUNT_JSON=${JSON.stringify(saJson)}`,
-      `secrets=${JSON.stringify(secrets)}`,
-    ]);
-  });
-
-  it('skips missing or empty values', () => {
+describe('resolveWmwSsrConfigValues', () => {
+  it('reads spreadsheet id and falls back to defaults', () => {
     expect(
-      buildAmplifySsrEnvLines({
-        WMW_SPREADSHEET_ID: '',
-        WMW_GOOGLE_SA_SECRET_NAME: undefined,
+      resolveWmwSsrConfigValues({
+        WMW_SPREADSHEET_ID: ' sheet-123 ',
+        WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
+        AWS_APP_ID: 'd3j7dgxx3prj17',
+        AWS_REGION: 'eu-west-2',
       }),
-    ).toEqual([]);
+    ).toEqual({
+      appId: 'd3j7dgxx3prj17',
+      region: 'eu-west-2',
+      spreadsheetId: 'sheet-123',
+      googleSaSecretName: 'wmw.google-service-account',
+    });
   });
 
-  it('round-trips secrets JSON through JSON.parse of the dotenv value', () => {
-    const secrets = JSON.stringify({
-      'wmw.google-service-account': '{"client_email":"a@b.com"}',
-    });
-    const [line] = buildAmplifySsrEnvLines({ secrets }, ['secrets']);
-    const valueLiteral = line.slice('secrets='.length);
-    expect(JSON.parse(valueLiteral)).toBe(secrets);
-    expect(JSON.parse(JSON.parse(valueLiteral))).toEqual({
-      'wmw.google-service-account': '{"client_email":"a@b.com"}',
-    });
+  it('allows null spreadsheet id when unset', () => {
+    expect(resolveWmwSsrConfigValues({}).spreadsheetId).toBeNull();
   });
 });
 
-describe('ensureWmwSecretInAmplifySecretsEnv', () => {
-  const saJson = JSON.stringify({
-    type: 'service_account',
-    client_email: 'wmw-reader@example.iam.gserviceaccount.com',
-    private_key:
-      '-----BEGIN PRIVATE KEY-----\\nMIIE\\n-----END PRIVATE KEY-----\\n',
-  });
-
-  it('leaves secrets untouched when the named leaf is already present', () => {
-    const secrets = JSON.stringify({
-      'wmw.google-service-account': saJson,
+describe('buildWmwSsrConfigModuleSource', () => {
+  it('embeds values with JSON string escaping', () => {
+    const source = buildWmwSsrConfigModuleSource({
+      appId: 'd3j7dgxx3prj17',
+      region: 'eu-west-2',
+      spreadsheetId: 'sheet-id',
+      googleSaSecretName: 'wmw.google-service-account',
     });
-    const fetchParameter = vi.fn();
-    const result = ensureWmwSecretInAmplifySecretsEnv(
-      {
-        WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
-        secrets,
-        AWS_APP_ID: 'd3j7dgxx3prj17',
-        AWS_BRANCH: 'main',
-      },
-      { fetchParameter },
-    );
-
-    expect(result.seededFrom).toBeNull();
-    expect(result.env.secrets).toBe(secrets);
-    expect(fetchParameter).not.toHaveBeenCalled();
-  });
-
-  it('seeds from shared SSM when build injects an empty secrets map', () => {
-    const sharedName = amplifySharedSecretParamName(
-      'd3j7dgxx3prj17',
-      'wmw.google-service-account',
-    );
-    const fetchParameter = vi.fn((name: string) =>
-      name === sharedName ? saJson : null,
-    );
-
-    const result = ensureWmwSecretInAmplifySecretsEnv(
-      {
-        WMW_SPREADSHEET_ID: 'sheet-id',
-        WMW_GOOGLE_SA_SECRET_NAME: 'wmw.google-service-account',
-        secrets: JSON.stringify({}),
-        AWS_APP_ID: 'd3j7dgxx3prj17',
-        AWS_BRANCH: 'main',
-      },
-      { fetchParameter },
-    );
-
-    expect(result.seededFrom).toBe(sharedName);
-    expect(parseAmplifySecretsMap(result.env.secrets)).toEqual({
-      'wmw.google-service-account': saJson,
-    });
-    expect(fetchParameter).toHaveBeenCalledWith(
-      amplifyBranchSecretParamName(
-        'd3j7dgxx3prj17',
-        'main',
-        'wmw.google-service-account',
-      ),
-    );
-    expect(fetchParameter).toHaveBeenCalledWith(sharedName);
-  });
-
-  it('prefers branch SSM over shared when both could resolve', () => {
-    const branchName = amplifyBranchSecretParamName(
-      'd3j7dgxx3prj17',
-      'main',
-      'wmw.google-service-account',
-    );
-    const fetchParameter = vi.fn((name: string) =>
-      name === branchName ? saJson : 'SHOULD_NOT_USE',
-    );
-
-    const result = ensureWmwSecretInAmplifySecretsEnv(
-      {
-        secrets: '{}',
-        AWS_APP_ID: 'd3j7dgxx3prj17',
-        AWS_BRANCH: 'main',
-      },
-      { fetchParameter },
-    );
-
-    expect(result.seededFrom).toBe(branchName);
-    expect(fetchParameter).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('flattenWmwServiceAccountJsonEnv', () => {
-  it('promotes the secrets-map leaf into WMW_GOOGLE_SERVICE_ACCOUNT_JSON', () => {
-    const saJson =
-      '{"client_email":"a@b.com","private_key":"-----BEGIN PRIVATE KEY-----\\nx\\n-----END PRIVATE KEY-----\\n"}';
-    const flattened = flattenWmwServiceAccountJsonEnv({
-      secrets: JSON.stringify({ 'wmw.google-service-account': saJson }),
-    });
-    expect(flattened.WMW_GOOGLE_SERVICE_ACCOUNT_JSON).toBe(saJson);
-  });
-
-  it('does not overwrite an existing top-level JSON env', () => {
-    const existing = '{"client_email":"keep@b.com"}';
-    const flattened = flattenWmwServiceAccountJsonEnv({
-      WMW_GOOGLE_SERVICE_ACCOUNT_JSON: existing,
-      secrets: JSON.stringify({
-        'wmw.google-service-account': '{"client_email":"other@b.com"}',
-      }),
-    });
-    expect(flattened.WMW_GOOGLE_SERVICE_ACCOUNT_JSON).toBe(existing);
+    expect(source).toContain('spreadsheetId: "sheet-id"');
+    expect(source).toContain('googleSaSecretName: "wmw.google-service-account"');
+    expect(source).not.toContain('PRIVATE KEY');
   });
 });

--- a/scripts/write-amplify-ssr-env.ts
+++ b/scripts/write-amplify-ssr-env.ts
@@ -1,237 +1,105 @@
 /**
- * Amplify console env vars / Hosting secrets are available in the build
- * environment, but Next.js SSR (Server Actions) does not see them unless
- * they are written to `.env.production` before `next build`.
+ * Amplify build helper for WMW SSR.
  *
- * Amplify's build-time SSM loader only reads `/amplify/{appId}/{branch}/`.
- * Hosting secrets created for all branches live under
- * `/amplify/shared/{appId}/` and often arrive as an empty `process.env.secrets`
- * map (`{}`). This script seeds the WMW Google SA from shared/branch SSM when
- * missing, then also writes `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` as a top-level
- * env so Next can statically inline `process.env.WMW_*` into Server Actions.
+ * Next.js 16 keeps `process.env.WMW_*` as runtime lookups, and Amplify only
+ * deploys `.next/**`, so `.env.production` never reaches Server Actions.
  *
- * @see https://docs.aws.amazon.com/amplify/latest/userguide/ssr-environment-variables.html
+ * This script writes non-secret config into `src/lib/wmw/wmw-ssr-config.ts`
+ * (bundled into `.next/server`). The Google SA JSON stays in Amplify Hosting
+ * Secrets / SSM and is read at runtime via the SSR Compute IAM role.
  */
-import { execFileSync } from 'node:child_process';
-import { appendFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
-/**
- * WMW SSR keys. Prefer top-level SA JSON — Next inlines static
- * `process.env.WMW_*` access; nested `secrets` alone is easy to miss at runtime.
- */
-export const AMPLIFY_SSR_ENV_KEYS = [
-  'WMW_SPREADSHEET_ID',
-  'WMW_GOOGLE_SA_SECRET_NAME',
-  'WMW_GOOGLE_SERVICE_ACCOUNT_JSON',
-  'secrets',
-] as const;
+export const WMW_SSR_CONFIG_PATH = 'src/lib/wmw/wmw-ssr-config.ts';
 
-/** Default Amplify Hosting secret leaf name (must match `[a-zA-Z0-9_.-]+`). */
 export const DEFAULT_WMW_GOOGLE_SA_SECRET_NAME = 'wmw.google-service-account';
+export const DEFAULT_WMW_AMPLIFY_APP_ID = 'd3j7dgxx3prj17';
+export const DEFAULT_WMW_AWS_REGION = 'eu-west-2';
 
-export type WriteAmplifySsrEnvResult = {
-  writtenKeys: string[];
-  skipped: boolean;
-  seededFrom: string | null;
+export type WmwSsrConfigValues = {
+  appId: string;
+  region: string;
+  spreadsheetId: string | null;
+  googleSaSecretName: string;
 };
 
-export type FetchSsmSecureString = (name: string) => string | null;
-
-export type WriteAmplifySsrEnvOptions = {
-  /** Override SSM fetch (tests). Defaults to `aws ssm get-parameter`. */
-  fetchParameter?: FetchSsmSecureString;
+export type WriteWmwSsrConfigResult = {
+  path: string;
+  spreadsheetIdSet: boolean;
 };
 
-/**
- * Build dotenv lines. Values are JSON-stringified so nested JSON / newlines
- * in the Amplify `secrets` map stay intact for Next.js env loading.
- */
-export function buildAmplifySsrEnvLines(
-  env: Record<string, string | undefined>,
-  keys: readonly string[] = AMPLIFY_SSR_ENV_KEYS,
-): string[] {
-  const lines: string[] = [];
-  for (const key of keys) {
-    const value = env[key];
-    if (value === undefined || value === '') continue;
-    lines.push(`${key}=${JSON.stringify(value)}`);
-  }
-  return lines;
-}
-
-export function parseAmplifySecretsMap(
-  raw: string | undefined,
-): Record<string, string> {
-  if (!raw?.trim()) return {};
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== 'object' || parsed === null) return {};
-    const out: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      if (typeof value === 'string' && value.trim()) {
-        out[key] = value;
-      }
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
-export function amplifySharedSecretParamName(
-  appId: string,
-  secretName: string,
-): string {
-  return `/amplify/shared/${appId}/${secretName}`;
-}
-
-export function amplifyBranchSecretParamName(
-  appId: string,
-  branch: string,
-  secretName: string,
-): string {
-  return `/amplify/${appId}/${branch}/${secretName}`;
-}
-
-export function fetchSsmSecureStringViaAwsCli(
-  name: string,
-  exec: typeof execFileSync = execFileSync,
-  region =
-    process.env.AWS_REGION ||
-    process.env.AWS_DEFAULT_REGION ||
-    'eu-west-2',
-): string | null {
-  try {
-    const out = exec(
-      'aws',
-      [
-        'ssm',
-        'get-parameter',
-        '--name',
-        name,
-        '--with-decryption',
-        '--query',
-        'Parameter.Value',
-        '--output',
-        'text',
-        '--region',
-        region,
-      ],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
-    );
-    const value = String(out).trim();
-    return value && value !== 'None' ? value : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * If `process.env.secrets` lacks the WMW SA leaf, pull it from Amplify SSM
- * (branch path first, then shared / all-branches).
- */
-export function ensureWmwSecretInAmplifySecretsEnv(
-  env: Record<string, string | undefined>,
-  options?: WriteAmplifySsrEnvOptions,
-): {
-  env: Record<string, string | undefined>;
-  seededFrom: string | null;
-  secretName: string;
-} {
-  const secretName =
-    env.WMW_GOOGLE_SA_SECRET_NAME?.trim() || DEFAULT_WMW_GOOGLE_SA_SECRET_NAME;
-  const map = parseAmplifySecretsMap(env.secrets);
-  if (map[secretName]?.trim()) {
-    return { env, seededFrom: null, secretName };
-  }
-
-  const appId = env.AWS_APP_ID?.trim();
-  const branch = env.AWS_BRANCH?.trim();
-  const fetchParameter =
-    options?.fetchParameter ?? fetchSsmSecureStringViaAwsCli;
-
-  const candidates: string[] = [];
-  if (appId && branch) {
-    candidates.push(amplifyBranchSecretParamName(appId, branch, secretName));
-  }
-  if (appId) {
-    candidates.push(amplifySharedSecretParamName(appId, secretName));
-  }
-
-  for (const paramName of candidates) {
-    const value = fetchParameter(paramName)?.trim();
-    if (!value) continue;
-    map[secretName] = value;
-    return {
-      env: { ...env, secrets: JSON.stringify(map) },
-      seededFrom: paramName,
-      secretName,
-    };
-  }
-
-  return { env, seededFrom: null, secretName };
-}
-
-/**
- * Promote the SA leaf into `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` so Server Actions
- * can use static `process.env.WMW_GOOGLE_SERVICE_ACCOUNT_JSON` (Next inlines it).
- */
-export function flattenWmwServiceAccountJsonEnv(
-  env: Record<string, string | undefined>,
-  secretName: string = DEFAULT_WMW_GOOGLE_SA_SECRET_NAME,
-): Record<string, string | undefined> {
-  if (env.WMW_GOOGLE_SERVICE_ACCOUNT_JSON?.trim()) return env;
-  const fromMap = parseAmplifySecretsMap(env.secrets)[secretName]?.trim();
-  if (!fromMap) return env;
-  return { ...env, WMW_GOOGLE_SERVICE_ACCOUNT_JSON: fromMap };
-}
-
-export function writeAmplifySsrEnvFile(
+export function resolveWmwSsrConfigValues(
   env: Record<string, string | undefined> = process.env,
-  filePath = '.env.production',
-  options?: WriteAmplifySsrEnvOptions,
-): WriteAmplifySsrEnvResult {
-  const {
-    env: seededEnv,
-    seededFrom,
-    secretName,
-  } = ensureWmwSecretInAmplifySecretsEnv(env, options);
+): WmwSsrConfigValues {
+  const spreadsheetId = env.WMW_SPREADSHEET_ID?.trim() || null;
+  const googleSaSecretName =
+    env.WMW_GOOGLE_SA_SECRET_NAME?.trim() || DEFAULT_WMW_GOOGLE_SA_SECRET_NAME;
+  const appId = env.AWS_APP_ID?.trim() || DEFAULT_WMW_AMPLIFY_APP_ID;
+  const region =
+    env.AWS_REGION?.trim() ||
+    env.AWS_DEFAULT_REGION?.trim() ||
+    DEFAULT_WMW_AWS_REGION;
 
-  const resolvedEnv = flattenWmwServiceAccountJsonEnv(seededEnv, secretName);
+  return { appId, region, spreadsheetId, googleSaSecretName };
+}
 
-  if (seededFrom) {
+/** Build the TypeScript module source (safe string escaping via JSON.stringify). */
+export function buildWmwSsrConfigModuleSource(
+  values: WmwSsrConfigValues,
+): string {
+  return `/**
+ * Non-secret WMW SSR config available to Server Actions.
+ * Generated by scripts/write-amplify-ssr-env.ts during Amplify build.
+ * Google SA JSON is fetched at runtime from SSM (compute role) — not stored here.
+ */
+import 'server-only';
+
+export type WmwSsrConfig = {
+  /** Amplify app id (SSM path prefix). */
+  appId: string;
+  /** AWS region for SSM. */
+  region: string;
+  /** Equity Workbook spreadsheet ID (non-secret). */
+  spreadsheetId: string | null;
+  /** Hosting secret leaf name under /amplify/shared/{appId}/. */
+  googleSaSecretName: string;
+};
+
+export const wmwSsrConfig: WmwSsrConfig = {
+  appId: ${JSON.stringify(values.appId)},
+  region: ${JSON.stringify(values.region)},
+  spreadsheetId: ${JSON.stringify(values.spreadsheetId)},
+  googleSaSecretName: ${JSON.stringify(values.googleSaSecretName)},
+};
+`;
+}
+
+export function writeWmwSsrConfigFile(
+  env: Record<string, string | undefined> = process.env,
+  filePath = WMW_SSR_CONFIG_PATH,
+): WriteWmwSsrConfigResult {
+  const values = resolveWmwSsrConfigValues(env);
+  writeFileSync(filePath, buildWmwSsrConfigModuleSource(values), 'utf8');
+
+  if (values.spreadsheetId) {
     console.log(
-      `write-amplify-ssr-env: seeded ${secretName} from SSM ${seededFrom}`,
+      `write-amplify-ssr-env: wrote ${filePath} (spreadsheetId set, SA via runtime SSM)`,
     );
   } else {
-    const hasSa = Boolean(
-      parseAmplifySecretsMap(resolvedEnv.secrets)[secretName]?.trim() ||
-        resolvedEnv.WMW_GOOGLE_SERVICE_ACCOUNT_JSON?.trim(),
-    );
     console.log(
-      `write-amplify-ssr-env: secrets map ${hasSa ? 'already has' : 'missing'} ${secretName}`,
+      `write-amplify-ssr-env: wrote ${filePath} (WARNING: WMW_SPREADSHEET_ID missing)`,
     );
   }
 
-  if (resolvedEnv.WMW_GOOGLE_SERVICE_ACCOUNT_JSON?.trim()) {
-    console.log(
-      'write-amplify-ssr-env: including WMW_GOOGLE_SERVICE_ACCOUNT_JSON for Next static env inline',
-    );
-  }
+  return { path: filePath, spreadsheetIdSet: Boolean(values.spreadsheetId) };
+}
 
-  const lines = buildAmplifySsrEnvLines(resolvedEnv);
-  if (lines.length === 0) {
-    console.log('write-amplify-ssr-env: no SSR env vars present; skipping');
-    return { writtenKeys: [], skipped: true, seededFrom };
-  }
-
-  appendFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
-  const writtenKeys = lines.map((line) => line.slice(0, line.indexOf('=')));
-  console.log(
-    `write-amplify-ssr-env: wrote ${writtenKeys.join(', ')} to ${filePath}`,
-  );
-  return { writtenKeys, skipped: false, seededFrom };
+/** @deprecated Prefer writeWmwSsrConfigFile — kept as amplify.yml entrypoint name. */
+export function writeAmplifySsrEnvFile(
+  env: Record<string, string | undefined> = process.env,
+): WriteWmwSsrConfigResult {
+  return writeWmwSsrConfigFile(env);
 }
 
 const isMain =
@@ -239,5 +107,5 @@ const isMain =
   import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMain) {
-  writeAmplifySsrEnvFile();
+  writeWmwSsrConfigFile();
 }

--- a/src/lib/wmw/amplify-hosting-secret.test.ts
+++ b/src/lib/wmw/amplify-hosting-secret.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  amplifyBranchSecretParamName,
+  amplifySharedSecretParamName,
+  fetchAmplifyHostingSecret,
+} from '@/lib/wmw/amplify-hosting-secret';
+
+describe('amplify hosting secret paths', () => {
+  it('uses documented shared and branch SSM layouts', () => {
+    expect(
+      amplifySharedSecretParamName('d3j7dgxx3prj17', 'wmw.google-service-account'),
+    ).toBe('/amplify/shared/d3j7dgxx3prj17/wmw.google-service-account');
+    expect(
+      amplifyBranchSecretParamName(
+        'd3j7dgxx3prj17',
+        'main',
+        'wmw.google-service-account',
+      ),
+    ).toBe('/amplify/d3j7dgxx3prj17/main/wmw.google-service-account');
+  });
+});
+
+describe('fetchAmplifyHostingSecret', () => {
+  it('returns the first parameter value that resolves', async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ Parameter: { Value: '  secret-json  ' } });
+
+    await expect(
+      fetchAmplifyHostingSecret({
+        appId: 'd3j7dgxx3prj17',
+        branch: 'main',
+        secretName: 'wmw.google-service-account',
+        client: { send },
+      }),
+    ).resolves.toBe('secret-json');
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when no candidate resolves', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('denied'));
+    await expect(
+      fetchAmplifyHostingSecret({
+        branch: null,
+        client: { send },
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/lib/wmw/amplify-hosting-secret.ts
+++ b/src/lib/wmw/amplify-hosting-secret.ts
@@ -1,0 +1,81 @@
+/**
+ * Fetch Amplify Hosting secrets from SSM at SSR runtime (compute IAM role).
+ * Prefer shared (all-branches) path, then branch path.
+ */
+import 'server-only';
+import {
+  GetParameterCommand,
+  SSMClient,
+  type SSMClientConfig,
+} from '@aws-sdk/client-ssm';
+import { wmwSsrConfig } from '@/lib/wmw/wmw-ssr-config';
+
+export type FetchAmplifyHostingSecretOptions = {
+  secretName?: string;
+  appId?: string;
+  branch?: string | null;
+  region?: string;
+  /** Injected for tests. */
+  client?: Pick<SSMClient, 'send'>;
+};
+
+export function amplifySharedSecretParamName(
+  appId: string,
+  secretName: string,
+): string {
+  return `/amplify/shared/${appId}/${secretName}`;
+}
+
+export function amplifyBranchSecretParamName(
+  appId: string,
+  branch: string,
+  secretName: string,
+): string {
+  return `/amplify/${appId}/${branch}/${secretName}`;
+}
+
+/**
+ * Load a Hosting secret SecureString. Tries branch path then shared path.
+ * Returns null when missing or when the compute role cannot read SSM.
+ */
+export async function fetchAmplifyHostingSecret(
+  options: FetchAmplifyHostingSecretOptions = {},
+): Promise<string | null> {
+  const secretName =
+    options.secretName?.trim() || wmwSsrConfig.googleSaSecretName;
+  const appId = options.appId?.trim() || wmwSsrConfig.appId;
+  const region = options.region?.trim() || wmwSsrConfig.region;
+  const branch =
+    options.branch === undefined
+      ? process.env.AWS_BRANCH?.trim() || 'main'
+      : options.branch?.trim() || null;
+
+  const candidates: string[] = [];
+  if (branch) {
+    candidates.push(amplifyBranchSecretParamName(appId, branch, secretName));
+  }
+  candidates.push(amplifySharedSecretParamName(appId, secretName));
+
+  const client =
+    options.client ??
+    new SSMClient({
+      region,
+    } satisfies SSMClientConfig);
+
+  for (const name of candidates) {
+    try {
+      const response = await client.send(
+        new GetParameterCommand({
+          Name: name,
+          WithDecryption: true,
+        }),
+      );
+      const value = response.Parameter?.Value?.trim();
+      if (value) return value;
+    } catch {
+      /* try next candidate */
+    }
+  }
+
+  return null;
+}

--- a/src/lib/wmw/config.ts
+++ b/src/lib/wmw/config.ts
@@ -1,7 +1,11 @@
 /**
  * WMW app config from environment.
  * Spreadsheet ID + SA secret name (#181). SA JSON itself is resolved server-side
- * via `resolveGoogleServiceAccountCredentials` (never NEXT_PUBLIC_).
+ * via `resolveGoogleServiceAccountCredentialsAsync` (never NEXT_PUBLIC_).
+ *
+ * Production spreadsheet ID is injected into `wmw-ssr-config.ts` at Amplify build
+ * (see write-amplify-ssr-env) and read from the Server Action — not from here —
+ * because Amplify SSR compute does not receive `.env.production` at runtime.
  */
 export type WmwConfig = {
   spreadsheetId: string | null;
@@ -17,7 +21,7 @@ export const WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER = 'wmw.google-service-account
 
 /** Shared error copy when spreadsheet ID / SA credentials are missing (#181). */
 export const WMW_WORKBOOK_NOT_CONFIGURED_REASON =
-  'WMW Workbook source is not configured (see #181). Set WMW_SPREADSHEET_ID and WMW_GOOGLE_SERVICE_ACCOUNT_JSON (or FILE / Amplify secrets).';
+  'WMW Workbook source is not configured (see #181). Set WMW_SPREADSHEET_ID and WMW_GOOGLE_SERVICE_ACCOUNT_JSON (or FILE / Amplify secrets + SSR compute role).';
 
 type EnvLike = Record<string, string | undefined>;
 
@@ -26,10 +30,7 @@ function readTrimmed(env: EnvLike, key: string): string | null {
   return value ? value : null;
 }
 
-/**
- * Static `process.env.WMW_*` reads so Next can inline build-time values into
- * Server Actions (dynamic `env[key]` / `process.env[key]` is not inlined).
- */
+/** Local `.env.local` / test reads. */
 export function readWmwConfigProcessEnv(): EnvLike {
   return {
     WMW_SPREADSHEET_ID: process.env.WMW_SPREADSHEET_ID,

--- a/src/lib/wmw/google-sa-credentials.test.ts
+++ b/src/lib/wmw/google-sa-credentials.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   AMPLIFY_SECRETS_ENV,
   parseGoogleServiceAccountJson,
   resolveGoogleServiceAccountCredentials,
+  resolveGoogleServiceAccountCredentialsAsync,
   WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV,
 } from '@/lib/wmw/google-sa-credentials';
 import {
@@ -66,5 +67,33 @@ describe('resolveGoogleServiceAccountCredentials', () => {
     ).toMatchObject({
       clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
     });
+  });
+});
+
+describe('resolveGoogleServiceAccountCredentialsAsync', () => {
+  it('falls back to SSM hosting secret when sync env is empty', async () => {
+    const fetchHostingSecret = vi.fn(async () => SAMPLE_JSON);
+    await expect(
+      resolveGoogleServiceAccountCredentialsAsync({
+        env: {},
+        fetchHostingSecret,
+      }),
+    ).resolves.toMatchObject({
+      clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
+    });
+    expect(fetchHostingSecret).toHaveBeenCalled();
+  });
+
+  it('skips SSM when inline JSON is present', async () => {
+    const fetchHostingSecret = vi.fn();
+    await expect(
+      resolveGoogleServiceAccountCredentialsAsync({
+        env: { [WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV]: SAMPLE_JSON },
+        fetchHostingSecret,
+      }),
+    ).resolves.toMatchObject({
+      clientEmail: 'wmw-reader@example.iam.gserviceaccount.com',
+    });
+    expect(fetchHostingSecret).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/wmw/google-sa-credentials.ts
+++ b/src/lib/wmw/google-sa-credentials.ts
@@ -5,17 +5,19 @@
 
 import 'server-only';
 import { readFileSync } from 'node:fs';
+import { fetchAmplifyHostingSecret } from '@/lib/wmw/amplify-hosting-secret';
 import {
   WMW_GOOGLE_SA_SECRET_NAME_ENV,
   WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER,
 } from '@/lib/wmw/config';
+import { wmwSsrConfig } from '@/lib/wmw/wmw-ssr-config';
 
 export const WMW_GOOGLE_SERVICE_ACCOUNT_JSON_ENV =
   'WMW_GOOGLE_SERVICE_ACCOUNT_JSON';
 export const WMW_GOOGLE_SERVICE_ACCOUNT_FILE_ENV =
   'WMW_GOOGLE_SERVICE_ACCOUNT_FILE';
 
-/** Amplify Hosting injects branch secrets as a JSON map under this env key. */
+/** Amplify Hosting injects branch secrets as a JSON map under this env key (build only). */
 export const AMPLIFY_SECRETS_ENV = 'secrets';
 
 export const WMW_SHEETS_READONLY_SCOPE =
@@ -78,10 +80,7 @@ function readAmplifySecretsMap(env: EnvLike): Record<string, string> {
   }
 }
 
-/**
- * Static `process.env.*` reads so Next can inline Amplify `.env.production`
- * values into Server Actions (dynamic `process.env[key]` is not inlined).
- */
+/** Local / test env reads (`.env.local`). Production uses SSM via the async resolver. */
 export function readGoogleSaProcessEnv(): EnvLike {
   return {
     WMW_GOOGLE_SERVICE_ACCOUNT_JSON: process.env.WMW_GOOGLE_SERVICE_ACCOUNT_JSON,
@@ -92,10 +91,10 @@ export function readGoogleSaProcessEnv(): EnvLike {
 }
 
 /**
- * Resolution order (first hit wins):
- * 1. `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` — raw JSON (local `.env.local` / Amplify SSR)
- * 2. `WMW_GOOGLE_SERVICE_ACCOUNT_FILE` — path to JSON file
- * 3. Amplify Hosting `process.env.secrets[WMW_GOOGLE_SA_SECRET_NAME]`
+ * Sync resolution (local + tests):
+ * 1. `WMW_GOOGLE_SERVICE_ACCOUNT_JSON`
+ * 2. `WMW_GOOGLE_SERVICE_ACCOUNT_FILE`
+ * 3. Amplify build-time `process.env.secrets[name]` (usually empty on SSR compute)
  */
 export function resolveGoogleServiceAccountCredentials(
   env: EnvLike = readGoogleSaProcessEnv(),
@@ -112,6 +111,7 @@ export function resolveGoogleServiceAccountCredentials(
 
   const secretName =
     env[WMW_GOOGLE_SA_SECRET_NAME_ENV]?.trim() ||
+    wmwSsrConfig.googleSaSecretName ||
     WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER;
   const fromAmplify = readAmplifySecretsMap(env)[secretName]?.trim();
   if (fromAmplify) {
@@ -119,4 +119,31 @@ export function resolveGoogleServiceAccountCredentials(
   }
 
   return null;
+}
+
+export type ResolveGoogleSaCredentialsAsyncOptions = {
+  env?: EnvLike;
+  /** Injected SSM fetch for tests. */
+  fetchHostingSecret?: typeof fetchAmplifyHostingSecret;
+};
+
+/**
+ * Production Refresh path: sync env/file first, then Amplify Hosting secret via SSM
+ * (requires SSR Compute IAM role with `ssm:GetParameter` on the shared secret).
+ */
+export async function resolveGoogleServiceAccountCredentialsAsync(
+  options: ResolveGoogleSaCredentialsAsyncOptions = {},
+): Promise<GoogleServiceAccountCredentials | null> {
+  const env = options.env ?? readGoogleSaProcessEnv();
+  const sync = resolveGoogleServiceAccountCredentials(env);
+  if (sync) return sync;
+
+  const secretName =
+    env[WMW_GOOGLE_SA_SECRET_NAME_ENV]?.trim() ||
+    wmwSsrConfig.googleSaSecretName ||
+    WMW_GOOGLE_SA_SECRET_NAME_PLACEHOLDER;
+  const fetchSecret = options.fetchHostingSecret ?? fetchAmplifyHostingSecret;
+  const fromSsm = await fetchSecret({ secretName });
+  if (!fromSsm) return null;
+  return parseGoogleServiceAccountJson(fromSsm);
 }

--- a/src/lib/wmw/pull-workbook-action.test.ts
+++ b/src/lib/wmw/pull-workbook-action.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/wmw/amplify-hosting-secret', () => ({
+  fetchAmplifyHostingSecret: vi.fn(async () => null),
+}));
+
 import { pullWmwWorkbookTabs } from '@/lib/wmw/pull-workbook-action';
 import {
   WMW_SPREADSHEET_ID_ENV,

--- a/src/lib/wmw/pull-workbook-action.ts
+++ b/src/lib/wmw/pull-workbook-action.ts
@@ -10,24 +10,28 @@ import {
   WMW_WORKBOOK_NOT_CONFIGURED_REASON,
 } from '@/lib/wmw/config';
 import { createGoogleSaAccessTokenProvider } from '@/lib/wmw/google-sa-access-token';
-import { resolveGoogleServiceAccountCredentials } from '@/lib/wmw/google-sa-credentials';
+import { resolveGoogleServiceAccountCredentialsAsync } from '@/lib/wmw/google-sa-credentials';
 import type { WmwWorkbookRaw } from '@/lib/wmw/types';
 import { createGoogleSheetsWorkbookSource } from '@/lib/wmw/workbook-source';
+import { wmwSsrConfig } from '@/lib/wmw/wmw-ssr-config';
 
 /**
  * Pull the four frozen Workbook tabs via Sheets (unformatted values).
  * Called from the client facade Refresh path as a Server Action.
+ * Production: spreadsheet ID from build-written `wmwSsrConfig`; SA JSON from SSM.
  */
 export async function pullWmwWorkbookTabs(): Promise<WmwWorkbookRaw> {
   const config = getWmwConfig();
-  const credentials = resolveGoogleServiceAccountCredentials();
+  const spreadsheetId =
+    wmwSsrConfig.spreadsheetId?.trim() || config.spreadsheetId;
+  const credentials = await resolveGoogleServiceAccountCredentialsAsync();
 
-  if (!config.spreadsheetId || !credentials) {
+  if (!spreadsheetId || !credentials) {
     throw new Error(WMW_WORKBOOK_NOT_CONFIGURED_REASON);
   }
 
   const source = createGoogleSheetsWorkbookSource({
-    spreadsheetId: config.spreadsheetId,
+    spreadsheetId,
     getAccessToken: createGoogleSaAccessTokenProvider({ credentials }),
   });
 

--- a/src/lib/wmw/wmw-ssr-config.ts
+++ b/src/lib/wmw/wmw-ssr-config.ts
@@ -1,0 +1,25 @@
+/**
+ * Non-secret WMW SSR config available to Server Actions.
+ * Amplify build overwrites spreadsheet fields via write-amplify-ssr-env.ts.
+ * Google SA JSON is fetched at runtime from SSM (compute role) — not stored here.
+ */
+import 'server-only';
+
+export type WmwSsrConfig = {
+  /** Amplify app id (SSM path prefix). */
+  appId: string;
+  /** AWS region for SSM. */
+  region: string;
+  /** Equity Workbook spreadsheet ID (non-secret). */
+  spreadsheetId: string | null;
+  /** Hosting secret leaf name under /amplify/shared/{appId}/. */
+  googleSaSecretName: string;
+};
+
+/** Defaults for production Amplify app; spreadsheetId filled at Amplify build. */
+export const wmwSsrConfig: WmwSsrConfig = {
+  appId: 'd3j7dgxx3prj17',
+  region: 'eu-west-2',
+  spreadsheetId: null,
+  googleSaSecretName: 'wmw.google-service-account',
+};


### PR DESCRIPTION
## Summary
- Root cause: Next 16 does not inline `process.env.WMW_*`, and Amplify WEB_COMPUTE only deploys `.next/**`, so `.env.production` never reached the Refresh Server Action.
- Production Refresh now loads the Google SA from Amplify Hosting Secrets via SSM (`/amplify/shared/{appId}/wmw.google-service-account`) using the SSR Compute IAM role.
- Non-secret spreadsheet ID is written into `wmw-ssr-config.ts` at Amplify build time so it is bundled into `.next/server`.
- Local still uses `WMW_GOOGLE_SERVICE_ACCOUNT_JSON` / `FILE`.

## Ops already done
- Created IAM role `AmplifySSRComputeRole-hashadar-wmw` with SSM GetParameter on the WMW Hosting secret
- Attached it as the Amplify app compute role

## Test plan
- [ ] CI `quality` passes
- [ ] Amplify BUILD logs `wrote src/lib/wmw/wmw-ssr-config.ts (spreadsheetId set, SA via runtime SSM)`
- [ ] After deploy, Refresh on `/labs/wmw` succeeds (no POST 500)
- [ ] Successful Refresh writes last-good snapshots (S3 404s stop)
