### PR TITLE
docs: WMW Labs mention + prefer merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #
 # Triggers: pull_request is the merge gate (required). Push to main re-runs quality plus
 # `next build` as a post-ship safety net. Do not also push-trigger on develop — that
-# duplicates the PR run after every squash-merge.
+# duplicates the PR run after every merge to develop.
 name: CI
 
 on:

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,4 +1,4 @@
-# Keep develop aligned with main after squash merges / hotfixes.
+# Keep develop aligned with main after promotes / hotfixes.
 # Same tree → reset develop to main. Different tree → rebase develop onto main.
 # See docs/BRANCHING.md.
 name: Sync develop from main

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal site for [Hasha Dar](https://hashadar.com)
 
 - **Public site** — portfolio photography, blog, and page content driven from a data layer + live Site Content storage
 - **Site Admin** — authenticated CMS for Posts, portfolio Photos, and the Home Photo (`/admin`)
-- **Labs** — separate gated products under `/labs` that reuse site-wide sign-in; currently **Job OS**, a private job-hunting graph (Employer → Opportunity → Application) with fit analysis behind a facade
+- **Labs** — separate gated products under `/labs` that reuse site-wide sign-in; currently **Job OS** (private job-hunting graph: Employer → Opportunity → Application, with fit analysis behind a facade) and **WMW (What's My Worth)** (private net-worth lab: read-only Net Worth, pairs, and Account MWR from the equity Workbook)
 - **Cloud backend** — AWS Amplify Gen 2 (Cognito auth, Amplify Data, Storage, and Functions such as Bedrock-backed fit analysis)
 - **Engineering hygiene** — TypeScript throughout, Vitest, GitHub Actions CI, Amplify Hosting CD, domain language in `CONTEXT.md` / ADRs
 
@@ -49,7 +49,7 @@ npm run build
 | Doc | Purpose |
 |-----|---------|
 | [Wiki changelogs](https://github.com/hashadar/hashadar_website/wiki) | Product changelogs (Site + per Lab), ASD-STE100 |
-| [CONTEXT-MAP.md](CONTEXT-MAP.md) | Domain contexts (Site, Job OS) |
+| [CONTEXT-MAP.md](CONTEXT-MAP.md) | Domain contexts (Site, Job OS, WMW) |
 | [Codebase conventions](docs/CODEBASE-CONVENTIONS.md) | Imports, data layer, design system, Next.js |
 | [Branching](docs/BRANCHING.md) | `develop` / `main`, hotfixes, sync |
 | [CI and deployment](docs/CI-AND-DEPLOYMENT.md) | GitHub Actions + Amplify |

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,6 +1,6 @@
 # Branching and hotfixes
 
-Simple two-branch flow. Linear history via **squash-only** merges.
+Simple two-branch flow. Prefer **merge commits** (create a merge commit) when landing PRs.
 
 ## Branches
 
@@ -21,19 +21,19 @@ When `develop` looks good, open a PR **`develop` → `main`**. There is no inter
 
 1. Branch from `develop`.
 2. PR → `develop` (CI `quality` should pass).
-3. Squash-merge.
+3. Merge with a **merge commit** (preferred). Squash or rebase merges are allowed when a one-commit history is genuinely clearer; do not treat squash as the default.
 
 ### Promote to prod
 
 1. Open PR **`develop` → `main`**.
-2. Squash-merge.
+2. Merge with a **merge commit** (preferred).
 3. Amplify deploys from `main`.
-4. Sync workflow aligns `develop` to `main` (same tree after a full promote; see below).
+4. Sync workflow aligns `develop` to `main` when needed (see below).
 
 ### Hotfix
 
 1. Branch `hotfix/…` from **`main`**.
-2. PR → `main`, squash-merge, deploy.
+2. PR → `main`, merge (merge commit preferred), deploy.
 3. Sync brings the fix onto `develop`.
 
 Never land a prod hotfix on `develop` first.
@@ -42,7 +42,8 @@ Never land a prod hotfix on `develop` first.
 
 | Setting | Value | Why |
 |---------|--------|-----|
-| Squash merge only | On | Linear history |
+| Allow merge commits | **On** (preferred) | Keeps branch topology and PR context |
+| Allow squash / rebase merges | On (optional) | Available when useful; not the default workflow |
 | Delete head branches on merge | **Off** | Must stay off — a `develop` → `main` PR would otherwise delete long-lived `develop` |
 | Protect `main` | No delete, no force-push, PR required, CI `quality` required | Prod guardrail |
 | Protect `develop` | No delete, no force-push | Keeps the pre-prod branch alive |
@@ -53,12 +54,15 @@ After merging a **feature** PR, delete the feature branch yourself (GitHub UI �
 
 Workflow: `.github/workflows/sync-develop.yml` (on push to `main`, or manual dispatch).
 
-Squash merges rewrite history, so graphs diverge even when trees match. The job:
+After hotfixes on `main`, or when histories diverge, the job:
 
 1. If `develop` is missing → recreate from `main`.
-2. If trees match → reset `develop` to `main`.
-3. If `develop` has commits not yet on `main` → rebase onto `main`.
-4. If rebase conflicts → open a `ready-for-human` issue.
+2. If refs already match → no-op.
+3. If trees match but tips differ → reset `develop` to `main`.
+4. If `develop` has commits not yet on `main` → rebase onto `main`.
+5. If rebase conflicts → open a `ready-for-human` issue.
+
+With merge-commit promotes, `develop` and `main` often already share history after a full promote; the workflow still covers hotfix catch-up.
 
 After a sync locally:
 

--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -8,7 +8,7 @@
 | **Push to `main`** | GitHub Actions | Same quality suite **plus** `next build` as a cheap post-ship safety net. Still does not deploy. |
 | **Production build and deploy** | **AWS Amplify** autobuild | On push to connected branches: runs `amplify.yml` (conditional Gen 2 `ampx pipeline-deploy` or `ampx generate outputs`, reuse or `npm ci`, `npm run build`), publishes `.next`. **This is the only CD path** unless the team explicitly changes strategy. Prefer **`main` only** for Amplify autobuild. |
 
-There is **no** Actions CI on push to `develop` — that would duplicate the PR `quality` run after every squash-merge.
+There is **no** Actions CI on push to `develop` — that would duplicate the PR `quality` run after every merge to `develop`.
 
 ### Actions concurrency and path filters
 
@@ -63,8 +63,8 @@ If `nvm use 22` fails on the build image (version not installed), add a line bef
 ## Branching
 
 - Day-to-day integration branch: **`develop`**. Production: **`main`**.
-- Squash-only merges; hotfixes branch from `main`. Details: [BRANCHING.md](./BRANCHING.md).
-- After every push to `main`, `.github/workflows/sync-develop.yml` resets or rebases `develop` onto `main` (force-with-lease).
+- Prefer merge commits; hotfixes branch from `main`. Details: [BRANCHING.md](./BRANCHING.md).
+- After every push to `main`, `.github/workflows/sync-develop.yml` aligns `develop` with `main` when needed (reset or rebase; force-with-lease).
 
 ## Dependency updates
 
@@ -85,7 +85,7 @@ GitHub Actions builds without `amplify_outputs.json`. Public blog/portfolio read
 
 ## Branch protection (repository owner)
 
-Canonical settings live in [BRANCHING.md](./BRANCHING.md) (squash-only, **do not** enable delete-head-on-merge, slim rulesets for `main` / `develop`).
+Canonical settings live in [BRANCHING.md](./BRANCHING.md) (merge commits preferred, **do not** enable delete-head-on-merge, slim rulesets for `main` / `develop`).
 
 Minimum for CI:
 


### PR DESCRIPTION
## Summary
- Closes #193: README Labs bullet and CONTEXT-MAP docs blurb now name WMW alongside Job OS
- Simplifies `docs/BRANCHING.md` (and CI/sync comments) to prefer merge commits over squash-only defaults

## Test plan
- [ ] README Labs / Docs table read correctly for WMW
- [ ] BRANCHING.md matches preferred merge-commit workflow (`develop` / `main` / hotfixes)
- [ ] No product or Amplify behaviour changes