### PR TITLE
Quiet overlay header and footer for SitePage Chrome (#245)

### DIFF
--- a/docs/CODEBASE-CONVENTIONS.md
+++ b/docs/CODEBASE-CONVENTIONS.md
@@ -52,7 +52,7 @@ This document defines how to work in this codebase so that new and changed code 
 
 ### 4.1 Data-driven content
 
-- **Copy and labels** that might change or be localised (buttons, headings, nav labels, brand name, footer column titles) should come from `src/data` (JSON + types), not be hardcoded in components.
+- **Copy and labels** that might change or be localised (buttons, headings, nav labels, brand name, footer labels) should come from `src/data` (JSON + types), not be hardcoded in components.
 - **Site-wide metadata** (title, description, author, siteUrl, brandName, locale) lives in `src/data/common/site.json` and is typed in `src/data/types.ts`. Use `site` from `@/data` in layout, metadata, and SEO.
 - **Footer and navigation** come from `src/data`; use `footer`, `navigation`, and `site` in header, footer, and any shared layout.
 

--- a/src/components/layout/site-page.test.tsx
+++ b/src/components/layout/site-page.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { footer, navigation } from '@/data';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { footer, navigation, site } from '@/data';
 import { SitePage } from '@/components/layout/site-page';
+
+afterEach(() => {
+  cleanup();
+});
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/',
@@ -23,26 +27,90 @@ vi.mock('next/link', () => ({
 }));
 
 describe('SitePage', () => {
-  it('renders the main landmark with children and a self-loaded footer', () => {
+  it('owns the skip link, header, main landmark, and footer', () => {
     render(
       <SitePage>
         <p>Page body</p>
       </SitePage>,
     );
 
+    expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute(
+      'href',
+      '#main-content',
+    );
+
     const main = document.getElementById('main-content');
     expect(main).toBeInTheDocument();
     expect(main?.tagName).toBe('MAIN');
     expect(screen.getByText('Page body')).toBeInTheDocument();
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('keeps Home and Admin out of the header; public doors come from data', () => {
+    render(
+      <SitePage>
+        <p>Page body</p>
+      </SitePage>,
+    );
+
+    const header = screen.getByRole('banner');
+    expect(within(header).queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
+    expect(within(header).queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
+    expect(within(header).getByRole('link', { name: site.brandName })).toHaveAttribute(
+      'href',
+      '/',
+    );
+
+    for (const link of navigation.links) {
+      expect(within(header).getByRole('link', { name: link.label })).toHaveAttribute(
+        'href',
+        link.href,
+      );
+    }
+  });
+
+  it('renders a quiet footer with public doors and Admin last', () => {
+    render(
+      <SitePage>
+        <p>Page body</p>
+      </SitePage>,
+    );
+
+    const siteFooter = screen.getByRole('contentinfo');
+    expect(screen.queryByText('Get in Touch')).not.toBeInTheDocument();
+    expect(screen.queryByText('Navigation')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connect')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Turning zeros and ones into insights, pixels into stories, and moments into memories'),
+    ).not.toBeInTheDocument();
+    expect(within(siteFooter).queryByRole('link', { name: /sign out/i })).not.toBeInTheDocument();
+
+    for (const link of navigation.links) {
+      expect(within(siteFooter).getByRole('link', { name: link.label })).toHaveAttribute(
+        'href',
+        link.href,
+      );
+    }
+
     expect(screen.getByRole('link', { name: footer.contact.email })).toHaveAttribute(
       'href',
       `mailto:${footer.contact.email}`,
     );
+    expect(within(siteFooter).getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+      'href',
+      footer.contact.social.github,
+    );
+    expect(within(siteFooter).getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
+      'href',
+      footer.contact.social.linkedin,
+    );
+    expect(within(siteFooter).getByText(footer.contact.copyright)).toBeInTheDocument();
 
-    const siteFooter = screen.getByRole('contentinfo');
-    expect(
-      within(siteFooter).getByRole('link', { name: navigation.links[0].label }),
-    ).toHaveAttribute('href', navigation.links[0].href);
+    const footerLinks = within(siteFooter).getAllByRole('link');
+    const adminLink = footerLinks[footerLinks.length - 1];
+    expect(adminLink).toHaveAttribute('href', footer.contact.admin.href);
+    expect(adminLink).toHaveTextContent(footer.contact.admin.label);
   });
 
   it('applies optional mainClassName to the main landmark', () => {

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -1,81 +1,102 @@
 "use client";
 
-import {
-  Container,
-  FooterBackground,
-  FooterBrand,
-  FooterColumn,
-  GitHubIcon,
-  LinkedInIcon,
-  MotionRevealGroup,
-  NavLink,
-  SocialLink,
-  Text,
-} from "@/components/ui";
+import Link from "next/link";
+import { useLayoutEffect, useRef } from "react";
+import { NavLink, Text } from "@/components/ui";
 import { getCommonData } from "@/data";
+
+function fitWordmarkToDoors(mark: HTMLElement, nav: HTMLElement) {
+  mark.style.fontSize = "";
+  const links = [...nav.querySelectorAll("a")];
+  if (links.length === 0) return;
+
+  const first = links[0].getBoundingClientRect();
+  const last = links[links.length - 1].getBoundingClientRect();
+  const target = last.right - first.left;
+  const range = document.createRange();
+  range.selectNodeContents(mark);
+  const natural =
+    typeof range.getBoundingClientRect === "function"
+      ? range.getBoundingClientRect().width
+      : mark.scrollWidth;
+  const current = parseFloat(getComputedStyle(mark).fontSize);
+  if (target <= 0 || natural <= 0 || current <= 0) return;
+
+  mark.style.fontSize = `${(current * target) / natural}px`;
+}
 
 export function FooterSection() {
   const { footer, navigation, site } = getCommonData();
-  const {
-    heading,
-    description,
-    navigationTitle,
-    socialTitle,
-    email,
-    social,
-    copyright,
-  } = footer.contact;
+  const { email, social, copyright, admin } = footer.contact;
+  const markRef = useRef<HTMLParagraphElement>(null);
+  const navRef = useRef<HTMLElement>(null);
+
+  useLayoutEffect(() => {
+    const mark = markRef.current;
+    const nav = navRef.current;
+    if (!mark || !nav) return;
+
+    const fit = () => fitWordmarkToDoors(mark, nav);
+    fit();
+    void document.fonts?.ready.then(fit);
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(fit);
+    observer.observe(nav);
+    return () => observer.disconnect();
+  }, []);
 
   return (
-    <footer className="relative overflow-hidden bg-[var(--background)] border-t border-[var(--border)]">
-      <FooterBackground />
+    <footer className="border-t border-[var(--border)] bg-[var(--background)]">
+      <div className="container mx-auto px-6">
+        <div className="grid gap-6 py-12 md:grid-cols-[1fr_auto] md:items-end">
+          <div className="w-max">
+            <p
+              ref={markRef}
+              className="w-fit whitespace-nowrap font-body text-sm leading-none tracking-tight text-[var(--foreground)]"
+            >
+              {site.brandName}
+            </p>
+            <nav ref={navRef} className="mt-3 flex gap-x-5" aria-label="Footer">
+              {navigation.links.map((link) => (
+                <NavLink key={link.href} href={link.href}>
+                  {link.label}
+                </NavLink>
+              ))}
+            </nav>
+          </div>
 
-      <Container>
-        <div className="py-20 space-y-16">
-          <MotionRevealGroup className="grid gap-12 md:grid-cols-3 md:gap-16">
-            <FooterColumn title={heading}>
-              <Text className="leading-relaxed text-[var(--foreground)]">
-                {description}
-              </Text>
-
-              <div className="space-y-3">
-                <Text className="font-medium text-[var(--primary)]">
-                  <a href={`mailto:${email}`} className="hover:underline transition-colors duration-300">
-                    {email}
-                  </a>
-                </Text>
-              </div>
-            </FooterColumn>
-
-            <FooterColumn title={navigationTitle}>
-              <nav className="space-y-3 relative z-10">
-                {navigation.links.map((link) => (
-                  <NavLink key={link.href} href={link.href}>
-                    {link.label}
-                  </NavLink>
-                ))}
-              </nav>
-            </FooterColumn>
-
-            <FooterColumn title={socialTitle}>
-              <div className="flex gap-4 relative z-10">
-                <SocialLink
-                  href={social.linkedin}
-                  icon={<LinkedInIcon />}
-                  label="LinkedIn"
-                />
-                <SocialLink
-                  href={social.github}
-                  icon={<GitHubIcon />}
-                  label="GitHub"
-                />
-              </div>
-            </FooterColumn>
-          </MotionRevealGroup>
-
-          <FooterBrand brandName={site.brandName} copyright={copyright} />
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[var(--mono-500)]">
+            <a href={`mailto:${email}`} className="hover:text-[var(--primary)] transition-colors">
+              {email}
+            </a>
+            <a
+              href={social.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-[var(--primary)] transition-colors"
+            >
+              GitHub
+            </a>
+            <a
+              href={social.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-[var(--primary)] transition-colors"
+            >
+              LinkedIn
+            </a>
+            <Text as="span" size="xs" variant="muted">
+              {copyright}
+            </Text>
+            <Link
+              href={admin.href}
+              className="text-xs text-[var(--foreground)] opacity-45 transition-opacity hover:opacity-70"
+            >
+              {admin.label}
+            </Link>
+          </div>
         </div>
-      </Container>
+      </div>
     </footer>
   );
 }

--- a/src/components/ui/footer/nav-link.tsx
+++ b/src/components/ui/footer/nav-link.tsx
@@ -9,7 +9,7 @@ export function NavLink({ href, children }: NavLinkProps) {
   return (
     <Link
       href={href}
-      className="text-[var(--foreground)] hover:text-[var(--primary)] transition-colors duration-300 block cursor-pointer relative z-10"
+      className="text-sm font-medium text-[var(--foreground)] hover:text-[var(--primary)] transition-colors duration-300 cursor-pointer relative z-10"
     >
       {children}
     </Link>

--- a/src/components/ui/navigation/header.tsx
+++ b/src/components/ui/navigation/header.tsx
@@ -6,69 +6,59 @@ import { useState } from "react";
 import { navigation, site } from "@/data";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useSmoothScroll } from "@/hooks/use-smooth-scroll";
+import { cn } from "@/lib/utils";
 
 export function Header() {
   useSmoothScroll();
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  
+
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/";
-    if (href.startsWith("/#")) return pathname === "/";
-    return pathname === href;
+    return pathname === href || pathname.startsWith(`${href}/`);
   };
-  
+
   const closeMobileMenu = () => setMobileMenuOpen(false);
-  
+
+  const doorClassName =
+    "text-sm font-medium text-[var(--foreground)] hover:text-[var(--primary)] transition-colors";
+
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-[var(--background)]/80 backdrop-blur-sm border-b border-[var(--border)]">
-      <nav className="container mx-auto px-6 py-4 flex items-center justify-between">
-        <Link 
-          href="/" 
-          className="font-body font-bold text-xl text-[var(--foreground)] hover:text-[var(--primary)] transition-colors"
+    <header className="fixed top-0 left-0 right-0 z-50">
+      <nav
+        className="container mx-auto flex items-center justify-between px-6 py-5"
+        aria-label="Primary"
+      >
+        <Link
+          href="/"
+          className="font-body text-sm tracking-tight text-[var(--foreground)] hover:text-[var(--primary)] transition-colors"
         >
           {site.brandName}
         </Link>
-        
+
         <div className="flex items-center gap-4">
-          {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center gap-6">
+          <div className="hidden items-center gap-6 md:flex">
             {navigation.links.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
-                className={`text-sm font-medium transition-colors relative ${
-                  link.href === '/admin'
-                    ? isActive(link.href)
-                      ? 'text-[var(--foreground)]/70'
-                      : 'text-[var(--foreground)]/45 hover:text-[var(--foreground)]/70'
-                    : isActive(link.href)
-                      ? 'text-[var(--primary)]'
-                      : 'text-[var(--foreground)] hover:text-[var(--primary)]'
-                }`}
-                aria-current={isActive(link.href) ? 'page' : undefined}
+                className={doorClassName}
+                aria-current={isActive(link.href) ? "page" : undefined}
               >
                 {link.label}
-                {isActive(link.href) && link.href !== '/admin' && (
-                  <span className="absolute -bottom-1 left-0 right-0 h-0.5 bg-[var(--primary)]" />
-                )}
               </Link>
             ))}
           </div>
-          
-          {/* Theme Toggle - appears first on mobile, after nav on desktop */}
-          <div className="order-1 md:order-none">
-            <ThemeToggle />
-          </div>
-          
-          {/* Mobile Menu Button - appears second on mobile */}
+
+          <ThemeToggle />
+
           <button
-            className="md:hidden order-2 p-2 text-[var(--foreground)] hover:text-[var(--primary)] transition-colors"
+            className="order-2 p-2 text-[var(--foreground)] hover:text-[var(--primary)] transition-colors md:hidden"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-label="Toggle mobile menu"
             aria-expanded={mobileMenuOpen}
           >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               {mobileMenuOpen ? (
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               ) : (
@@ -78,21 +68,16 @@ export function Header() {
           </button>
         </div>
       </nav>
-      
-      {/* Mobile Menu */}
+
       {mobileMenuOpen && (
-        <div className="md:hidden bg-[var(--background)] border-b border-[var(--border)]">
-          <div className="container mx-auto px-6 py-4 flex flex-col gap-4">
+        <div className="bg-[var(--background)] md:hidden">
+          <div className="container mx-auto flex flex-col gap-4 px-6 py-4">
             {navigation.links.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
                 onClick={closeMobileMenu}
-                className={`text-base font-medium transition-colors ${
-                  isActive(link.href)
-                    ? "text-[var(--primary)]"
-                    : "text-[var(--foreground)] hover:text-[var(--primary)]"
-                }`}
+                className={cn(doorClassName, "text-base")}
                 aria-current={isActive(link.href) ? "page" : undefined}
               >
                 {link.label}
@@ -104,4 +89,3 @@ export function Header() {
     </header>
   );
 }
-

--- a/src/components/ui/theme-toggle.test.tsx
+++ b/src/components/ui/theme-toggle.test.tsx
@@ -45,4 +45,12 @@ describe('ThemeToggle', () => {
       await screen.findByRole('button', { name: 'Switch to light mode' }),
     ).toBeInTheDocument();
   });
+
+  it('uses a sun or moon icon rather than a Light or Dark word', () => {
+    render(<ThemeToggle />);
+
+    const button = screen.getByRole('button', { name: 'Switch to dark mode' });
+    expect(button.querySelector('svg')).toBeTruthy();
+    expect(button).not.toHaveTextContent(/light|dark/i);
+  });
 });

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-import { Button } from "./button";
 
 const THEME_CHANGE_EVENT = "hashadar-theme-change";
 
@@ -44,15 +43,53 @@ export function ThemeToggle() {
   const label = isDark ? "Switch to light mode" : "Switch to dark mode";
 
   return (
-    <Button
-      variant="ghost"
+    <button
+      type="button"
       onClick={toggleTheme}
       aria-label={label}
       aria-pressed={isDark}
       title={label}
+      className="inline-flex cursor-pointer items-center justify-center border-0 bg-transparent p-1 text-[var(--foreground)] transition-colors hover:text-[var(--primary)] focus-visible:outline-none focus-visible:text-[var(--primary)]"
     >
-      <span aria-hidden="true">{isDark ? "☀" : "☾"}</span>
-      <span className="ml-2">{isDark ? "Light" : "Dark"}</span>
-    </Button>
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.75}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+      />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.75}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+      />
+    </svg>
   );
 }

--- a/src/data/common/footer.json
+++ b/src/data/common/footer.json
@@ -1,14 +1,14 @@
 {
   "contact": {
-    "heading": "Get in Touch",
-    "description": "Turning zeros and ones into insights, pixels into stories, and moments into memories",
-    "navigationTitle": "Navigation",
-    "socialTitle": "Connect",
     "email": "hello@hashadar.com",
     "social": {
       "github": "https://github.com/hashadar",
       "linkedin": "https://linkedin.com/in/hdar"
     },
-    "copyright": "© 2026 hasha dar. All rights reserved."
+    "copyright": "© 2026 hasha dar. All rights reserved.",
+    "admin": {
+      "label": "Admin",
+      "href": "/admin"
+    }
   }
 }

--- a/src/data/common/navigation.json
+++ b/src/data/common/navigation.json
@@ -1,10 +1,6 @@
 {
   "links": [
     {
-      "label": "Home",
-      "href": "/"
-    },
-    {
       "label": "About",
       "href": "/about"
     },
@@ -19,10 +15,6 @@
     {
       "label": "Blog",
       "href": "/blog"
-    },
-    {
-      "label": "Admin",
-      "href": "/admin"
     }
   ]
 }

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -58,8 +58,20 @@ describe('getCommonData', () => {
     expect(navigation.links).toContainEqual({ label: 'Labs', href: '/labs' });
   });
 
-  it('includes an unobtrusive Admin navigation link and no footer sign-in', () => {
-    expect(navigation.links).toContainEqual({ label: 'Admin', href: '/admin' });
+  it('keeps header doors to public pages only, with Admin as a footer-only link', () => {
+    expect(navigation.links).toEqual([
+      { label: 'About', href: '/about' },
+      { label: 'Portfolio', href: '/portfolio' },
+      { label: 'Labs', href: '/labs' },
+      { label: 'Blog', href: '/blog' },
+    ]);
+    expect(navigation.links).not.toContainEqual({ label: 'Home', href: '/' });
+    expect(navigation.links).not.toContainEqual({ label: 'Admin', href: '/admin' });
+    expect(footer.contact.admin).toEqual({ label: 'Admin', href: '/admin' });
     expect(footer.contact).not.toHaveProperty('ownerSignIn');
+    expect(footer.contact).not.toHaveProperty('heading');
+    expect(footer.contact).not.toHaveProperty('description');
+    expect(footer.contact).not.toHaveProperty('navigationTitle');
+    expect(footer.contact).not.toHaveProperty('socialTitle');
   });
 });

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -629,13 +629,10 @@ export interface SocialLinks {
 }
 
 export interface ContactInfo {
-  heading: string;
-  description: string;
-  navigationTitle: string;
-  socialTitle: string;
   email: string;
   social: SocialLinks;
   copyright: string;
+  admin: NavLink;
 }
 
 export interface FooterData {

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -331,15 +331,12 @@ export function assertValidLoginPage(data: unknown): void {
 export function assertValidFooter(data: unknown): void {
   const footer = requireRecord(data, 'footer');
   const contact = requireRecord(footer.contact, 'footer.contact');
-  requireString(contact, 'heading', 'footer.contact');
-  requireString(contact, 'description', 'footer.contact');
-  requireString(contact, 'navigationTitle', 'footer.contact');
-  requireString(contact, 'socialTitle', 'footer.contact');
   requireString(contact, 'email', 'footer.contact');
   requireString(contact, 'copyright', 'footer.contact');
   const social = requireRecord(contact.social, 'footer.contact.social');
   requireString(social, 'github', 'footer.contact.social');
   requireString(social, 'linkedin', 'footer.contact.social');
+  assertCta(contact.admin, 'footer.contact.admin');
 }
 
 export function assertValidAdminPage(data: unknown): void {


### PR DESCRIPTION
## Summary
- Replace the frosted header bar and three-column footer with quiet overlay Chrome on every `SitePage` route, matching the approved Home narrative preview.
- Header: small wordmark to `/`, doors About / Portfolio / Labs / Blog from data, sun/moon theme toggle, no Home or Admin, no frost, border, or active underline.
- Footer: wordmark fitted to the door row, the same public doors, email, GitHub, LinkedIn, copyright, and Admin last and quiet. No slogan, column headings, or sign-out.

## Test plan
- [ ] Home, About, Portfolio, Labs, Blog, and Sign-in all show the new header and footer.
- [ ] Header has no frosted bar, bottom border, Home link, or Admin link; wordmark goes to `/`.
- [ ] Theme toggle is a sun/moon icon and switches light/dark.
- [ ] Footer doors match the header; Admin is last and quiet; no `Get in Touch` / slogan / sign-out.
- [ ] Mobile menu still offers About, Portfolio, Labs, and Blog.
- [ ] Login, Admin, and Lab product interiors are unchanged aside from inheriting this Chrome via `SitePage`.
- [ ] `npm test` passes.

Fixes #245

Made with [Cursor](https://cursor.com)