### PR TITLE
Motion revamp Phase 4–5: Wire marketing consumers + card polish

### DIFF
--- a/src/components/sections/about/about-hero-section.test.tsx
+++ b/src/components/sections/about/about-hero-section.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AboutHeroSection } from '@/components/sections/about/about-hero-section';
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  mockPrefersReducedMotion(false);
+});
+
+describe('AboutHeroSection', () => {
+  it('uses an elevated DOM entrance without a canvas', () => {
+    mockPrefersReducedMotion(false);
+    const { container } = render(
+      <AboutHeroSection name="Hasha Dar" title="AI & Data Consultant" />,
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Hasha Dar' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'AI & Data Consultant' }),
+    ).toBeInTheDocument();
+    expect(container.querySelector('canvas')).toBeNull();
+  });
+
+  it('shows name and title immediately when reduced motion is preferred', () => {
+    mockPrefersReducedMotion(true);
+    render(<AboutHeroSection name="Hasha Dar" title="AI & Data Consultant" />);
+
+    expect(screen.getByRole('heading', { name: 'Hasha Dar' })).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'AI & Data Consultant' })).toBeVisible();
+  });
+});

--- a/src/components/sections/about/about-hero-section.tsx
+++ b/src/components/sections/about/about-hero-section.tsx
@@ -9,23 +9,23 @@ interface AboutHeroSectionProps {
 
 export function AboutHeroSection({ name, title }: AboutHeroSectionProps) {
   return (
-    <Section className="relative overflow-hidden pt-28 md:pt-36 pb-20">
+    <Section className="relative overflow-hidden pt-28 pb-20 md:pt-36">
       <SectionBackground variant="marketing" />
 
       <Container>
-        <div className="max-w-4xl mx-auto text-center space-y-8">
-          <MotionReveal variant="fade-up" distance="md" inView={false}>
-            <Heading size="xl" className="text-[var(--foreground)] mb-4">
+        <div className="mx-auto max-w-4xl space-y-8 text-center">
+          <MotionReveal variant="clip-up" distance="md" inView={false}>
+            <Heading size="xl" className="mb-4 text-[var(--foreground)]">
               {name}
             </Heading>
           </MotionReveal>
 
-          <MotionReveal variant="fade-up" distance="sm" delay={0.2} inView={false} className="relative">
-            <div className="absolute left-1/2 -translate-x-1/2 -top-4 w-16 h-px bg-[var(--primary)] transform -skew-x-12 opacity-40" />
-            <Heading size="sm" as="h2" className="text-[var(--primary)] tracking-[0.25em] capitalize relative">
+          <MotionReveal variant="fade-up" distance="sm" delay={0.15} inView={false} className="relative">
+            <div className="absolute -top-4 left-1/2 h-px w-16 -translate-x-1/2 -skew-x-12 transform bg-[var(--primary)] opacity-40" />
+            <Heading size="sm" as="h2" className="relative capitalize tracking-[0.25em] text-[var(--primary)]">
               {title}
             </Heading>
-            <div className="absolute left-1/2 -translate-x-1/2 -bottom-4 w-12 h-px bg-[var(--primary)] transform skew-x-12 opacity-30" />
+            <div className="absolute -bottom-4 left-1/2 h-px w-12 -translate-x-1/2 skew-x-12 transform bg-[var(--primary)] opacity-30" />
           </MotionReveal>
         </div>
       </Container>

--- a/src/components/sections/about/about-professional-section.tsx
+++ b/src/components/sections/about/about-professional-section.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-import { ProseSection, type ProseSectionProps } from "@/components/sections/shared/prose-section";
-
-export type AboutProfessionalSectionProps = Omit<ProseSectionProps, "cta" | "id">;
-
-export function AboutProfessionalSection(props: AboutProfessionalSectionProps) {
-  return <ProseSection {...props} />;
-}

--- a/src/components/sections/blog/blog-grid.tsx
+++ b/src/components/sections/blog/blog-grid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { SectionHeader, Container, Section, BlogCard, MotionReveal } from "@/components/ui";
+import { SectionHeader, Container, Section, BlogCard, MotionReveal, MotionRevealGroup, SectionBackground, Text } from "@/components/ui";
 import { blog } from "@/data";
 import type { BlogPost } from "@/data/types";
 
@@ -56,17 +56,18 @@ export function BlogGrid({ posts }: BlogGridProps) {
   }, [posts, selectedCategory, sortOption]);
 
   return (
-    <Section className="py-20">
+    <Section className="relative overflow-hidden py-20">
+      <SectionBackground variant="marketing" />
+
       <Container>
-        {/* Header */}
         <div className="mb-16 space-y-4">
           <SectionHeader animated={false}>
             {blog.heading}
           </SectionHeader>
-          
-          <p className="text-[var(--foreground)] text-lg max-w-2xl">
+
+          <Text size="lg" className="max-w-2xl text-[var(--foreground)]">
             {blog.description}
-          </p>
+          </Text>
         </div>
 
         {/* Filters and Sort */}
@@ -127,14 +128,12 @@ export function BlogGrid({ posts }: BlogGridProps) {
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <MotionRevealGroup className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {filteredAndSortedPosts.map((post, index) => (
               <MotionReveal
                 key={post.slug}
                 variant="fade-up"
                 distance="sm"
-                delay={index * 0.05}
-                inView={false}
               >
                 <BlogCard
                   slug={post.slug}
@@ -148,7 +147,7 @@ export function BlogGrid({ posts }: BlogGridProps) {
                 />
               </MotionReveal>
             ))}
-          </div>
+          </MotionRevealGroup>
         )}
       </Container>
     </Section>

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -7,6 +7,7 @@ import {
   FooterColumn,
   GitHubIcon,
   LinkedInIcon,
+  MotionRevealGroup,
   NavLink,
   SocialLink,
   Text,
@@ -31,8 +32,8 @@ export function FooterSection() {
 
       <Container>
         <div className="py-20 space-y-16">
-          <div className="grid md:grid-cols-3 gap-12 md:gap-16">
-            <FooterColumn title={heading} delay={0}>
+          <MotionRevealGroup className="grid gap-12 md:grid-cols-3 md:gap-16">
+            <FooterColumn title={heading}>
               <Text className="leading-relaxed text-[var(--foreground)]">
                 {description}
               </Text>
@@ -46,7 +47,7 @@ export function FooterSection() {
               </div>
             </FooterColumn>
 
-            <FooterColumn title={navigationTitle} delay={0.2}>
+            <FooterColumn title={navigationTitle}>
               <nav className="space-y-3 relative z-10">
                 {navigation.links.map((link) => (
                   <NavLink key={link.href} href={link.href}>
@@ -56,7 +57,7 @@ export function FooterSection() {
               </nav>
             </FooterColumn>
 
-            <FooterColumn title={socialTitle} delay={0.4}>
+            <FooterColumn title={socialTitle}>
               <div className="flex gap-4 relative z-10">
                 <SocialLink
                   href={social.linkedin}
@@ -70,7 +71,7 @@ export function FooterSection() {
                 />
               </div>
             </FooterColumn>
-          </div>
+          </MotionRevealGroup>
 
           <FooterBrand brandName={site.brandName} copyright={copyright} />
         </div>

--- a/src/components/sections/homepage/about-section.tsx
+++ b/src/components/sections/homepage/about-section.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-import { ProseSection, type ProseSectionProps } from "@/components/sections/shared/prose-section";
-
-export type AboutSectionProps = ProseSectionProps;
-
-export function AboutSection(props: AboutSectionProps) {
-  return <ProseSection id="about" {...props} />;
-}

--- a/src/components/sections/homepage/blog-section.tsx
+++ b/src/components/sections/homepage/blog-section.tsx
@@ -46,11 +46,11 @@ export function BlogSection({
           </SectionHeader>
 
           {description && (
-            <div className="max-w-2xl mx-auto text-center">
+            <MotionReveal variant="fade" className="mx-auto max-w-2xl text-center">
               <Text size="lg" className="text-[var(--foreground)]/80">
                 {description}
               </Text>
-            </div>
+            </MotionReveal>
           )}
 
           {posts.length > 0 ? (
@@ -86,8 +86,7 @@ export function BlogSection({
             <MotionReveal
               variant="fade-up"
               distance="sm"
-              delay={0.4}
-              className="flex justify-center pt-8 relative z-10"
+              className="relative z-10 flex justify-center pt-8"
             >
               <Button href={cta.href} variant="primary" size="md">
                 {cta.label}

--- a/src/components/sections/homepage/photography-section.test.tsx
+++ b/src/components/sections/homepage/photography-section.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PhotographySection } from '@/components/sections/homepage/photography-section';
+
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} />
+  ),
+}));
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  mockPrefersReducedMotion(false);
+});
+
+describe('PhotographySection', () => {
+  it('keeps a minimal atmosphere and still shows the photo when reduced motion is preferred', () => {
+    mockPrefersReducedMotion(true);
+
+    const { container } = render(
+      <PhotographySection
+        heading="Photography"
+        description="Travel and portrait work."
+        images={[
+          {
+            src: '/photos/teaser.webp',
+            alt: 'Teaser portrait',
+            title: 'Teaser',
+            category: 'Portrait',
+            location: 'London',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Photography' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Teaser portrait' })).toBeVisible();
+    expect(container.querySelector('.geometric-pattern')).toBeNull();
+  });
+});

--- a/src/components/sections/homepage/photography-section.tsx
+++ b/src/components/sections/homepage/photography-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SectionHeader, Text, Container, Section, SectionBackground, PhotoCard, Lightbox, Button } from "@/components/ui";
+import { SectionHeader, Text, Container, Section, SectionBackground, PhotoCard, Lightbox, Button, MotionReveal } from "@/components/ui";
 import { useState } from "react";
 
 interface PhotoItem {
@@ -34,24 +34,21 @@ export function PhotographySection({ heading, description, images }: Photography
 
       <Container>
         <div className="space-y-12 md:space-y-16">
-          {/* Header */}
           <SectionHeader animated={false} showBottomAccent>
             {heading}
           </SectionHeader>
 
-          {/* Description */}
           {description && (
-            <div className="max-w-2xl mx-auto text-center">
+            <MotionReveal variant="fade" className="mx-auto max-w-2xl text-center">
               <Text size="lg" className="text-[var(--foreground)]/80">
                 {description}
               </Text>
-            </div>
+            </MotionReveal>
           )}
 
-          {/* Single Image Display */}
           {images.length > 0 && (
-            <div className="flex justify-center">
-              <div className="max-w-4xl w-full">
+            <MotionReveal variant="fade" className="flex justify-center">
+              <div className="w-full max-w-4xl">
                 <PhotoCard
                   src={images[0].src}
                   alt={images[0].alt}
@@ -67,19 +64,17 @@ export function PhotographySection({ heading, description, images }: Photography
                   onClick={openLightbox}
                 />
               </div>
-            </div>
+            </MotionReveal>
           )}
 
-          {/* Button */}
-          <div className="flex justify-center pt-8 relative z-10">
+          <MotionReveal variant="fade-up" distance="sm" className="relative z-10 flex justify-center pt-8">
             <Button href="/portfolio" variant="primary" size="md">
               View Full Portfolio
             </Button>
-          </div>
+          </MotionReveal>
         </div>
       </Container>
 
-      {/* Lightbox */}
       <Lightbox
         isOpen={lightboxOpen}
         images={images}

--- a/src/components/sections/marketing-motion.test.ts
+++ b/src/components/sections/marketing-motion.test.ts
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const webglImport = /hero-webgl|@react-three|from ['"]three['"]/;
+
+function readSrc(pathFromRepo: string) {
+  return readFileSync(join(repoRoot, pathFromRepo), 'utf8');
+}
+
+function walkTsx(dirFromRepo: string): string[] {
+  const abs = join(repoRoot, dirFromRepo);
+  return readdirSync(abs).flatMap((entry) => {
+    const next = join(dirFromRepo, entry);
+    const absNext = join(repoRoot, next);
+    if (statSync(absNext).isDirectory()) {
+      return walkTsx(next);
+    }
+    if (next.endsWith('.tsx') || next.endsWith('.ts')) {
+      return [next.split('\\').join('/')];
+    }
+    return [];
+  });
+}
+
+describe('marketing motion wiring', () => {
+  it('staggers home blog, portfolio, and blog index grids', () => {
+    const grids = [
+      'src/components/sections/homepage/blog-section.tsx',
+      'src/components/sections/portfolio/portfolio-grid.tsx',
+      'src/components/sections/blog/blog-grid.tsx',
+    ];
+
+    for (const file of grids) {
+      expect(readSrc(file), file).toContain('MotionRevealGroup');
+    }
+  });
+
+  it('keeps photography atmosphere quiet so imagery leads', () => {
+    expect(readSrc('src/components/sections/homepage/photography-section.tsx')).toContain(
+      'variant="photography"',
+    );
+    expect(readSrc('src/components/sections/portfolio/portfolio-grid.tsx')).toContain(
+      'variant="photography"',
+    );
+  });
+
+  it('does not import WebGL on marketing or Labs surfaces', () => {
+    const roots = [
+      'src/components/sections/about',
+      'src/components/sections/blog',
+      'src/components/sections/portfolio',
+      'src/components/sections/shared',
+      'src/components/sections/labs',
+      'src/app/about',
+      'src/app/blog',
+      'src/app/portfolio',
+      'src/app/labs',
+    ];
+    const files = [
+      ...roots.flatMap(walkTsx),
+      'src/components/sections/footer-section.tsx',
+      'src/components/sections/homepage/blog-section.tsx',
+      'src/components/sections/homepage/photography-section.tsx',
+      'src/components/ui/photo-card.tsx',
+      'src/components/ui/blog-card.tsx',
+      'src/components/ui/lightbox.tsx',
+    ];
+
+    for (const file of files) {
+      expect(readSrc(file), file).not.toMatch(webglImport);
+    }
+  });
+
+  it('keeps the blog reading surface free of decorative motion', () => {
+    const source = readSrc('src/app/blog/[slug]/page.tsx');
+    expect(source).not.toContain('MotionReveal');
+    expect(source).not.toContain('SectionBackground');
+  });
+});

--- a/src/components/sections/portfolio/portfolio-grid.test.tsx
+++ b/src/components/sections/portfolio/portfolio-grid.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PortfolioGrid } from '@/components/sections/portfolio/portfolio-grid';
+
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} />
+  ),
+}));
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  mockPrefersReducedMotion(false);
+});
+
+describe('PortfolioGrid', () => {
+  it('staggers photos without a competing marketing grid', () => {
+    mockPrefersReducedMotion(true);
+
+    const { container } = render(
+      <PortfolioGrid
+        images={[
+          {
+            src: '/photos/one.webp',
+            alt: 'First',
+            title: 'One',
+            category: 'Travel',
+            location: 'Lisbon',
+          },
+          {
+            src: '/photos/two.webp',
+            alt: 'Second',
+            title: 'Two',
+            category: 'Portrait',
+            location: 'London',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'First' })).toBeVisible();
+    expect(screen.getByRole('img', { name: 'Second' })).toBeVisible();
+    expect(container.querySelector('.geometric-pattern')).toBeNull();
+  });
+});

--- a/src/components/sections/portfolio/portfolio-grid.tsx
+++ b/src/components/sections/portfolio/portfolio-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SectionHeader, Container, Section, PhotoCard, Lightbox, MotionReveal, Text } from "@/components/ui";
+import { SectionHeader, Container, Section, PhotoCard, Lightbox, MotionReveal, MotionRevealGroup, Text, SectionBackground } from "@/components/ui";
 import { portfolio } from "@/data";
 import type { PhotoItem } from "@/data/types";
 import { useState, useEffect } from "react";
@@ -44,29 +44,29 @@ export function PortfolioGrid({ images }: PortfolioGridProps) {
   }, [images]);
 
   return (
-    <Section className="py-20">
+    <Section className="relative overflow-hidden py-20">
+      <SectionBackground variant="photography" />
+
       <Container>
         <div className="mb-16 space-y-4">
           <SectionHeader animated={false}>
             {portfolio.heading}
           </SectionHeader>
-          
-          <p className="text-[var(--foreground)] text-lg max-w-2xl">
+
+          <Text size="lg" className="max-w-2xl text-[var(--foreground)]">
             {portfolio.description}
-          </p>
+          </Text>
         </div>
 
         {images.length === 0 ? (
           <Text variant="muted">No photos yet.</Text>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <MotionRevealGroup className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {images.map((image, index) => (
               <MotionReveal
                 key={`${image.src}-${index}`}
                 variant="fade-up"
                 distance="sm"
-                delay={index * 0.1}
-                inView={false}
               >
                 <PhotoCard
                   src={image.src}
@@ -87,7 +87,7 @@ export function PortfolioGrid({ images }: PortfolioGridProps) {
                 />
               </MotionReveal>
             ))}
-          </div>
+          </MotionRevealGroup>
         )}
       </Container>
 

--- a/src/components/sections/shared/certifications-listing.tsx
+++ b/src/components/sections/shared/certifications-listing.tsx
@@ -8,6 +8,7 @@ import {
   SectionBackground,
   SectionHeader,
   MotionReveal,
+  MotionRevealGroup,
 } from "@/components/ui";
 import type { CertificationsSection } from "@/data/types";
 
@@ -22,19 +23,14 @@ export function CertificationsListing({ heading, items }: CertificationsSection)
             {heading}
           </SectionHeader>
 
-          <div className="max-w-4xl mx-auto space-y-12">
-            {items.map((item, index) => (
-              <MotionReveal
-                key={item.name}
-                variant="slide-in"
-                delay={index * 0.2}
-                className="relative"
-              >
-                <div className="relative group">
-                  <div className="absolute left-0 top-0 bottom-0 w-2 bg-[var(--primary)] opacity-20 transform skew-x-12" />
+          <MotionRevealGroup className="mx-auto max-w-4xl space-y-12">
+            {items.map((item) => (
+              <MotionReveal key={item.name} variant="slide-in" className="relative">
+                <div className="group relative">
+                  <div className="absolute top-0 bottom-0 left-0 w-2 skew-x-12 transform bg-[var(--primary)] opacity-20" />
 
-                  <div className="pl-12 pb-2">
-                    <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2 mb-3">
+                  <div className="pb-2 pl-12">
+                    <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                       <div className="space-y-1">
                         <Heading size="sm" as="h2" className="text-[var(--foreground)]">
                           {item.name}
@@ -43,7 +39,7 @@ export function CertificationsListing({ heading, items }: CertificationsSection)
                           {item.issuer}
                         </Text>
                       </div>
-                      <Text variant="muted" className="text-sm font-medium md:text-right shrink-0">
+                      <Text variant="muted" className="shrink-0 text-sm font-medium md:text-right">
                         {item.issued}
                       </Text>
                     </div>
@@ -61,12 +57,12 @@ export function CertificationsListing({ heading, items }: CertificationsSection)
                       </p>
                     ) : null}
 
-                    <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
+                    <div className="h-px w-12 bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
                   </div>
                 </div>
               </MotionReveal>
             ))}
-          </div>
+          </MotionRevealGroup>
         </div>
       </Container>
     </Section>

--- a/src/components/sections/shared/education-listing.tsx
+++ b/src/components/sections/shared/education-listing.tsx
@@ -8,6 +8,7 @@ import {
   SectionBackground,
   SectionHeader,
   MotionReveal,
+  MotionRevealGroup,
 } from "@/components/ui";
 import type { EducationSection } from "@/data/types";
 
@@ -22,19 +23,18 @@ export function EducationListing({ heading, entries }: EducationSection) {
             {heading}
           </SectionHeader>
 
-          <div className="max-w-4xl mx-auto space-y-12">
-            {entries.map((entry, index) => (
+          <MotionRevealGroup className="mx-auto max-w-4xl space-y-12">
+            {entries.map((entry) => (
               <MotionReveal
                 key={`${entry.institution}-${entry.qualification}`}
                 variant="slide-in"
-                delay={index * 0.2}
                 className="relative"
               >
-                <div className="relative group">
-                  <div className="absolute left-0 top-0 bottom-0 w-2 bg-[var(--primary)] opacity-20 transform skew-x-12" />
+                <div className="group relative">
+                  <div className="absolute top-0 bottom-0 left-0 w-2 skew-x-12 transform bg-[var(--primary)] opacity-20" />
 
-                  <div className="pl-12 pb-2">
-                    <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2 mb-3">
+                  <div className="pb-2 pl-12">
+                    <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                       <div className="space-y-1">
                         <Heading size="md" as="h2" className="text-[var(--foreground)]">
                           {entry.institution}
@@ -43,21 +43,21 @@ export function EducationListing({ heading, entries }: EducationSection) {
                           {entry.qualification}
                         </Text>
                       </div>
-                      <Text variant="muted" className="text-sm font-medium md:text-right shrink-0">
+                      <Text variant="muted" className="shrink-0 text-sm font-medium md:text-right">
                         {entry.period}
                       </Text>
                     </div>
 
-                    <Text className="leading-relaxed text-sm mb-3">
+                    <Text className="mb-3 text-sm leading-relaxed">
                       {entry.description}
                     </Text>
 
-                    <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
+                    <div className="h-px w-12 bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
                   </div>
                 </div>
               </MotionReveal>
             ))}
-          </div>
+          </MotionRevealGroup>
         </div>
       </Container>
     </Section>

--- a/src/components/sections/shared/experience-listing.tsx
+++ b/src/components/sections/shared/experience-listing.tsx
@@ -8,6 +8,7 @@ import {
   SectionBackground,
   SectionHeader,
   MotionReveal,
+  MotionRevealGroup,
   type SectionBackgroundVariant,
 } from "@/components/ui";
 import type { ExperienceSection } from "@/data/types";
@@ -37,19 +38,14 @@ export function ExperienceListing({
             </SectionHeader>
           )}
 
-          <div className="max-w-4xl mx-auto space-y-16">
-            {companies.map((company, companyIndex) => (
-              <MotionReveal
-                key={company.name}
-                variant="slide-in"
-                delay={companyIndex * 0.3}
-                className="relative"
-              >
-                <div className="relative group">
-                  <div className="absolute left-0 top-0 bottom-0 w-2 bg-[var(--primary)] opacity-20 transform skew-x-12" />
+          <MotionRevealGroup className="mx-auto max-w-4xl space-y-16">
+            {companies.map((company) => (
+              <MotionReveal key={company.name} variant="slide-in" className="relative">
+                <div className="group relative">
+                  <div className="absolute top-0 bottom-0 left-0 w-2 skew-x-12 transform bg-[var(--primary)] opacity-20" />
 
-                  <div className="pl-12 pb-8">
-                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-6">
+                  <div className="pb-8 pl-12">
+                    <div className="mb-6 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                       <div className="space-y-1">
                         <Heading size="md" as="h2" className="text-[var(--foreground)]">
                           {company.name}
@@ -59,26 +55,25 @@ export function ExperienceListing({
                         </Text>
                       </div>
 
-                      <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-40" />
+                      <div className="h-px w-12 bg-gradient-to-r from-[var(--primary)] to-transparent opacity-40" />
                     </div>
 
-                    <div className="space-y-8">
+                    <MotionRevealGroup className="space-y-8">
                       {company.roles.map((role, roleIndex) => (
                         <MotionReveal
                           key={`${company.name}-${role.role}`}
                           variant="fade-up"
                           distance="sm"
-                          delay={companyIndex * 0.3 + roleIndex * 0.15}
-                          className="relative group/role"
+                          className="group/role relative"
                         >
                           {roleIndex > 0 && (
-                            <div className="absolute -left-8 top-0 w-px h-8 bg-[var(--primary)] opacity-30" />
+                            <div className="absolute top-0 -left-8 h-8 w-px bg-[var(--primary)] opacity-30" />
                           )}
 
-                          <div className="pl-8 space-y-3 relative">
-                            <div className="absolute -left-6 top-2 w-3 h-3 border border-[var(--primary)] transform rotate-45 opacity-0 group-hover/role:opacity-100 transition-opacity duration-300" />
+                          <div className="relative space-y-3 pl-8">
+                            <div className="absolute top-2 -left-6 h-3 w-3 rotate-45 transform border border-[var(--primary)] opacity-0 transition-opacity duration-300 group-hover/role:opacity-100 motion-reduce:transition-none" />
 
-                            <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2">
+                            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                               <div className="space-y-1">
                                 <Heading size="sm" as="h3" className="text-[var(--foreground)]">
                                   {role.role}
@@ -91,20 +86,20 @@ export function ExperienceListing({
                               </div>
                             </div>
 
-                            <Text className="leading-relaxed text-sm">
+                            <Text className="text-sm leading-relaxed">
                               {role.description}
                             </Text>
 
-                            <div className="w-12 h-px bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
+                            <div className="h-px w-12 bg-gradient-to-r from-[var(--primary)] to-transparent opacity-20" />
                           </div>
                         </MotionReveal>
                       ))}
-                    </div>
+                    </MotionRevealGroup>
                   </div>
                 </div>
               </MotionReveal>
             ))}
-          </div>
+          </MotionRevealGroup>
         </div>
       </Container>
     </Section>

--- a/src/components/sections/shared/prose-section.tsx
+++ b/src/components/sections/shared/prose-section.tsx
@@ -8,6 +8,7 @@ import {
   SectionBackground,
   Button,
   MotionReveal,
+  MotionRevealGroup,
 } from "@/components/ui";
 import type { AboutSection } from "@/data/types";
 
@@ -35,42 +36,39 @@ export function ProseSection({
             {heading}
           </SectionHeader>
 
-          <MotionReveal variant="fade-up" distance="md" delay={0.2} className="relative max-w-4xl mx-auto">
+          <MotionReveal variant="fade-up" distance="md" className="relative mx-auto max-w-4xl">
             <div
-              className="absolute inset-0 border-2 border-[var(--primary)] opacity-20 transform -rotate-1 pointer-events-none"
+              className="pointer-events-none absolute inset-0 -rotate-1 transform border-2 border-[var(--primary)] opacity-20"
               style={{
                 clipPath:
                   "polygon(0 0, calc(100% - 30px) 0, 100% 30px, 100% 100%, 30px 100%, 0 calc(100% - 30px))",
               }}
             />
 
-            <div className="absolute top-0 left-0 w-20 h-px bg-[var(--primary)] transform -skew-x-12 opacity-50 pointer-events-none" />
-            <div className="absolute bottom-0 right-0 w-32 h-px bg-[var(--primary)] transform skew-x-12 opacity-30 pointer-events-none" />
+            <div className="pointer-events-none absolute top-0 left-0 h-px w-20 -skew-x-12 transform bg-[var(--primary)] opacity-50" />
+            <div className="pointer-events-none absolute right-0 bottom-0 h-px w-32 skew-x-12 transform bg-[var(--primary)] opacity-30" />
 
-            <div className="p-8 md:p-16 lg:p-20 relative z-10">
-              <div className="space-y-6">
+            <div className="relative z-10 p-8 md:p-16 lg:p-20">
+              <MotionRevealGroup className="space-y-6">
                 {paragraphs.map((paragraph, index) => (
-                  <Text
-                    key={index}
-                    size="lg"
-                    className="leading-relaxed text-[var(--foreground)]"
-                  >
-                    {paragraph}
-                  </Text>
+                  <MotionReveal key={index} variant="fade-up" distance="sm">
+                    <Text size="lg" className="leading-relaxed text-[var(--foreground)]">
+                      {paragraph}
+                    </Text>
+                  </MotionReveal>
                 ))}
-              </div>
+              </MotionRevealGroup>
             </div>
 
-            <div className="absolute top-6 right-6 w-8 h-8 border-2 border-[var(--primary)] transform rotate-45 opacity-30 pointer-events-none" />
-            <div className="absolute bottom-6 left-6 w-6 h-6 bg-[var(--primary)] transform -rotate-12 opacity-10 pointer-events-none" />
+            <div className="pointer-events-none absolute top-6 right-6 h-8 w-8 rotate-45 transform border-2 border-[var(--primary)] opacity-30" />
+            <div className="pointer-events-none absolute bottom-6 left-6 h-6 w-6 -rotate-12 transform bg-[var(--primary)] opacity-10" />
           </MotionReveal>
 
           {cta && (
             <MotionReveal
               variant="fade-up"
               distance="sm"
-              delay={0.4}
-              className="flex justify-center relative z-10"
+              className="relative z-10 flex justify-center"
             >
               <Button href={cta.href} variant="primary" size="md">
                 {cta.label}

--- a/src/components/ui/blog-card.test.tsx
+++ b/src/components/ui/blog-card.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BlogCard } from '@/components/ui/blog-card';
+
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; src: string; className?: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} className={props.className} />
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BlogCard', () => {
+  it('links to the post and matches PhotoCard hover zoom language', () => {
+    render(
+      <BlogCard
+        slug="motion-notes"
+        title="Motion notes"
+        excerpt="How the site moves."
+        category="Engineering"
+        date="2026-09-04"
+        author="Hasha"
+        image="/blog/motion-notes/hero.webp"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: /Motion notes/ })).toHaveAttribute(
+      'href',
+      '/blog/motion-notes',
+    );
+    expect(screen.getByText('Engineering')).toBeInTheDocument();
+    expect(screen.getByText('How the site moves.')).toBeInTheDocument();
+
+    const image = screen.getByRole('img', { name: 'Motion notes' });
+    expect(image.className).toMatch(/group-hover:scale-/);
+    expect(image.className).toMatch(/motion-reduce:group-hover:scale-100/);
+  });
+});

--- a/src/components/ui/blog-card.tsx
+++ b/src/components/ui/blog-card.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 import {
   formatBlogCardDate,
   resolveBlogPostImage,
@@ -31,73 +32,53 @@ export function BlogCard({
   priority = false,
   className = "",
 }: BlogCardProps) {
-  const [isHovered, setIsHovered] = useState(false);
   const [imageError, setImageError] = useState(false);
 
   const formattedDate = formatBlogCardDate(date);
   const imageSrc = resolveBlogPostImage(image, { imageLoadFailed: imageError });
 
   return (
-    <Link
-      href={`/blog/${slug}`}
-      className={`group block ${className}`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div
-        className="relative overflow-hidden bg-[var(--muted)] border border-[var(--border)] transition-all duration-500"
-        style={{
-          transform: isHovered ? 'scale(1.02)' : 'scale(1)',
-        }}
-      >
-        {/* Image */}
+    <Link href={`/blog/${slug}`} className={cn("group block", className)}>
+      <div className="relative overflow-hidden border border-[var(--border)] bg-[var(--muted)]">
         <div className="relative aspect-[16/9] overflow-hidden bg-[var(--muted)]">
           <Image
             src={imageSrc}
             alt={title}
             fill
-            className="object-cover transition-transform duration-700 group-hover:scale-110"
+            className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
             quality={85}
             priority={priority}
             loading={priority ? "eager" : "lazy"}
             onError={() => setImageError(true)}
           />
-          
-          {/* Overlay on hover */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100 motion-reduce:transition-none" />
         </div>
 
-        {/* Content */}
         <div className="p-6">
-          {/* Category */}
           <div className="mb-3">
-            <span className="text-[var(--primary)] font-medium text-sm uppercase tracking-wide">
+            <span className="text-sm font-medium uppercase tracking-wide text-[var(--primary)]">
               {category}
             </span>
           </div>
 
-          {/* Title */}
-          <h3 className="text-[var(--foreground)] font-body font-bold text-xl mb-3 line-clamp-3 group-hover:text-[var(--primary)] transition-colors duration-300">
+          <h3 className="mb-3 line-clamp-3 font-body text-xl font-bold text-[var(--foreground)] transition-colors duration-300 group-hover:text-[var(--primary)] motion-reduce:transition-none">
             {title}
           </h3>
 
-          {/* Excerpt */}
-          <p className="text-[var(--foreground)]/70 text-sm mb-4 line-clamp-3">
+          <p className="mb-4 line-clamp-3 text-sm text-[var(--foreground)]/70">
             {excerpt}
           </p>
 
-          {/* Meta info */}
           <div className="flex items-center justify-between text-xs text-[var(--foreground)]/60">
             <span>{author}</span>
             <span>{formattedDate}</span>
           </div>
         </div>
 
-        {/* Border effect on hover */}
-        <div className="absolute inset-0 border-2 border-transparent group-hover:border-[var(--primary)] transition-colors duration-500 pointer-events-none" />
+        <div className="pointer-events-none absolute inset-0 border-2 border-transparent transition-colors duration-300 group-hover:border-[var(--primary)] motion-reduce:transition-none" />
       </div>
     </Link>
   );
 }
-

--- a/src/components/ui/footer/social-link.test.tsx
+++ b/src/components/ui/footer/social-link.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SocialLink } from '@/components/ui/footer/social-link';
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  mockPrefersReducedMotion(false);
+});
+
+describe('SocialLink', () => {
+  it('remains a labelled control when reduced motion is preferred', () => {
+    mockPrefersReducedMotion(true);
+
+    render(
+      <SocialLink href="https://github.com/hashadar" icon={<span>GH</span>} label="GitHub" />,
+    );
+
+    const link = screen.getByRole('link', { name: 'GitHub' });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', 'https://github.com/hashadar');
+  });
+});

--- a/src/components/ui/footer/social-link.tsx
+++ b/src/components/ui/footer/social-link.tsx
@@ -2,6 +2,8 @@
 
 import { motion } from "framer-motion";
 import { ReactNode } from "react";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { motionSprings } from "@/lib/motion/tokens";
 
 interface SocialLinkProps {
   href: string;
@@ -10,18 +12,20 @@ interface SocialLinkProps {
 }
 
 export function SocialLink({ href, icon, label }: SocialLinkProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   return (
     <motion.a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       aria-label={label}
-      className="relative z-10 w-12 h-12 bg-[var(--foreground)] rounded-lg flex items-center justify-center text-[var(--background)] hover:bg-[var(--primary)] transition-all duration-300 cursor-pointer"
-      whileHover={{ scale: 1.1 }}
-      whileTap={{ scale: 0.95 }}
+      className="relative z-10 flex h-12 w-12 cursor-pointer items-center justify-center rounded-lg bg-[var(--foreground)] text-[var(--background)] transition-colors duration-300 hover:bg-[var(--primary)]"
+      whileHover={prefersReducedMotion ? undefined : { scale: 1.08 }}
+      whileTap={prefersReducedMotion ? undefined : { scale: 0.96 }}
+      transition={motionSprings.hover}
     >
       {icon}
     </motion.a>
   );
 }
-

--- a/src/components/ui/lightbox.test.tsx
+++ b/src/components/ui/lightbox.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Lightbox } from '@/components/ui/lightbox';
+
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} />
+  ),
+}));
+
+function mockPrefersReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  mockPrefersReducedMotion(false);
+  document.body.style.overflow = '';
+});
+
+const images = [
+  {
+    src: '/photos/one.webp',
+    alt: 'First photo',
+    title: 'One',
+    category: 'Travel',
+    location: 'Lisbon',
+  },
+];
+
+describe('Lightbox', () => {
+  it('shows the current photo when open', () => {
+    mockPrefersReducedMotion(false);
+
+    render(
+      <Lightbox
+        isOpen
+        images={images}
+        currentIndex={0}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'First photo' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'One' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close lightbox' })).toBeInTheDocument();
+  });
+
+  it('appears immediately when reduced motion is preferred', () => {
+    mockPrefersReducedMotion(true);
+
+    render(
+      <Lightbox
+        isOpen
+        images={images}
+        currentIndex={0}
+        onClose={() => {}}
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'First photo' });
+    expect(image).toBeVisible();
+    expect(image.closest('[style]')).not.toHaveStyle({ opacity: '0' });
+  });
+});

--- a/src/components/ui/lightbox.tsx
+++ b/src/components/ui/lightbox.tsx
@@ -3,6 +3,8 @@
 import Image from "next/image";
 import { useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { motionDurations, motionEasings } from "@/lib/motion/tokens";
 
 interface LightboxImage {
   src: string;
@@ -29,14 +31,17 @@ export function Lightbox({
   onNext,
   onPrevious,
 }: LightboxProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
   const currentImage = images[currentIndex];
   const hasMultipleImages = images.length > 1;
 
-  // Preload adjacent images for faster navigation
   const nextIndex = (currentIndex + 1) % images.length;
   const prevIndex = (currentIndex - 1 + images.length) % images.length;
 
-  // Handle keyboard navigation
+  const fadeTransition = prefersReducedMotion
+    ? { duration: 0 }
+    : { duration: motionDurations.fast, ease: motionEasings.out };
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (!isOpen) return;
@@ -53,10 +58,9 @@ export function Lightbox({
           break;
       }
     },
-    [isOpen, onClose, onNext, onPrevious]
+    [isOpen, onClose, onNext, onPrevious],
   );
 
-  // Add/remove keyboard event listener
   useEffect(() => {
     if (isOpen) {
       document.addEventListener("keydown", handleKeyDown);
@@ -75,13 +79,13 @@ export function Lightbox({
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          initial={{ opacity: 0 }}
+          initial={prefersReducedMotion ? false : { opacity: 0 }}
           animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
+          exit={prefersReducedMotion ? { opacity: 1 } : { opacity: 0 }}
+          transition={fadeTransition}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/95"
           onClick={onClose}
         >
-          {/* Close button */}
           <button
             onClick={onClose}
             className="absolute top-4 right-4 z-50 p-2 text-white hover:text-[var(--primary)] transition-colors"
@@ -103,7 +107,6 @@ export function Lightbox({
             </svg>
           </button>
 
-          {/* Previous button */}
           {hasMultipleImages && onPrevious && (
             <button
               onClick={(e) => {
@@ -130,7 +133,6 @@ export function Lightbox({
             </button>
           )}
 
-          {/* Next button */}
           {hasMultipleImages && onNext && (
             <button
               onClick={(e) => {
@@ -157,16 +159,14 @@ export function Lightbox({
             </button>
           )}
 
-          {/* Image container */}
           <motion.div
-            initial={{ scale: 0.9, opacity: 0 }}
+            initial={prefersReducedMotion ? false : { scale: 0.96, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.9, opacity: 0 }}
-            transition={{ duration: 0.2 }}
+            exit={prefersReducedMotion ? { opacity: 1 } : { scale: 0.96, opacity: 0 }}
+            transition={fadeTransition}
             className="relative max-w-7xl mx-4"
             onClick={(e) => e.stopPropagation()}
           >
-            {/* Current Image */}
             <div className="relative">
               <Image
                 src={currentImage.src}
@@ -181,33 +181,29 @@ export function Lightbox({
               />
             </div>
 
-            {/* Preload adjacent images for faster navigation */}
             {hasMultipleImages && (
-              <>
-                <div className="hidden">
-                  <Image
-                    src={images[nextIndex]?.src}
-                    alt={images[nextIndex]?.alt || ""}
-                    width={1600}
-                    height={1200}
-                    quality={90}
-                    priority
-                    loading="eager"
-                  />
-                  <Image
-                    src={images[prevIndex]?.src}
-                    alt={images[prevIndex]?.alt || ""}
-                    width={1600}
-                    height={1200}
-                    quality={90}
-                    priority
-                    loading="eager"
-                  />
-                </div>
-              </>
+              <div className="hidden">
+                <Image
+                  src={images[nextIndex]?.src}
+                  alt={images[nextIndex]?.alt || ""}
+                  width={1600}
+                  height={1200}
+                  quality={90}
+                  priority
+                  loading="eager"
+                />
+                <Image
+                  src={images[prevIndex]?.src}
+                  alt={images[prevIndex]?.alt || ""}
+                  width={1600}
+                  height={1200}
+                  quality={90}
+                  priority
+                  loading="eager"
+                />
+              </div>
             )}
 
-            {/* Image caption */}
             {(currentImage.title || currentImage.category || currentImage.location) && (
               <div className="mt-4 text-center">
                 {currentImage.title && (
@@ -230,7 +226,6 @@ export function Lightbox({
               </div>
             )}
 
-            {/* Image counter */}
             {hasMultipleImages && (
               <div className="mt-4 text-center text-white/50 text-sm">
                 {currentIndex + 1} / {images.length}
@@ -242,4 +237,3 @@ export function Lightbox({
     </AnimatePresence>
   );
 }
-

--- a/src/components/ui/photo-card.test.tsx
+++ b/src/components/ui/photo-card.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PhotoCard } from '@/components/ui/photo-card';
+
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; src: string; className?: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} className={props.className} />
+  ),
+}));
+
+const photo = {
+  src: '/photos/portrait.webp',
+  alt: 'Studio portrait',
+  title: 'Studio light',
+  category: 'Portrait',
+  location: 'London',
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PhotoCard', () => {
+  it('shows caption details and a hover zoom that reduced motion can disable', () => {
+    render(<PhotoCard {...photo} showOverlay />);
+
+    expect(screen.getByRole('img', { name: 'Studio portrait' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Studio light' })).toBeInTheDocument();
+    expect(screen.getByText('Portrait')).toBeInTheDocument();
+    expect(screen.getByText('London')).toBeInTheDocument();
+
+    const image = screen.getByRole('img', { name: 'Studio portrait' });
+    expect(image.className).toMatch(/group-hover:scale-/);
+    expect(image.className).toMatch(/motion-reduce:group-hover:scale-100/);
+  });
+
+  it('keeps auto-aspect photos free of spatial hover zoom under reduced motion', () => {
+    render(
+      <PhotoCard
+        {...photo}
+        aspectRatio="auto"
+        width={1200}
+        height={800}
+        showOverlay
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'Studio portrait' });
+    expect(image.className).toMatch(/motion-reduce:group-hover:scale-100/);
+    expect(image.className).not.toMatch(/group-hover:scale-110/);
+  });
+});

--- a/src/components/ui/photo-card.tsx
+++ b/src/components/ui/photo-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useState } from "react";
+import { cn } from "@/lib/utils";
 
 interface PhotoCardProps {
   src: string;
@@ -20,6 +20,54 @@ interface PhotoCardProps {
   onMouseEnter?: () => void;
 }
 
+const imageMotionClass =
+  "transition-transform duration-500 ease-out group-hover:scale-[1.04] motion-reduce:transition-none motion-reduce:group-hover:scale-100";
+
+function PhotoCardChrome({
+  title,
+  category,
+  location,
+  showOverlay,
+}: Pick<PhotoCardProps, "title" | "category" | "location" | "showOverlay">) {
+  if (!showOverlay) {
+    return null;
+  }
+
+  const hasCaption = Boolean(title || category || location);
+
+  return (
+    <>
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100 motion-reduce:transition-none" />
+
+      {hasCaption && (
+        <div className="absolute inset-x-0 bottom-0 translate-y-full p-6 opacity-100 transition-transform duration-300 group-hover:translate-y-0 motion-reduce:translate-y-0 motion-reduce:opacity-0 motion-reduce:transition-none motion-reduce:group-hover:opacity-100">
+          {title && (
+            <h3 className="mb-2 font-body text-xl font-bold text-white">
+              {title}
+            </h3>
+          )}
+          {(category || location) && (
+            <div className="flex gap-3 text-sm">
+              {category && (
+                <span className="font-medium text-[var(--primary)]">
+                  {category}
+                </span>
+              )}
+              {location && (
+                <span className="text-white/80">
+                  {location}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="pointer-events-none absolute inset-0 border-2 border-transparent transition-colors duration-300 group-hover:border-[var(--primary)] motion-reduce:transition-none" />
+    </>
+  );
+}
+
 export function PhotoCard({
   src,
   alt,
@@ -36,132 +84,49 @@ export function PhotoCard({
   onClick,
   onMouseEnter,
 }: PhotoCardProps) {
-  const [isHovered, setIsHovered] = useState(false);
+  const isAuto = aspectRatio === "auto" && Boolean(width && height);
 
-  const handleMouseEnter = () => {
-    setIsHovered(true);
-    onMouseEnter?.();
-  };
-
-  // For auto aspect ratio with width/height, use different layout
-  if (aspectRatio === "auto" && width && height) {
-    return (
-      <div
-        className={`group relative overflow-hidden bg-[var(--muted)] cursor-pointer ${className}`}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={() => setIsHovered(false)}
-        onClick={onClick}
-        style={{
-          transform: isHovered ? 'scale(1.02)' : 'scale(1)',
-          transition: 'transform 0.5s ease-out'
-        }}
-      >
-        {/* Image with explicit dimensions */}
+  return (
+    <div
+      className={cn(
+        "group relative cursor-pointer overflow-hidden bg-[var(--muted)]",
+        isAuto ? "" : "aspect-[2/3]",
+        className,
+      )}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+    >
+      {isAuto ? (
         <Image
           src={src}
           alt={alt}
           width={width}
           height={height}
-          className="w-full h-auto transition-transform duration-700 group-hover:scale-110"
+          className={cn("h-auto w-full", imageMotionClass)}
           sizes={sizes}
           quality={85}
           priority={priority}
           loading={priority ? "eager" : "lazy"}
         />
-        
-        {/* Overlay */}
-        {showOverlay && (
-          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-        )}
-        
-        {/* Content */}
-        {(title || category || location) && showOverlay && (
-          <div className="absolute inset-x-0 bottom-0 p-6 transform translate-y-full group-hover:translate-y-0 transition-transform duration-500">
-            {title && (
-              <h3 className="text-white font-body font-bold text-xl mb-2">
-                {title}
-              </h3>
-            )}
-            {(category || location) && (
-              <div className="flex gap-3 text-sm">
-                {category && (
-                  <span className="text-[var(--primary)] font-medium">
-                    {category}
-                  </span>
-                )}
-                {location && (
-                  <span className="text-white/80">
-                    {location}
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-        
-        {/* Border effect on hover */}
-        <div className="absolute inset-0 border-2 border-transparent group-hover:border-[var(--primary)] transition-colors duration-500 pointer-events-none" />
-      </div>
-    );
-  }
+      ) : (
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          className={cn("object-cover", imageMotionClass)}
+          sizes={sizes}
+          quality={85}
+          priority={priority}
+          loading={priority ? "eager" : "lazy"}
+        />
+      )}
 
-  // For fixed aspect ratio (2/3), use fill layout
-  return (
-    <div
-      className={`group relative aspect-[2/3] overflow-hidden bg-[var(--muted)] cursor-pointer ${className}`}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={() => setIsHovered(false)}
-      onClick={onClick}
-      style={{
-        transform: isHovered ? 'scale(1.02)' : 'scale(1)',
-        transition: 'transform 0.5s ease-out'
-      }}
-    >
-      {/* Image */}
-      <Image
-        src={src}
-        alt={alt}
-        fill
-        className="object-cover transition-transform duration-700 group-hover:scale-110"
-        sizes={sizes}
-        quality={85}
-        priority={priority}
-        loading={priority ? "eager" : "lazy"}
+      <PhotoCardChrome
+        title={title}
+        category={category}
+        location={location}
+        showOverlay={showOverlay}
       />
-      
-      {/* Overlay */}
-      {showOverlay && (
-        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-      )}
-      
-      {/* Content */}
-      {(title || category || location) && showOverlay && (
-        <div className="absolute inset-x-0 bottom-0 p-6 transform translate-y-full group-hover:translate-y-0 transition-transform duration-500">
-          {title && (
-            <h3 className="text-white font-body font-bold text-xl mb-2">
-              {title}
-            </h3>
-          )}
-          {(category || location) && (
-            <div className="flex gap-3 text-sm">
-              {category && (
-                <span className="text-[var(--primary)] font-medium">
-                  {category}
-                </span>
-              )}
-              {location && (
-                <span className="text-white/80">
-                  {location}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Border effect on hover */}
-      <div className="absolute inset-0 border-2 border-transparent group-hover:border-[var(--primary)] transition-colors duration-500" />
     </div>
   );
 }
-

--- a/src/lib/motion/tokens.test.ts
+++ b/src/lib/motion/tokens.test.ts
@@ -19,13 +19,14 @@ describe("motion tokens", () => {
     expect(motionEasings.inOut).toBe("easeInOut");
   });
 
-  it("exposes hero enter and reveal spring presets", () => {
+  it("exposes hero enter, reveal, and hover spring presets", () => {
     expect(motionSprings.heroEnter).toMatchObject({
       type: "spring",
       damping: 25,
       stiffness: 80,
     });
     expect(motionSprings.reveal.type).toBe("spring");
+    expect(motionSprings.hover.stiffness).toBeGreaterThan(motionSprings.reveal.stiffness);
   });
 
   it("exposes a positive stagger step", () => {

--- a/src/lib/motion/tokens.ts
+++ b/src/lib/motion/tokens.ts
@@ -19,7 +19,7 @@ export const motionEasings = {
 
 export type MotionEasing = keyof typeof motionEasings;
 
-/** Spring presets for hero enter and reveal-style motion. */
+/** Spring presets for hero enter, reveal-style motion, and hover scale. */
 export const motionSprings = {
   heroEnter: {
     type: "spring" as const,
@@ -30,6 +30,11 @@ export const motionSprings = {
     type: "spring" as const,
     damping: 28,
     stiffness: 120,
+  },
+  hover: {
+    type: "spring" as const,
+    damping: 20,
+    stiffness: 260,
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Wire homepage, About, portfolio, blog index, and footer onto `MotionReveal` / `MotionRevealGroup` and the redesigned marketing/photography atmospheres.
- Polish PhotoCard and BlogCard hover (coherent overlay + caption) and lightbox enter/exit via motion tokens; skip spatial zoom under reduced motion.
- Tokenise social-link hover springs, drop unused prose wrappers, and keep blog posts quiet with no WebGL on marketing routes.

Closes #234

## Test plan
- [ ] Home about / photography / blog / experience reveal without floating diamond loops; photography imagery still leads
- [ ] About hero is elevated DOM only (no canvas); listings stagger
- [ ] Portfolio and blog index grids use staggered card reveals
- [ ] Card hover: overlay/caption/border without layout-shifting zoom; `prefers-reduced-motion` disables scale
- [ ] Lightbox open/close uses tokens; reduced motion is instant
- [ ] Footer columns stagger; social links scale with the hover spring unless reduced motion
- [ ] Blog post reading page stays undecorated
- [ ] `npm test` and `npm run typecheck` pass


Made with [Cursor](https://cursor.com)