### PR TITLE
Fix Opportunity Body not persisting on save

### DIFF
--- a/src/components/sections/labs/job-os/job-os-opportunities-workspace.test.tsx
+++ b/src/components/sections/labs/job-os/job-os-opportunities-workspace.test.tsx
@@ -1,0 +1,154 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JobOsOpportunitiesWorkspace } from '@/components/sections/labs/job-os/job-os-opportunities-workspace';
+import { jobOs } from '@/data';
+import {
+  createJobOs,
+  createMemoryJobOsBodyStorage,
+  createMemoryJobOsStore,
+  type JobOs,
+} from '@/lib/job-os';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+const ORIGINAL_BODY = 'Original listing prose.';
+const UPDATED_BODY = 'Updated listing prose.';
+
+function createClient(): JobOs {
+  return createJobOs({
+    store: createMemoryJobOsStore(),
+    bodies: createMemoryJobOsBodyStorage(),
+    now: () => '2026-08-13T10:00:00.000Z',
+    createId: (() => {
+      let n = 0;
+      return () => `opp-${++n}`;
+    })(),
+  });
+}
+
+async function seedOpportunity(client: JobOs, body = ORIGINAL_BODY) {
+  const employer = await client.createEmployer({
+    name: 'Acme Analytics',
+    sizeTier: 'scaleup',
+    prestigeTier: 'mid',
+    sector: 'technology',
+  });
+  expect(employer.status).toBe('created');
+  if (employer.status !== 'created') {
+    throw new Error('expected employer');
+  }
+
+  const created = await client.createOpportunity({
+    employerId: employer.employer.id,
+    noticedAt: '2026-07-20T09:00:00.000Z',
+    title: 'Staff data scientist',
+  });
+  expect(created.status).toBe('created');
+  if (created.status !== 'created') {
+    throw new Error('expected opportunity');
+  }
+
+  const written = await client.updateOpportunityBody(
+    created.opportunity.id,
+    body,
+  );
+  expect(written.status).toBe('updated');
+
+  return created.opportunity.id;
+}
+
+async function editBodyAndSave(updated = UPDATED_BODY) {
+  const user = userEvent.setup();
+  await user.click(
+    await screen.findByRole('button', {
+      name: jobOs.opportunities.editBodyLabel,
+    }),
+  );
+  const textarea = screen.getByPlaceholderText(jobOs.opportunities.noBodyLabel);
+  await user.clear(textarea);
+  await user.click(textarea);
+  await user.paste(updated);
+  await user.click(
+    screen.getByRole('button', { name: jobOs.opportunities.saveLabel }),
+  );
+  expect(
+    await screen.findByText(jobOs.opportunities.savedLabel),
+  ).toBeInTheDocument();
+}
+
+describe('JobOsOpportunitiesWorkspace', () => {
+  it('persists an edited Opportunity Body so a reload shows the new text', async () => {
+    const client = createClient();
+    const opportunityId = await seedOpportunity(client);
+
+    const { unmount } = render(
+      <JobOsOpportunitiesWorkspace
+        jobOsClient={client}
+        selectedId={opportunityId}
+      />,
+    );
+
+    expect(await screen.findByText(ORIGINAL_BODY)).toBeInTheDocument();
+    await editBodyAndSave();
+    unmount();
+
+    render(
+      <JobOsOpportunitiesWorkspace
+        jobOsClient={client}
+        selectedId={opportunityId}
+      />,
+    );
+
+    expect(await screen.findByText(UPDATED_BODY)).toBeInTheDocument();
+    expect(screen.queryByText(ORIGINAL_BODY)).not.toBeInTheDocument();
+  });
+
+  it('does not revert a saved Body when the ledger refresh reads stale prose', async () => {
+    const inner = createClient();
+    const opportunityId = await seedOpportunity(inner);
+    const client = new Proxy(inner, {
+      get(target, prop, receiver) {
+        if (prop === 'getOpportunityBody') {
+          return async (id: string) => {
+            const result = await target.getOpportunityBody(id);
+            if (result.status !== 'ok') {
+              return result;
+            }
+            return { ...result, body: ORIGINAL_BODY };
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+
+    render(
+      <JobOsOpportunitiesWorkspace
+        jobOsClient={client}
+        selectedId={opportunityId}
+      />,
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Staff data scientist' }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(ORIGINAL_BODY)).toBeInTheDocument();
+    await editBodyAndSave();
+
+    expect(screen.getByText(UPDATED_BODY)).toBeInTheDocument();
+    expect(screen.queryByText(ORIGINAL_BODY)).not.toBeInTheDocument();
+
+    const stored = await inner.getOpportunityBody(opportunityId);
+    expect(stored.status).toBe('ok');
+    if (stored.status !== 'ok') {
+      return;
+    }
+    expect(stored.body).toBe(UPDATED_BODY);
+  });
+});

--- a/src/components/sections/labs/job-os/job-os-opportunities-workspace.tsx
+++ b/src/components/sections/labs/job-os/job-os-opportunities-workspace.tsx
@@ -243,7 +243,7 @@ export function JobOsOpportunitiesWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [client, selectedId, opportunities]);
+  }, [client, selectedId]);
 
   async function refreshFitSurfaces(active: JobOs, opportunityId: string) {
     const [checklistResult, insightResult] = await Promise.all([

--- a/src/lib/job-os.test.ts
+++ b/src/lib/job-os.test.ts
@@ -286,6 +286,58 @@ describe('Job OS facade — Opportunities', () => {
     expect(updated.opportunity.title).toBe('Staff ML Engineer');
   });
 
+  it('persists an edited Opportunity Body across reload and keeps it after a field update', async () => {
+    const { jobOs } = createTestJobOs();
+    const anon = await jobOs.ensureAnonEmployer();
+    const created = await jobOs.createOpportunity({
+      employerId: anon.id,
+      noticedAt: '2026-07-20T09:00:00.000Z',
+      title: 'Staff Data Scientist',
+    });
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      return;
+    }
+
+    const written = await jobOs.updateOpportunityBody(
+      created.opportunity.id,
+      'Original listing prose.',
+    );
+    expect(written.status).toBe('updated');
+
+    const edited = await jobOs.updateOpportunityBody(
+      created.opportunity.id,
+      'Updated listing prose.',
+    );
+    expect(edited.status).toBe('updated');
+    if (edited.status !== 'updated') {
+      return;
+    }
+
+    const reloaded = await jobOs.getOpportunityBody(created.opportunity.id);
+    expect(reloaded.status).toBe('ok');
+    if (reloaded.status !== 'ok') {
+      return;
+    }
+    expect(reloaded.body).toBe('Updated listing prose.');
+
+    const renamed = await jobOs.updateOpportunity({
+      id: created.opportunity.id,
+      employerId: anon.id,
+      title: 'Principal Data Scientist',
+      status: 'open',
+    });
+    expect(renamed.status).toBe('updated');
+
+    const afterFields = await jobOs.getOpportunityBody(created.opportunity.id);
+    expect(afterFields.status).toBe('ok');
+    if (afterFields.status !== 'ok') {
+      return;
+    }
+    expect(afterFields.body).toBe('Updated listing prose.');
+    expect(afterFields.opportunity.title).toBe('Principal Data Scientist');
+  });
+
   it('rejects Opportunity Body update when body storage fails', async () => {
     const store = createMemoryJobOsStore();
     const bodies = createMemoryJobOsBodyStorage();


### PR DESCRIPTION
## Summary
- Closes #220: saving an edited Opportunity Body no longer gets overwritten when the ledger list refreshes.
- The detail screen was reloading Body whenever `opportunities` changed, so a stale Storage read after Save could restore the previous prose.
- Adds workspace and facade coverage for edit → save → reload, and for keeping the saved Body when the next read is stale.

## Test plan
- [x] `npm test -- src/lib/job-os.test.ts src/components/sections/labs/job-os/job-os-opportunities-workspace.test.tsx`
- [ ] Sign in → open an existing Opportunity with Body → Edit → change the prose → Save opportunity → reload → new Body is shown
- [ ] Confirm title/source/status still save in the same action

Made with [Cursor](https://cursor.com)