### PR TITLE
Loop primitive and Claim/Statement/Proof Home data (#246)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,3 +108,81 @@ button:focus-visible {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Home Loops — analog VFX on stills (ADR 0011). Motion classes are applied only when in view. */
+.loop-fallback {
+  background:
+    radial-gradient(
+      ellipse at 50% 42%,
+      color-mix(in oklab, var(--muted) 70%, var(--background)) 0%,
+      var(--muted) 100%
+    );
+}
+
+.loop-grain {
+  opacity: 0.22;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+}
+
+.dark .loop-grain {
+  mix-blend-mode: overlay;
+  opacity: 0.28;
+}
+
+.loop-light {
+  background: radial-gradient(
+    ellipse at 50% 40%,
+    transparent 42%,
+    color-mix(in oklab, var(--foreground) 28%, transparent) 100%
+  );
+  opacity: 0.55;
+}
+
+@keyframes loop-drift {
+  from {
+    transform: scale(1.04) translate3d(-0.6%, -0.4%, 0);
+  }
+  to {
+    transform: scale(1.1) translate3d(0.8%, 0.5%, 0);
+  }
+}
+
+@keyframes loop-grain {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(-1.5%, 1%);
+  }
+}
+
+@keyframes loop-light {
+  from {
+    opacity: 0.42;
+  }
+  to {
+    opacity: 0.7;
+  }
+}
+
+.loop-plate-motion {
+  animation: loop-drift 28s ease-in-out infinite alternate;
+}
+
+.loop-grain-motion {
+  animation: loop-grain 0.9s steps(2) infinite;
+}
+
+.loop-light-motion {
+  animation: loop-light 12s ease-in-out infinite alternate;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loop-plate-motion,
+  .loop-grain-motion,
+  .loop-light-motion {
+    animation: none;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,21 @@
 import dynamic from "next/dynamic";
 import { SitePage } from "@/components/layout/site-page";
 import { HeroSection } from "@/components/sections/homepage/hero-section";
-import { home, careerProfile, getHomeExperienceView } from "@/data";
-import { getRecentBlogPostsFromSiteContent } from "@/lib/site-content/server";
+import { careerProfile, getHomeExperienceView, site } from "@/data";
 import { getHomePhotographyTeaser } from "@/lib/site-content/server";
 
 export const revalidate = 60;
-
-const AboutSection = dynamic(() => import("@/components/sections/shared/prose-section").then(mod => ({ default: mod.ProseSection })), {
-  loading: () => <div className="min-h-screen" />,
-});
-
-const PhotographySection = dynamic(() => import("@/components/sections/homepage/photography-section").then(mod => ({ default: mod.PhotographySection })), {
-  loading: () => <div className="min-h-screen" />,
-});
 
 const ExperienceListing = dynamic(() => import("@/components/sections/shared/experience-listing").then(mod => ({ default: mod.ExperienceListing })), {
   loading: () => <div className="min-h-screen" />,
 });
 
-const BlogSection = dynamic(() => import("@/components/sections/homepage/blog-section").then(mod => ({ default: mod.BlogSection })), {
-  loading: () => <div className="min-h-[600px]" />,
-});
-
 export default async function Home() {
-  const [blogPosts, teaser] = await Promise.all([
-    getRecentBlogPostsFromSiteContent(3),
-    getHomePhotographyTeaser(),
-  ]);
-
-  const photography = {
-    ...home.photography,
-    images: teaser ? [teaser] : [],
-  };
+  const teaser = await getHomePhotographyTeaser();
 
   return (
     <SitePage>
-      <HeroSection {...home.hero} media={teaser} />
-      <AboutSection id="about" {...home.about} />
-      <PhotographySection {...photography} />
-      <BlogSection {...home.blog} posts={blogPosts} />
+      <HeroSection name={site.brandName} title={site.person.jobTitle} media={teaser} />
       <ExperienceListing {...getHomeExperienceView(careerProfile)} id="experience" />
     </SitePage>
   );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -39,3 +39,7 @@ export type { SectionBackgroundVariant } from "./backgrounds";
 // Home hero atmosphere (photo + CSS fallback)
 export { HeroMedia, HeroFallback } from "./hero-media";
 export type { HeroMediaProps } from "./hero-media";
+
+// Home Loops (treated stills)
+export { Loop } from "./loop";
+export type { LoopProps, LoopState } from "./loop";

--- a/src/components/ui/loop/index.ts
+++ b/src/components/ui/loop/index.ts
@@ -1,0 +1,2 @@
+export { Loop } from "./loop";
+export type { LoopProps, LoopState } from "./loop";

--- a/src/components/ui/loop/loop.test.tsx
+++ b/src/components/ui/loop/loop.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Loop } from "@/components/ui/loop/loop";
+
+vi.mock("next/image", () => ({
+  default: (props: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} />
+  ),
+}));
+
+function mockMatchMedia(matchesReduced: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes("prefers-reduced-motion") ? matchesReduced : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function mockInView(isIntersecting: boolean) {
+  Object.defineProperty(window, "IntersectionObserver", {
+    writable: true,
+    value: class {
+      callback: IntersectionObserverCallback;
+      constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+      }
+      observe() {
+        this.callback(
+          [{ isIntersecting } as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+    },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  mockMatchMedia(false);
+  mockInView(false);
+});
+
+describe("Loop", () => {
+  it("freezes analog motion when reduced motion is preferred", () => {
+    mockMatchMedia(true);
+    mockInView(true);
+
+    const { container } = render(
+      <div className="relative h-40">
+        <Loop src="/loops/claim-poster.webp" />
+      </div>,
+    );
+
+    const root = container.querySelector("[data-loop]");
+    expect(root).toHaveAttribute("data-loop", "frozen");
+    expect(root).toHaveAttribute("aria-hidden", "true");
+    expect(container.querySelector(".loop-grain-motion")).toBeNull();
+    expect(container.querySelector(".loop-plate-motion")).toBeNull();
+    expect(container.querySelector("canvas")).toBeNull();
+    expect(container.querySelector("img")).toHaveAttribute("src", "/loops/claim-poster.webp");
+  });
+
+  it("uses an intentional CSS fallback when the still is missing", () => {
+    mockMatchMedia(false);
+    mockInView(true);
+
+    const { container } = render(
+      <div className="relative h-40">
+        <Loop src={null} />
+      </div>,
+    );
+
+    const root = container.querySelector("[data-loop]");
+    expect(root).toHaveAttribute("data-loop", "fallback");
+    expect(root).toHaveAttribute("aria-hidden", "true");
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector(".loop-fallback")).toBeTruthy();
+    expect(container.querySelector(".loop-grain-motion")).toBeNull();
+    expect(container.querySelector("canvas")).toBeNull();
+  });
+
+  it("applies analog motion only when the still is in view", () => {
+    mockMatchMedia(false);
+    mockInView(true);
+
+    const { container } = render(
+      <div className="relative h-40">
+        <Loop src="/loops/writer-poster.webp" />
+      </div>,
+    );
+
+    expect(container.querySelector("[data-loop]")).toHaveAttribute("data-loop", "live");
+    expect(container.querySelector(".loop-grain-motion")).toBeTruthy();
+    expect(container.querySelector(".loop-plate-motion")).toBeTruthy();
+    expect(container.querySelector(".loop-light-motion")).toBeTruthy();
+
+    cleanup();
+    mockInView(false);
+
+    const frozen = render(
+      <div className="relative h-40">
+        <Loop src="/loops/writer-poster.webp" />
+      </div>,
+    );
+
+    expect(frozen.container.querySelector("[data-loop]")).toHaveAttribute("data-loop", "frozen");
+    expect(frozen.container.querySelector(".loop-grain-motion")).toBeNull();
+  });
+});

--- a/src/components/ui/loop/loop.tsx
+++ b/src/components/ui/loop/loop.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { cn } from "@/lib/utils";
+
+export interface LoopProps {
+  src?: string | null;
+  className?: string;
+  objectPosition?: string;
+}
+
+export type LoopState = "live" | "frozen" | "fallback";
+
+function useInView(elementRef: RefObject<HTMLElement | null>): boolean {
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setInView(entry.isIntersecting);
+      },
+      { threshold: 0.15 },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [elementRef]);
+
+  return inView;
+}
+
+export function Loop({ src, className, objectPosition = "center" }: LoopProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(rootRef);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const hasSrc = typeof src === "string" && src.length > 0;
+
+  const state: LoopState = !hasSrc
+    ? "fallback"
+    : inView && !prefersReducedMotion
+      ? "live"
+      : "frozen";
+  const motion = state === "live";
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn("pointer-events-none absolute inset-0 overflow-hidden", className)}
+      aria-hidden="true"
+      data-loop={state}
+    >
+      <div className={cn("loop-plate absolute inset-0", motion && "loop-plate-motion")}>
+        {hasSrc ? (
+          <Image
+            src={src}
+            alt=""
+            fill
+            sizes="100vw"
+            className="object-cover"
+            style={{ objectPosition }}
+            quality={85}
+          />
+        ) : (
+          <div className="loop-fallback absolute inset-0" />
+        )}
+      </div>
+      <div className={cn("loop-grain absolute inset-0", motion && "loop-grain-motion")} />
+      <div className={cn("loop-light absolute inset-0", motion && "loop-light-motion")} />
+    </div>
+  );
+}

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -63,6 +63,8 @@ import { careerProfile, getHomeExperienceView, getAboutCareerViews } from "@/dat
 const careerViews = getAboutCareerViews(careerProfile);
 ```
 
+Home (`pages/home.json`) is Claim → Statement → Proof. Claim Roles use the `ClaimRole` type (not career `Role`). Proof doors live under `proof.doors`. Career listings are not part of Home.
+
 Page JSON under `pages/` holds shell content only. It does not duplicate career structured data.
 
 ## Validation

--- a/src/data/page-data.test.ts
+++ b/src/data/page-data.test.ts
@@ -15,6 +15,31 @@ import {
 } from '@/data';
 
 describe('getPageData', () => {
+  it('describes Home as Claim, Statement, and Proof with doors in data', () => {
+    expect(home).not.toHaveProperty('hero');
+    expect(home).not.toHaveProperty('about');
+    expect(home).not.toHaveProperty('photography');
+    expect(home).not.toHaveProperty('blog');
+    expect(home.claim.lockup).toEqual(['hasha', 'dar']);
+    expect(home.claim.roles.map((role) => role.question)).toEqual([
+      'consultant?',
+      'photographer?',
+      'software developer?',
+      'writer?',
+    ]);
+    expect(home.claim.landingLine).toBe('all of the above.');
+    expect(home.claim.loopSrc).toBe('/loops/claim-poster.webp');
+    expect(home.statement.headline).toBe('One practice, not a menu.');
+    expect(home.statement.cta).toEqual({ label: 'About', href: '/about' });
+    expect(home.proof.doors.map((door) => ({ id: door.id, href: door.href, media: door.media }))).toEqual([
+      { id: 'consultant', href: '/about', media: 'loop' },
+      { id: 'photographer', href: '/portfolio', media: 'photo' },
+      { id: 'developer', href: '/labs', media: 'loop' },
+      { id: 'writer', href: '/blog', media: 'loop' },
+    ]);
+    expect(home.proof.doors.find((door) => door.id === 'developer')?.href).toBe('/labs');
+  });
+
   it('returns the matching page data for every public route', () => {
     expect(getPageData('/')).toBe(home);
     expect(getPageData('/home')).toBe(home);

--- a/src/data/pages/home.json
+++ b/src/data/pages/home.json
@@ -1,29 +1,53 @@
 {
-  "hero": {
-    "name": "hasha dar",
-    "title": "AI & Data Consultant"
+  "claim": {
+    "lockup": ["hasha", "dar"],
+    "roles": [
+      { "id": "consultant", "question": "consultant?" },
+      { "id": "photographer", "question": "photographer?" },
+      { "id": "developer", "question": "software developer?" },
+      { "id": "writer", "question": "writer?" }
+    ],
+    "landingLine": "all of the above.",
+    "loopSrc": "/loops/claim-poster.webp",
+    "loopObjectPosition": "center 78%"
   },
-  "about": {
-    "heading": "About",
-    "content": "I'm a Consultant at Deloitte, in the AI & Data department. My work involves helping our clients implement AI solutions and manage their data effectively. I hold a mechanical engineering degree from UCL, graduating in 2023. In my free time, I develop apps and do photography. I primarily shoot a mixture of portraiture, travel and event. I also enjoy theatre, where I worked as a production manager and contributed to sound and lighting design.",
+  "statement": {
+    "headline": "One practice, not a menu.",
+    "paragraph": "Consulting, photographs, tools, and writing are not hobbies stacked on a job. They are one way of looking, and of making.",
     "cta": {
-      "label": "Learn more about me",
+      "label": "About",
       "href": "/about"
     }
   },
-  "photography": {
-    "heading": "Photography",
-    "description": "Moments captured in portraiture, travel, and theatre.",
-    "images": []
-  },
-  "blog": {
-    "heading": "Blog",
-    "description": "My thoughts in one place.",
-    "cta": {
-      "label": "View all posts",
-      "href": "/blog"
-    },
-    "emptyState": "No blog posts yet. Check back soon!"
+  "proof": {
+    "doors": [
+      {
+        "id": "consultant",
+        "label": "consultant",
+        "href": "/about",
+        "media": "loop",
+        "src": "/loops/consultant-poster.webp"
+      },
+      {
+        "id": "photographer",
+        "label": "photographer",
+        "href": "/portfolio",
+        "media": "photo"
+      },
+      {
+        "id": "developer",
+        "label": "software developer",
+        "href": "/labs",
+        "media": "loop",
+        "src": "/loops/developer-poster.webp"
+      },
+      {
+        "id": "writer",
+        "label": "writer",
+        "href": "/blog",
+        "media": "loop",
+        "src": "/loops/writer-poster.webp"
+      }
+    ]
   }
 }
-

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -96,11 +96,48 @@ export interface BlogSection {
   emptyState?: string;
 }
 
+/** Home Role on the Claim — not career `Role`. */
+export interface ClaimRole {
+  id: string;
+  question: string;
+}
+
+export type ProofMedia = 'loop' | 'photo';
+
+export interface ProofDoor {
+  id: string;
+  label: string;
+  href: string;
+  media: ProofMedia;
+  /** Loop still under `/loops/`; omitted for the photographer Photograph. */
+  src?: string;
+}
+
+export interface HomeClaim {
+  lockup: string[];
+  roles: ClaimRole[];
+  landingLine: string;
+  loopSrc: string;
+  loopObjectPosition?: string;
+}
+
+export interface HomeStatement {
+  headline: string;
+  paragraph: string;
+  cta: {
+    label: string;
+    href: string;
+  };
+}
+
+export interface HomeProof {
+  doors: ProofDoor[];
+}
+
 export interface HomePageData {
-  hero: HeroSection;
-  about: AboutSection;
-  photography: PhotographySection;
-  blog: BlogSection;
+  claim: HomeClaim;
+  statement: HomeStatement;
+  proof: HomeProof;
 }
 
 export interface PortfolioPageData {

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -42,6 +42,28 @@ describe('validateDataFile', () => {
     ).toThrow(/pages\/home\.json/);
   });
 
+  it('rejects a catalogue Home shape', () => {
+    expect(() =>
+      validateDataFile(
+        'pages/home.json',
+        { ...homeData, about: { heading: 'About', content: 'x' } },
+        assertValidHomePage,
+      ),
+    ).toThrow(/catalogue block "about"/);
+  });
+
+  it('rejects a loop Proof door without a still', () => {
+    const invalid = structuredClone(homeData) as {
+      proof: { doors: Array<{ media: string; src?: string }> };
+    };
+    const door = invalid.proof.doors.find((entry) => entry.media === 'loop');
+    delete door?.src;
+
+    expect(() =>
+      validateDataFile('pages/home.json', invalid, assertValidHomePage),
+    ).toThrow(/src/);
+  });
+
   it('accepts all golden content JSON files', () => {
     expect(() =>
       validateDataFile('pages/about.json', aboutData, assertValidAboutPage),

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -71,19 +71,72 @@ export function validateDataFile(
   }
 }
 
+const HOME_ROLE_COUNT = 4;
+const PROOF_MEDIA = new Set(['loop', 'photo']);
+
+function assertClaimRole(value: unknown, context: string): Record<string, unknown> {
+  const role = requireRecord(value, context);
+  requireString(role, 'id', context);
+  requireString(role, 'question', context);
+  return role;
+}
+
+function assertProofDoor(value: unknown, context: string): Record<string, unknown> {
+  const door = requireRecord(value, context);
+  requireString(door, 'id', context);
+  requireString(door, 'label', context);
+  requireString(door, 'href', context);
+  const media = requireString(door, 'media', context);
+  if (!PROOF_MEDIA.has(media)) {
+    fail(`${context}: media must be "loop" or "photo"`);
+  }
+  if (media === 'loop') {
+    requireString(door, 'src', context);
+  }
+  return door;
+}
+
 export function assertValidHomePage(data: unknown): void {
   const page = requireRecord(data, 'home');
-  const hero = requireRecord(page.hero, 'home.hero');
-  requireString(hero, 'name', 'home.hero');
-  requireString(hero, 'title', 'home.hero');
-  assertAboutSection(page.about, 'home.about');
-  const photography = requireRecord(page.photography, 'home.photography');
-  requireString(photography, 'heading', 'home.photography');
-  requireArray(photography.images, 'home.photography.images').forEach((image, index) =>
-    assertPhotoItem(image, `home.photography.images[${index}]`),
-  );
-  const blog = requireRecord(page.blog, 'home.blog');
-  requireString(blog, 'heading', 'home.blog');
+  for (const retired of ['hero', 'about', 'photography', 'blog', 'experience'] as const) {
+    if (page[retired] !== undefined) {
+      fail(`home: unexpected catalogue block "${retired}"`);
+    }
+  }
+
+  const claim = requireRecord(page.claim, 'home.claim');
+  const lockup = requireArray(claim.lockup, 'home.claim.lockup');
+  if (lockup.length !== 2 || lockup.some((line) => typeof line !== 'string' || line.length === 0)) {
+    fail('home.claim.lockup: expected two non-empty strings');
+  }
+  requireString(claim, 'landingLine', 'home.claim');
+  requireString(claim, 'loopSrc', 'home.claim');
+  if (claim.loopObjectPosition !== undefined) {
+    requireString(claim, 'loopObjectPosition', 'home.claim');
+  }
+
+  const roles = requireArray(claim.roles, 'home.claim.roles');
+  if (roles.length !== HOME_ROLE_COUNT) {
+    fail(`home.claim.roles: expected ${HOME_ROLE_COUNT} roles`);
+  }
+  const roleIds = roles.map((role, index) => assertClaimRole(role, `home.claim.roles[${index}]`).id);
+
+  const statement = requireRecord(page.statement, 'home.statement');
+  requireString(statement, 'headline', 'home.statement');
+  requireString(statement, 'paragraph', 'home.statement');
+  assertCta(statement.cta, 'home.statement.cta');
+
+  const proof = requireRecord(page.proof, 'home.proof');
+  const doors = requireArray(proof.doors, 'home.proof.doors');
+  if (doors.length !== HOME_ROLE_COUNT) {
+    fail(`home.proof.doors: expected ${HOME_ROLE_COUNT} doors`);
+  }
+  doors.forEach((door, index) => {
+    const entry = assertProofDoor(door, `home.proof.doors[${index}]`);
+    if (entry.id !== roleIds[index]) {
+      fail(`home.proof.doors[${index}].id must match home.claim.roles[${index}].id`);
+    }
+  });
 }
 
 export function assertValidAboutPage(data: unknown): void {


### PR DESCRIPTION
## Summary
- Replace catalogue Home JSON with Claim, Statement, and Proof. Role questions and Proof doors live in data; Home Roles are `ClaimRole` so they do not collide with career `Role`.
- Add a CSS Loop primitive: still image plus grain, idle drift, and light breathe when in view. Reduced motion or a missing still freezes it; no video, canvas, or R3F.
- Home no longer renders About, photography, or blog blocks because that copy left `home.json`. Experience stays until #248. Claim and Proof UI are #247 / #248.

## Test plan
- [ ] `npm test` passes, including Home data validate, Loop reduced-motion freeze, and missing-src fallback.
- [ ] `/` still loads (name/title hero + Experience) with no About / photography / blog sections.
- [ ] `/about` still loads.
- [ ] Loop is not mounted on Home yet; inspect `<Loop>` tests / later Claim wiring for analog motion.
- [ ] Loop stills in data point at `/loops/claim-poster.webp`, `consultant-poster.webp`, `developer-poster.webp`, and `writer-poster.webp`.

Fixes #246

Made with [Cursor](https://cursor.com)