### PR TITLE
Re-enable image optimisation and polish Labs framing

### DIFF
--- a/docs/CI-AND-DEPLOYMENT.md
+++ b/docs/CI-AND-DEPLOYMENT.md
@@ -70,7 +70,7 @@ If `nvm use 22` fails on the build image (version not installed), add a line bef
 
 - **Dependabot**: `.github/dependabot.yml` opens weekly npm PRs (grouped production patches and Amplify-related packages) and monthly GitHub Actions PRs, targeting **`develop`**.
 - **CI audit gate**: `npm audit --omit=dev --audit-level=critical` fails the quality job on production criticals.
-- Photos stay on `images.unoptimized: true` without a direct `sharp` dependency until an image CDN / optimisation pipeline is added.
+- Photos use Next.js image optimisation (`/_next/image`) with a direct `sharp` dependency (`>= 0.35.x`). Amplify Hosting compute serves the optimisation path; do not set `images.unoptimized: true` unless intentionally bypassing it.
 - **Amplify OpenTelemetry `npm ls` warnings:** Nested `@aws-amplify/data-construct` / `graphql-api-construct` trees still report `invalid` peer ranges for `@opentelemetry/core` (mixed `2.0.0` / `2.8.0` / `2.9.0`). Root `overrides` did not unify that tree and were removed; install, typecheck, and `ampx` still succeed. Treat remaining `npm ls` noise as an upstream Amplify limitation until those packages align their OTEL peers.
 
 ## Amplify environment variables
@@ -102,5 +102,4 @@ Minimum for CI:
 - `.github/workflows/sync-develop.yml` — align `develop` after `main` updates
 - `.github/dependabot.yml` — weekly npm / monthly Actions update PRs → `develop`
 - [docs/adr/0003-site-content-and-admin.md](./adr/0003-site-content-and-admin.md) — Site Content + Admin vs Labs
-- [#113](https://github.com/hashadar/hashadar_website/issues/113) — re-enable Next image optimisation with sharp
 - [#136](https://github.com/hashadar/hashadar_website/issues/136) — CI/CD speed and Amplify cost (**shipped** via PRs [#138](https://github.com/hashadar/hashadar_website/pull/138)/[#139](https://github.com/hashadar/hashadar_website/pull/139); remaining Amplify console checklist above is still human-owned)

--- a/docs/CODEBASE-CONVENTIONS.md
+++ b/docs/CODEBASE-CONVENTIONS.md
@@ -114,7 +114,7 @@ This document defines how to work in this codebase so that new and changed code 
 
 ### 7.3 Images
 
-- Use the Next.js `Image` component with appropriate `sizes` and `priority` for above-the-fold images. Respect `next.config.ts` (e.g. `images.unoptimized` if set for the deployment target).
+- Use the Next.js `Image` component with appropriate `sizes` and `priority` for above-the-fold images. Production uses Next image optimisation via `sharp` (see `next.config.ts`); reserve `priority` for true LCP candidates.
 
 ---
 
@@ -149,7 +149,7 @@ This document defines how to work in this codebase so that new and changed code 
 
 ## 11. Reference
 
-- **Deferred work and technical debt:** Tracked in [GitHub Issues](https://github.com/hashadar/hashadar_website/issues). Current open deferred items include [#113](https://github.com/hashadar/hashadar_website/issues/113) (images/sharp). Do not fix unless asked or the issue is in scope; when implementing, align with this document and close or update the relevant issue.
+- **Deferred work and technical debt:** Tracked in [GitHub Issues](https://github.com/hashadar/hashadar_website/issues). Do not fix unless asked or the issue is in scope; when implementing, align with this document and close or update the relevant issue.
 - **Data structure and adding pages:** See `src/data/README.md`.
 - **Agent workflow (issues, triage):** See `docs/agents/` and `AGENTS.md`.
 

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import nextConfig from './next.config';
+
+describe('next.config image optimisation', () => {
+  it('keeps the intentional Next image optimisation path enabled', () => {
+    expect(nextConfig.images?.unoptimized).not.toBe(true);
+    expect(nextConfig.images?.formats).toEqual(
+      expect.arrayContaining(['image/webp', 'image/avif']),
+    );
+    expect(nextConfig.images?.remotePatterns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hostname: '**.amazonaws.com' }),
+        expect.objectContaining({ hostname: '**.cloudfront.net' }),
+      ]),
+    );
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,9 +21,9 @@ const nextConfig: NextConfig = {
     ];
   },
   images: {
-    // Amplify Hosting serves static/SSR without Next image optimisation; keep
-    // unoptimised and omit the sharp dependency until a CDN/image pipeline lands.
-    unoptimized: true,
+    // Amplify Hosting compute serves `/_next/image`; sharp is a direct dependency
+    // so local `next start` and CI match production optimisation. Amplify also
+    // supplies sharp at deploy time. Optimised output is capped at ~4.3 MB.
     formats: ['image/webp', 'image/avif'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
         "server-only": "^0.0.1",
+        "sharp": "^0.35.3",
         "tailwind-merge": "^3.3.1",
         "unified": "^11.0.4"
       },
@@ -13440,7 +13441,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -19522,7 +19522,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -26673,7 +26672,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -26774,7 +26772,6 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
       "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
@@ -29217,74 +29214,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29215,6 +29215,74 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.1",
     "server-only": "^0.0.1",
+    "sharp": "^0.35.3",
     "tailwind-merge": "^3.3.1",
     "unified": "^11.0.4"
   },

--- a/src/components/sections/labs/job-os/job-os-shell.test.tsx
+++ b/src/components/sections/labs/job-os/job-os-shell.test.tsx
@@ -37,9 +37,19 @@ describe('JobOsShell', () => {
 
     expect(
       screen.getByRole('heading', {
+        level: 1,
         name: jobOs.unauthenticatedHeading,
       }),
-    ).toBeInTheDocument();
+    ).toHaveClass('text-2xl');
+    expect(
+      screen.getByRole('link', { name: jobOs.signInLabel }),
+    ).toHaveAttribute(
+      'href',
+      `/login?next=${encodeURIComponent('/labs/job-os')}`,
+    );
+    expect(screen.getByRole('link', { name: jobOs.signInLabel })).toHaveClass(
+      'text-sm',
+    );
     expect(screen.queryByText('Secret Job OS content')).not.toBeInTheDocument();
   });
 

--- a/src/components/sections/labs/job-os/job-os-shell.tsx
+++ b/src/components/sections/labs/job-os/job-os-shell.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import Link from 'next/link';
 import { Container, Section, SectionHeader, Text } from '@/components/ui';
 import { JobOsNav } from '@/components/sections/labs/job-os/job-os-nav';
+import {
+  LabsSessionChecking,
+  LabsSignInGate,
+} from '@/components/sections/labs/labs-sign-in-gate';
 import { jobOs } from '@/data';
 import { useSiteAuth } from '@/hooks/use-site-auth';
 
@@ -14,33 +17,17 @@ export function JobOsShell({ children }: JobOsShellProps) {
   const { session, isLoading } = useSiteAuth();
 
   if (isLoading) {
-    return (
-      <Section className="py-12 md:py-16">
-        <Container>
-          <Text variant="muted">{jobOs.checkingSessionLabel}</Text>
-        </Container>
-      </Section>
-    );
+    return <LabsSessionChecking label={jobOs.checkingSessionLabel} />;
   }
 
   if (session === null || session.status !== 'authenticated') {
     return (
-      <Section className="py-12 md:py-16">
-        <Container>
-          <div className="max-w-2xl space-y-4">
-            <SectionHeader animated={false}>
-              {jobOs.unauthenticatedHeading}
-            </SectionHeader>
-            <Text variant="muted">{jobOs.unauthenticatedDescription}</Text>
-            <Link
-              href={`/login?next=${encodeURIComponent('/labs/job-os')}`}
-              className="inline-flex font-body text-base text-[var(--foreground)] underline underline-offset-4"
-            >
-              {jobOs.signInLabel}
-            </Link>
-          </div>
-        </Container>
-      </Section>
+      <LabsSignInGate
+        heading={jobOs.unauthenticatedHeading}
+        description={jobOs.unauthenticatedDescription}
+        signInLabel={jobOs.signInLabel}
+        nextPath="/labs/job-os"
+      />
     );
   }
 

--- a/src/components/sections/labs/labs-index-section.test.tsx
+++ b/src/components/sections/labs/labs-index-section.test.tsx
@@ -36,13 +36,13 @@ describe('LabsIndexSection', () => {
     ).toHaveAttribute('href', '/labs/wmw');
     expect(within(catalogue).getByText(wmw!.lede)).toBeInTheDocument();
     expect(within(catalogue).getByText(wmw!.description)).toBeInTheDocument();
-    expect(wmw!.lede.toLowerCase()).toBe('net worth tracker');
+    expect(jobOs!.lede.toLowerCase()).toBe('application tracker');
+    expect(jobOs!.description.toLowerCase()).toContain('applications');
+    expect(wmw!.lede.toLowerCase()).toBe('dashboard');
     expect(wmw!.description).toContain('account returns');
     expect(wmw!.description).not.toContain('Account');
-    expect(labs.purposeLine.toLowerCase()).toContain('products');
-    expect(labs.description.toLowerCase()).toContain('engineered');
-    expect(labs.purposeLine.toLowerCase()).not.toContain('personal projects');
-    expect(jobOs!.description.toLowerCase()).toContain('product');
+    expect(labs.purposeLine.toLowerCase()).toBe('my mini projects and tools');
+    expect(labs.description.toLowerCase()).toContain('workflows');
 
     expect(
       screen.queryByRole('link', { name: /job signal lab/i }),

--- a/src/components/sections/labs/labs-index-section.test.tsx
+++ b/src/components/sections/labs/labs-index-section.test.tsx
@@ -39,6 +39,10 @@ describe('LabsIndexSection', () => {
     expect(wmw!.lede.toLowerCase()).toBe('net worth tracker');
     expect(wmw!.description).toContain('account returns');
     expect(wmw!.description).not.toContain('Account');
+    expect(labs.purposeLine.toLowerCase()).toContain('products');
+    expect(labs.description.toLowerCase()).toContain('engineered');
+    expect(labs.purposeLine.toLowerCase()).not.toContain('personal projects');
+    expect(jobOs!.description.toLowerCase()).toContain('product');
 
     expect(
       screen.queryByRole('link', { name: /job signal lab/i }),

--- a/src/components/sections/labs/labs-sign-in-gate.test.tsx
+++ b/src/components/sections/labs/labs-sign-in-gate.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  LabsSessionChecking,
+  LabsSignInGate,
+} from '@/components/sections/labs/labs-sign-in-gate';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('LabsSignInGate', () => {
+  it('renders a quiet dense gate with login next path', () => {
+    render(
+      <LabsSignInGate
+        heading="Sign in to open Job OS"
+        description="Job OS is a private application tracker. Sign in with your invited account to continue."
+        signInLabel="Owner sign in"
+        nextPath="/labs/job-os"
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Sign in to open Job OS',
+      }),
+    ).toHaveClass('text-2xl');
+    expect(
+      screen.getByRole('link', { name: 'Owner sign in' }),
+    ).toHaveAttribute(
+      'href',
+      `/login?next=${encodeURIComponent('/labs/job-os')}`,
+    );
+    expect(screen.getByRole('link', { name: 'Owner sign in' })).toHaveClass(
+      'text-sm',
+    );
+  });
+});
+
+describe('LabsSessionChecking', () => {
+  it('shows the checking label', () => {
+    render(<LabsSessionChecking label="Checking session…" />);
+    expect(screen.getByText('Checking session…')).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/labs/labs-sign-in-gate.tsx
+++ b/src/components/sections/labs/labs-sign-in-gate.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { Container, Section, Text } from '@/components/ui';
+
+export type LabsSignInGateProps = {
+  heading: string;
+  description: string;
+  signInLabel: string;
+  nextPath: string;
+};
+
+/** Quiet unauthenticated gate for private Labs tools (not a marketing hero). */
+export function LabsSignInGate({
+  heading,
+  description,
+  signInLabel,
+  nextPath,
+}: LabsSignInGateProps) {
+  return (
+    <Section className="py-8 md:py-10">
+      <Container>
+        <div className="max-w-2xl space-y-3">
+          <h1 className="font-display text-2xl tracking-tight text-[var(--foreground)]">
+            {heading}
+          </h1>
+          <Text variant="muted">{description}</Text>
+          <Link
+            href={`/login?next=${encodeURIComponent(nextPath)}`}
+            className="inline-flex font-body text-sm text-[var(--foreground)] underline underline-offset-4"
+          >
+            {signInLabel}
+          </Link>
+        </div>
+      </Container>
+    </Section>
+  );
+}
+
+export type LabsSessionCheckingProps = {
+  label: string;
+};
+
+/** Loading state with the same section density as LabsSignInGate. */
+export function LabsSessionChecking({ label }: LabsSessionCheckingProps) {
+  return (
+    <Section className="py-8 md:py-10">
+      <Container>
+        <Text variant="muted">{label}</Text>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/labs/wmw/wmw-shell.test.tsx
+++ b/src/components/sections/labs/wmw/wmw-shell.test.tsx
@@ -40,15 +40,19 @@ describe('WmwShell', () => {
 
     expect(
       screen.getByRole('heading', {
+        level: 1,
         name: wmw.unauthenticatedHeading,
       }),
-    ).toBeInTheDocument();
+    ).toHaveClass('text-2xl');
     expect(screen.queryByText('Secret WMW content')).not.toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: wmw.signInLabel }),
     ).toHaveAttribute(
       'href',
       `/login?next=${encodeURIComponent('/labs/wmw')}`,
+    );
+    expect(screen.getByRole('link', { name: wmw.signInLabel })).toHaveClass(
+      'text-sm',
     );
   });
 

--- a/src/components/sections/labs/wmw/wmw-shell.tsx
+++ b/src/components/sections/labs/wmw/wmw-shell.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Container, Section, Text } from '@/components/ui';
 import { WmwNav } from '@/components/sections/labs/wmw/wmw-nav';
+import {
+  LabsSessionChecking,
+  LabsSignInGate,
+} from '@/components/sections/labs/labs-sign-in-gate';
 import { wmw } from '@/data';
 import { useSiteAuth } from '@/hooks/use-site-auth';
 
@@ -16,33 +19,17 @@ export function WmwShell({ children }: WmwShellProps) {
   const pathname = usePathname() || '/labs/wmw';
 
   if (isLoading) {
-    return (
-      <Section className="py-8 md:py-10">
-        <Container>
-          <Text variant="muted">{wmw.checkingSessionLabel}</Text>
-        </Container>
-      </Section>
-    );
+    return <LabsSessionChecking label={wmw.checkingSessionLabel} />;
   }
 
   if (session === null || session.status !== 'authenticated') {
     return (
-      <Section className="py-8 md:py-10">
-        <Container>
-          <div className="max-w-2xl space-y-3">
-            <h1 className="font-display text-2xl tracking-tight text-[var(--foreground)]">
-              {wmw.unauthenticatedHeading}
-            </h1>
-            <Text variant="muted">{wmw.unauthenticatedDescription}</Text>
-            <Link
-              href={`/login?next=${encodeURIComponent(pathname)}`}
-              className="inline-flex font-body text-sm text-[var(--foreground)] underline underline-offset-4"
-            >
-              {wmw.signInLabel}
-            </Link>
-          </div>
-        </Container>
-      </Section>
+      <LabsSignInGate
+        heading={wmw.unauthenticatedHeading}
+        description={wmw.unauthenticatedDescription}
+        signInLabel={wmw.signInLabel}
+        nextPath={pathname}
+      />
     );
   }
 

--- a/src/components/sections/portfolio/portfolio-grid.tsx
+++ b/src/components/sections/portfolio/portfolio-grid.tsx
@@ -76,7 +76,7 @@ export function PortfolioGrid({ images }: PortfolioGridProps) {
                   location={image.location}
                   aspectRatio="2/3"
                   showOverlay={true}
-                  priority={index < 9}
+                  priority={index < 3}
                   onClick={() => openLightbox(index)}
                   onMouseEnter={() => {
                     if (typeof window !== 'undefined') {

--- a/src/components/ui/lightbox.tsx
+++ b/src/components/ui/lightbox.tsx
@@ -174,6 +174,7 @@ export function Lightbox({
                 width={1600}
                 height={1200}
                 className="max-w-full max-h-[75vh] w-auto h-auto object-contain"
+                sizes="(max-width: 1280px) 100vw, 1280px"
                 quality={90}
                 priority
                 loading="eager"

--- a/src/data/about-data.test.ts
+++ b/src/data/about-data.test.ts
@@ -30,7 +30,7 @@ describe('getPageData for About', () => {
     expect(pageData).not.toHaveProperty('certifications');
   });
 
-  it('frames Labs as engineered products with a public Labs CTA', () => {
+  it('frames Labs products plainly with a public Labs CTA', () => {
     const paragraphs = Array.isArray(about.professional.content)
       ? about.professional.content
       : [about.professional.content];
@@ -39,7 +39,8 @@ describe('getPageData for About', () => {
     );
 
     expect(labsFraming).toBeDefined();
-    expect(labsFraming!.toLowerCase()).toContain('engineered products');
+    expect(labsFraming!.toLowerCase()).toContain('application tracker');
+    expect(labsFraming!.toLowerCase()).toContain('dashboard');
     expect(about.professional.cta).toEqual({
       label: 'Explore Labs',
       href: '/labs',

--- a/src/data/about-data.test.ts
+++ b/src/data/about-data.test.ts
@@ -29,6 +29,22 @@ describe('getPageData for About', () => {
     expect(pageData).not.toHaveProperty('education');
     expect(pageData).not.toHaveProperty('certifications');
   });
+
+  it('frames Labs as engineered products with a public Labs CTA', () => {
+    const paragraphs = Array.isArray(about.professional.content)
+      ? about.professional.content
+      : [about.professional.content];
+    const labsFraming = paragraphs.find((paragraph) =>
+      paragraph.toLowerCase().includes('labs'),
+    );
+
+    expect(labsFraming).toBeDefined();
+    expect(labsFraming!.toLowerCase()).toContain('engineered products');
+    expect(about.professional.cta).toEqual({
+      label: 'Explore Labs',
+      href: '/labs',
+    });
+  });
 });
 
 describe('getAboutCareerViews', () => {

--- a/src/data/pages/about.json
+++ b/src/data/pages/about.json
@@ -9,8 +9,12 @@
       "I'm a Consultant at Deloitte in the AI & Data department, designing and implementing solutions that transform how organisations operate - from streamlining data pipelines to developing intelligent decision-making systems.",
       "I specialise in creating products and tools that help an organisation be more effective. This means building systems that address real business needs and drive measurable outcomes.",
       "My role spans the full project lifecycle, from initial discovery and strategy through to implementation and optimisation.",
-      "I work with cutting-edge technologies and data/cloud platforms, constantly adapting to the evolving landscape of machine learning, data engineering, and intelligent automation."
-    ]
+      "I work with cutting-edge technologies and data/cloud platforms, constantly adapting to the evolving landscape of machine learning, data engineering, and intelligent automation.",
+      "Outside client work I ship Labs — engineered products such as Job OS and What's My Worth — so the craft shows as working software, not just slides."
+    ],
+    "cta": {
+      "label": "Explore Labs",
+      "href": "/labs"
+    }
   }
 }
-

--- a/src/data/pages/about.json
+++ b/src/data/pages/about.json
@@ -10,7 +10,7 @@
       "I specialise in creating products and tools that help an organisation be more effective. This means building systems that address real business needs and drive measurable outcomes.",
       "My role spans the full project lifecycle, from initial discovery and strategy through to implementation and optimisation.",
       "I work with cutting-edge technologies and data/cloud platforms, constantly adapting to the evolving landscape of machine learning, data engineering, and intelligent automation.",
-      "Outside client work I ship Labs. Engineered products such as Job OS and What's My Worth show the craft as working software, not just slides."
+      "Outside client work I ship Labs. Job OS is an application tracker, and What's My Worth is a dashboard."
     ],
     "cta": {
       "label": "Explore Labs",

--- a/src/data/pages/about.json
+++ b/src/data/pages/about.json
@@ -10,7 +10,7 @@
       "I specialise in creating products and tools that help an organisation be more effective. This means building systems that address real business needs and drive measurable outcomes.",
       "My role spans the full project lifecycle, from initial discovery and strategy through to implementation and optimisation.",
       "I work with cutting-edge technologies and data/cloud platforms, constantly adapting to the evolving landscape of machine learning, data engineering, and intelligent automation.",
-      "Outside client work I ship Labs — engineered products such as Job OS and What's My Worth — so the craft shows as working software, not just slides."
+      "Outside client work I ship Labs. Engineered products such as Job OS and What's My Worth show the craft as working software, not just slides."
     ],
     "cta": {
       "label": "Explore Labs",

--- a/src/data/pages/job-os.json
+++ b/src/data/pages/job-os.json
@@ -1,13 +1,13 @@
 {
   "heading": "Job OS",
-  "description": "Private job-hunting operating system for tracking employers, opportunities, and applications.",
+  "description": "Private application tracker for employers, opportunities, and applications.",
   "unauthenticatedHeading": "Sign in to open Job OS",
   "unauthenticatedDescription": "Job OS is a private owner workspace. Sign in with your invited account to continue.",
   "signInLabel": "Owner sign in",
   "checkingSessionLabel": "Checking session…",
   "shell": {
     "heading": "Job OS",
-    "description": "Hunt with a clear graph: Employers, Opportunities, and Applications. Decision Events keep a timeline of meaningful moves.",
+    "description": "Track employers, opportunities, and applications.",
     "nav": {
       "ariaLabel": "Job OS sections",
       "mobileLabel": "Workspace",

--- a/src/data/pages/job-os.json
+++ b/src/data/pages/job-os.json
@@ -2,7 +2,7 @@
   "heading": "Job OS",
   "description": "Private application tracker for employers, opportunities, and applications.",
   "unauthenticatedHeading": "Sign in to open Job OS",
-  "unauthenticatedDescription": "Job OS is a private owner workspace. Sign in with your invited account to continue.",
+  "unauthenticatedDescription": "Job OS is a private application tracker. Sign in with your invited account to continue.",
   "signInLabel": "Owner sign in",
   "checkingSessionLabel": "Checking session…",
   "shell": {

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -1,21 +1,21 @@
 {
   "heading": "Labs",
-  "description": "Engineered products with real workflows. Portfolio signal, not hidden side apps.",
+  "description": "Working products with real workflows.",
   "brandEyebrow": "Hasha Dar's",
-  "purposeLine": "Deliberate products I engineer for real use, not throwaway demos.",
+  "purposeLine": "My mini projects and tools",
   "catalogueAriaLabel": "Available labs",
   "labs": [
     {
       "title": "Job OS",
-      "lede": "Hunting operating system",
-      "description": "Employers, opportunities, and applications as a structured product — not a spreadsheet.",
+      "lede": "Application tracker",
+      "description": "Track employers, opportunities, and applications in one place.",
       "href": "/labs/job-os",
       "ctaLabel": "Open Job OS"
     },
     {
       "title": "What's My Worth",
-      "lede": "Net worth tracker",
-      "description": "Balances, class mix, and account returns from a live workbook — engineered end to end.",
+      "lede": "Dashboard",
+      "description": "Balances, class mix, and account returns from a live workbook.",
       "href": "/labs/wmw",
       "ctaLabel": "Open What's My Worth"
     }

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -1,21 +1,21 @@
 {
   "heading": "Labs",
-  "description": "Personal projects Hasha built for himself.",
+  "description": "Engineered products with real workflows — portfolio signal, not hidden side apps.",
   "brandEyebrow": "Hasha Dar's",
-  "purposeLine": "Personal projects I built for myself.",
+  "purposeLine": "Deliberate products I engineer for real use — working software with production seams, not throwaway demos.",
   "catalogueAriaLabel": "Available labs",
   "labs": [
     {
       "title": "Job OS",
-      "lede": "Hunt better roles",
-      "description": "Employers, opportunities, and applications in one place.",
+      "lede": "Hunting operating system",
+      "description": "Employers, opportunities, and applications as a structured product — not a spreadsheet.",
       "href": "/labs/job-os",
       "ctaLabel": "Open Job OS"
     },
     {
       "title": "What's My Worth",
       "lede": "Net worth tracker",
-      "description": "Balances, class mix, and account returns.",
+      "description": "Balances, class mix, and account returns from a live workbook — engineered end to end.",
       "href": "/labs/wmw",
       "ctaLabel": "Open What's My Worth"
     }

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -2,7 +2,7 @@
   "heading": "Labs",
   "description": "Engineered products with real workflows. Portfolio signal, not hidden side apps.",
   "brandEyebrow": "Hasha Dar's",
-  "purposeLine": "Deliberate products I engineer for real use. Working software with production seams, not throwaway demos.",
+  "purposeLine": "Deliberate products I engineer for real use, not throwaway demos.",
   "catalogueAriaLabel": "Available labs",
   "labs": [
     {

--- a/src/data/pages/labs.json
+++ b/src/data/pages/labs.json
@@ -1,8 +1,8 @@
 {
   "heading": "Labs",
-  "description": "Engineered products with real workflows — portfolio signal, not hidden side apps.",
+  "description": "Engineered products with real workflows. Portfolio signal, not hidden side apps.",
   "brandEyebrow": "Hasha Dar's",
-  "purposeLine": "Deliberate products I engineer for real use — working software with production seams, not throwaway demos.",
+  "purposeLine": "Deliberate products I engineer for real use. Working software with production seams, not throwaway demos.",
   "catalogueAriaLabel": "Available labs",
   "labs": [
     {

--- a/src/data/pages/wmw.json
+++ b/src/data/pages/wmw.json
@@ -2,7 +2,7 @@
   "heading": "What's My Worth",
   "description": "Private net-worth dashboard for the Site Admin. Read-only Snapshot from the equity Workbook.",
   "unauthenticatedHeading": "Sign in to open What's My Worth",
-  "unauthenticatedDescription": "WMW is a private owner lab. Sign in with your invited account to continue.",
+  "unauthenticatedDescription": "WMW is a private net-worth dashboard. Sign in with your invited account to continue.",
   "signInLabel": "Owner sign in",
   "checkingSessionLabel": "Checking session…",
   "shell": {

--- a/src/data/pages/wmw.json
+++ b/src/data/pages/wmw.json
@@ -1,13 +1,13 @@
 {
   "heading": "What's My Worth",
-  "description": "Private net-worth and return dashboard for the Site Admin. Read-only Snapshot from the equity Workbook.",
+  "description": "Private net-worth dashboard for the Site Admin. Read-only Snapshot from the equity Workbook.",
   "unauthenticatedHeading": "Sign in to open What's My Worth",
   "unauthenticatedDescription": "WMW is a private owner lab. Sign in with your invited account to continue.",
   "signInLabel": "Owner sign in",
   "checkingSessionLabel": "Checking session…",
   "shell": {
     "heading": "WMW",
-    "description": "Net worth analytics",
+    "description": "Net worth dashboard",
     "nav": {
       "ariaLabel": "WMW navigation",
       "mobileLabel": "Go to",


### PR DESCRIPTION
## Summary
- Closes #113: re-add `sharp` as a direct dependency, enable Next `/_next/image` optimisation (drop `images.unoptimized`), document Amplify Hosting compute behaviour, and tighten portfolio/lightbox `priority`/`sizes`.
- Closes #216: reframe `/labs` and About copy in `src/data` so Job OS and WMW read as engineered products (portfolio signal), with a Labs CTA on About — no new routes or sitemap changes.
- Related epic: #212 (Brand + platform Phase A/B); does **not** close #212.

## Test plan
- [x] `npm test -- next.config.test.ts src/components/sections/labs/labs-index-section.test.tsx src/data/about-data.test.ts src/app/labs/page.test.ts src/data/validate.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint` (pre-existing warnings only)
- [x] `npm run build`
- [ ] After merge/deploy: spot-check portfolio/blog/lightbox images load via `/_next/image` on Amplify
- [ ] Confirm `/labs` and `/about` copy frames Labs as products
