### PR TITLE
Home narrative Phase 3: Claim first viewport (#247)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,14 +120,35 @@ button:focus-visible {
 }
 
 .loop-grain {
-  opacity: 0.22;
+  opacity: 0.28;
   mix-blend-mode: multiply;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
 }
 
 .dark .loop-grain {
   mix-blend-mode: overlay;
-  opacity: 0.28;
+  opacity: 0.34;
+}
+
+.loop-flash {
+  background: #fff6ea;
+  opacity: 0;
+  mix-blend-mode: overlay;
+  -webkit-backdrop-filter: blur(0);
+  backdrop-filter: blur(0);
+}
+
+.dark .loop-flash {
+  background: #ffffff;
+  mix-blend-mode: soft-light;
+}
+
+.loop-plate img {
+  transition: filter 0.2s ease;
+}
+
+.dark .loop-plate img {
+  filter: invert(1) hue-rotate(180deg);
 }
 
 .loop-light {
@@ -154,7 +175,76 @@ button:focus-visible {
     transform: translate(0, 0);
   }
   50% {
-    transform: translate(-1.5%, 1%);
+    transform: translate(-0.9%, 0.6%);
+  }
+}
+
+@keyframes loop-reel-flash {
+  0%,
+  78% {
+    opacity: 0;
+    -webkit-backdrop-filter: blur(0);
+    backdrop-filter: blur(0);
+  }
+  80.2% {
+    opacity: 0.07;
+    -webkit-backdrop-filter: blur(3px);
+    backdrop-filter: blur(3px);
+  }
+  80.7% {
+    opacity: 0;
+    -webkit-backdrop-filter: blur(0);
+    backdrop-filter: blur(0);
+  }
+  81.3% {
+    opacity: 0.14;
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+  }
+  82.4% {
+    opacity: 0;
+    -webkit-backdrop-filter: blur(0);
+    backdrop-filter: blur(0);
+  }
+  93%,
+  100% {
+    opacity: 0;
+    -webkit-backdrop-filter: blur(0);
+    backdrop-filter: blur(0);
+  }
+}
+
+@keyframes loop-plate-blur {
+  0%,
+  78%,
+  80.7%,
+  82.4%,
+  93%,
+  100% {
+    filter: blur(0);
+  }
+  80.2% {
+    filter: blur(2px);
+  }
+  81.3% {
+    filter: blur(5px);
+  }
+}
+
+@keyframes loop-plate-blur-dark {
+  0%,
+  78%,
+  80.7%,
+  82.4%,
+  93%,
+  100% {
+    filter: invert(1) hue-rotate(180deg) blur(0);
+  }
+  80.2% {
+    filter: invert(1) hue-rotate(180deg) blur(2px);
+  }
+  81.3% {
+    filter: invert(1) hue-rotate(180deg) blur(5px);
   }
 }
 
@@ -171,8 +261,21 @@ button:focus-visible {
   animation: loop-drift 28s ease-in-out infinite alternate;
 }
 
+.loop-plate-motion img {
+  transition: none;
+  animation: loop-plate-blur 11s linear infinite;
+}
+
+.dark .loop-plate-motion img {
+  animation: loop-plate-blur-dark 11s linear infinite;
+}
+
 .loop-grain-motion {
-  animation: loop-grain 0.9s steps(2) infinite;
+  animation: loop-grain 2.8s steps(2) infinite;
+}
+
+.loop-flash-motion {
+  animation: loop-reel-flash 11s linear infinite;
 }
 
 .loop-light-motion {
@@ -181,8 +284,14 @@ button:focus-visible {
 
 @media (prefers-reduced-motion: reduce) {
   .loop-plate-motion,
+  .loop-plate-motion img,
   .loop-grain-motion,
+  .loop-flash-motion,
   .loop-light-motion {
     animation: none;
+  }
+
+  .loop-plate img {
+    transition: none;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,7 @@
 import dynamic from "next/dynamic";
 import { SitePage } from "@/components/layout/site-page";
 import { HeroSection } from "@/components/sections/homepage/hero-section";
-import { careerProfile, getHomeExperienceView, site } from "@/data";
-import { getHomePhotographyTeaser } from "@/lib/site-content/server";
+import { careerProfile, getHomeExperienceView, home } from "@/data";
 
 export const revalidate = 60;
 
@@ -10,12 +9,10 @@ const ExperienceListing = dynamic(() => import("@/components/sections/shared/exp
   loading: () => <div className="min-h-screen" />,
 });
 
-export default async function Home() {
-  const teaser = await getHomePhotographyTeaser();
-
+export default function Home() {
   return (
     <SitePage>
-      <HeroSection name={site.brandName} title={site.person.jobTitle} media={teaser} />
+      <HeroSection claim={home.claim} />
       <ExperienceListing {...getHomeExperienceView(careerProfile)} id="experience" />
     </SitePage>
   );

--- a/src/components/layout/site-page.test.tsx
+++ b/src/components/layout/site-page.test.tsx
@@ -57,10 +57,7 @@ describe('SitePage', () => {
     const header = screen.getByRole('banner');
     expect(within(header).queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
     expect(within(header).queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
-    expect(within(header).getByRole('link', { name: site.brandName })).toHaveAttribute(
-      'href',
-      '/',
-    );
+    expect(within(header).queryByRole('link', { name: site.brandName })).not.toBeInTheDocument();
 
     for (const link of navigation.links) {
       expect(within(header).getByRole('link', { name: link.label })).toHaveAttribute(
@@ -111,6 +108,7 @@ describe('SitePage', () => {
     const adminLink = footerLinks[footerLinks.length - 1];
     expect(adminLink).toHaveAttribute('href', footer.contact.admin.href);
     expect(adminLink).toHaveTextContent(footer.contact.admin.label);
+    expect(siteFooter.querySelector('.container')).toBeNull();
   });
 
   it('applies optional mainClassName to the main landmark', () => {

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -47,7 +47,7 @@ export function FooterSection() {
 
   return (
     <footer className="border-t border-[var(--border)] bg-[var(--background)]">
-      <div className="container mx-auto px-6">
+      <div className="w-full px-6">
         <div className="grid gap-6 py-12 md:grid-cols-[1fr_auto] md:items-end">
           <div className="w-max">
             <p

--- a/src/components/sections/homepage/fit-claim-lockup.test.ts
+++ b/src/components/sections/homepage/fit-claim-lockup.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { fitClaimLockup } from "@/components/sections/homepage/fit-claim-lockup";
+
+function mockLineWidth(line: HTMLElement, widthAtProbe: number, probe: number) {
+  line.getBoundingClientRect = () => {
+    const size = parseFloat(line.style.fontSize) || probe;
+    const width = widthAtProbe * (size / probe);
+    return {
+      width,
+      height: size * 0.8,
+      top: 0,
+      left: 0,
+      bottom: size * 0.8,
+      right: width,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    };
+  };
+}
+
+function createLockup({
+  availableWidth,
+  availableHeight,
+  hashaWidthAtProbe,
+  darWidthAtProbe,
+  probe = 80,
+}: {
+  availableWidth: number;
+  availableHeight: number;
+  hashaWidthAtProbe: number;
+  darWidthAtProbe: number;
+  probe?: number;
+}) {
+  const lockup = document.createElement("h1");
+  const hasha = document.createElement("span");
+  const dar = document.createElement("span");
+  hasha.textContent = "hasha";
+  dar.textContent = "dar";
+  lockup.append(hasha, dar);
+
+  Object.defineProperty(lockup, "clientWidth", { get: () => availableWidth });
+  Object.defineProperty(lockup, "clientHeight", { get: () => availableHeight });
+  Object.defineProperty(lockup, "scrollHeight", {
+    get: () => {
+      const size = parseFloat(hasha.style.fontSize) || probe;
+      return size * 0.8 * 2;
+    },
+  });
+
+  mockLineWidth(hasha, hashaWidthAtProbe, probe);
+  mockLineWidth(dar, darWidthAtProbe, probe);
+
+  return { lockup, hasha, dar };
+}
+
+describe("fitClaimLockup", () => {
+  it("shares one font size and stays inside a landscape viewport without stretching dar", () => {
+    const { lockup, hasha, dar } = createLockup({
+      availableWidth: 800,
+      availableHeight: 200,
+      hashaWidthAtProbe: 400,
+      darWidthAtProbe: 240,
+    });
+
+    fitClaimLockup(lockup);
+
+    expect(hasha.style.fontSize).toBe(dar.style.fontSize);
+    expect(lockup.scrollHeight).toBeLessThanOrEqual(lockup.clientHeight);
+    expect(dar.getBoundingClientRect().width).toBeLessThan(lockup.clientWidth);
+    expect(hasha.getBoundingClientRect().width).toBeLessThanOrEqual(lockup.clientWidth);
+  });
+
+  it("scales back down when the rendered glyphs are wider than the probe suggested", () => {
+    const { lockup, hasha, dar } = createLockup({
+      availableWidth: 800,
+      availableHeight: 600,
+      hashaWidthAtProbe: 400,
+      darWidthAtProbe: 240,
+    });
+
+    hasha.getBoundingClientRect = () => {
+      const size = parseFloat(hasha.style.fontSize) || 80;
+      const linear = 400 * (size / 80);
+      const width = size === 80 ? linear : linear * 1.19;
+      return {
+        width,
+        height: size * 0.8,
+        top: 0,
+        left: 0,
+        bottom: size * 0.8,
+        right: width,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+    };
+
+    fitClaimLockup(lockup);
+
+    expect(hasha.style.fontSize).toBe(dar.style.fontSize);
+    expect(hasha.getBoundingClientRect().width).toBeLessThanOrEqual(lockup.clientWidth);
+  });
+});

--- a/src/components/sections/homepage/fit-claim-lockup.ts
+++ b/src/components/sections/homepage/fit-claim-lockup.ts
@@ -1,0 +1,46 @@
+const CLAIM_LOCKUP_PROBE_PX = 80;
+const CLAIM_LOCKUP_WIDTH_FILL = 0.99;
+
+function applySharedSize(lines: HTMLElement[], size: number) {
+  for (const line of lines) {
+    line.style.fontSize = `${size}px`;
+  }
+}
+
+function longestLineWidth(lines: HTMLElement[]) {
+  return Math.max(...lines.map((line) => line.getBoundingClientRect().width));
+}
+
+export function fitClaimLockup(lockup: HTMLElement): void {
+  const lines = [...lockup.querySelectorAll("span")] as HTMLElement[];
+  if (lines.length === 0) return;
+
+  const availableWidth = lockup.clientWidth;
+  const availableHeight = lockup.clientHeight;
+  if (!availableWidth || !availableHeight) return;
+
+  const current =
+    parseFloat(lines[0].style.fontSize) ||
+    parseFloat(getComputedStyle(lines[0]).fontSize) ||
+    CLAIM_LOCKUP_PROBE_PX;
+
+  applySharedSize(lines, current);
+
+  const longest = longestLineWidth(lines);
+  if (!longest) return;
+
+  let size = current * ((availableWidth * CLAIM_LOCKUP_WIDTH_FILL) / longest);
+  applySharedSize(lines, size);
+
+  for (let pass = 0; pass < 2; pass += 1) {
+    const overflowWidth = longestLineWidth(lines);
+    if (overflowWidth <= availableWidth) break;
+    size *= availableWidth / overflowWidth;
+    applySharedSize(lines, size);
+  }
+
+  if (lockup.scrollHeight > availableHeight) {
+    size *= availableHeight / lockup.scrollHeight;
+    applySharedSize(lines, size);
+  }
+}

--- a/src/components/sections/homepage/hero-section.test.tsx
+++ b/src/components/sections/homepage/hero-section.test.tsx
@@ -1,11 +1,12 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { home } from "@/data";
 import { HeroSection } from "@/components/sections/homepage/hero-section";
 
 vi.mock("next/image", () => ({
   default: (props: { alt: string; src: string }) => (
     // eslint-disable-next-line @next/next/no-img-element
-    <img alt={props.alt} src={props.src} data-testid="hero-media-image" />
+    <img alt={props.alt} src={props.src} />
   ),
 }));
 
@@ -28,54 +29,121 @@ function mockMatchMedia(matchesReduced: boolean) {
 afterEach(() => {
   cleanup();
   mockMatchMedia(false);
+  vi.useRealTimers();
 });
 
 describe("HeroSection", () => {
-  it("keeps brand typography in the DOM with media atmosphere", () => {
+  it("renders the name as a two-line lockup, not a job title headline", () => {
     mockMatchMedia(false);
 
-    const { container } = render(
-      <HeroSection
-        name="Hasha Dar"
-        title="Software Engineer"
-        media={{
-          src: "https://example.com/hero.webp",
-          alt: "Travel portrait",
-          title: "Teaser",
-        }}
-      />,
-    );
+    render(<HeroSection claim={home.claim} />);
 
-    expect(screen.getByRole("heading", { level: 1, name: "Hasha Dar" })).toBeInTheDocument();
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("hasha");
+    expect(heading).toHaveTextContent("dar");
+    expect(heading.querySelectorAll("span")).toHaveLength(2);
     expect(
-      screen.getByRole("heading", { level: 2, name: "Software Engineer" }),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("hero-media-image")).toBeInTheDocument();
-    expect(container.querySelector("canvas")).toBeNull();
-
-    const atmosphere = container.querySelector('[aria-hidden="true"]');
-    expect(atmosphere).toBeTruthy();
-    expect(atmosphere).toHaveClass("pointer-events-none");
+      screen.queryByRole("heading", { name: /AI & Data Consultant|Software Engineer/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("shows CSS fallback when media is missing", () => {
+  it("places the Claim Loop behind the lockup and falls back when the still is missing", () => {
     mockMatchMedia(false);
-    const { container } = render(
-      <HeroSection name="Hasha Dar" title="Software Engineer" media={null} />,
-    );
 
-    expect(screen.getByRole("heading", { level: 1, name: "Hasha Dar" })).toBeInTheDocument();
-    expect(screen.queryByTestId("hero-media-image")).not.toBeInTheDocument();
-    expect(container.querySelector('[aria-hidden="true"]')).toBeTruthy();
+    const { container, rerender } = render(<HeroSection claim={home.claim} />);
+
+    const loop = container.querySelector("[data-loop]");
+    expect(loop).toHaveAttribute("aria-hidden", "true");
+    expect(container.querySelector("img")).toHaveAttribute("src", home.claim.loopSrc);
+
+    rerender(<HeroSection claim={{ ...home.claim, loopSrc: "" }} />);
+    expect(container.querySelector("[data-loop]")).toHaveAttribute("data-loop", "fallback");
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+    expect(container.querySelector(".loop-fallback")).toBeTruthy();
   });
 
-  it("still shows brand text when reduced motion is preferred", () => {
+  it("shows the name and four Roles statically when reduced motion is preferred", () => {
     mockMatchMedia(true);
-    render(<HeroSection name="Hasha Dar" title="Software Engineer" />);
 
-    expect(screen.getByRole("heading", { level: 1, name: "Hasha Dar" })).toBeVisible();
-    expect(
-      screen.getByRole("heading", { level: 2, name: "Software Engineer" }),
-    ).toBeVisible();
+    render(<HeroSection claim={home.claim} />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("hasha");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("dar");
+
+    const staticLine = screen.getByText(
+      "consultant? photographer? software developer? writer?",
+    );
+    expect(staticLine).toHaveTextContent("consultant?");
+    expect(staticLine).toHaveTextContent("photographer?");
+    expect(staticLine).toHaveTextContent("software developer?");
+    expect(staticLine).toHaveTextContent("writer?");
+    expect(staticLine).not.toHaveTextContent("all of the above.");
+    expect(staticLine).not.toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("keeps Roles as static text, not a live region", () => {
+    mockMatchMedia(false);
+
+    const { container } = render(<HeroSection claim={home.claim} />);
+
+    expect(container.querySelector("[aria-live]")).toBeNull();
+    const forAssistiveTech = screen.getByText(
+      "consultant? photographer? software developer? writer?",
+    );
+    expect(forAssistiveTech).not.toHaveAttribute("aria-hidden", "true");
+    expect(forAssistiveTech).not.toHaveAttribute("aria-live");
+  });
+
+  it("loops Roles through the four questions and never lands on the closing line", () => {
+    mockMatchMedia(false);
+    vi.useFakeTimers();
+
+    const { container } = render(<HeroSection claim={home.claim} />);
+    const ticker = [...container.querySelectorAll("p")].find(
+      (node) => node.getAttribute("aria-hidden") === "true",
+    );
+
+    expect(ticker).toHaveTextContent("consultant?");
+
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(ticker).toHaveTextContent("photographer?");
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(ticker).toHaveTextContent("software developer?");
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(ticker).toHaveTextContent("writer?");
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(ticker).toHaveTextContent("consultant?");
+    expect(ticker).not.toHaveTextContent("all of the above.");
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(ticker).toHaveTextContent("photographer?");
+  });
+
+  it("keeps the lockup unclipped on a landscape reduced-motion Claim", () => {
+    mockMatchMedia(true);
+
+    const { container } = render(<HeroSection claim={home.claim} />);
+    const heading = screen.getByRole("heading", { level: 1 });
+    const lockup = container.querySelector("[data-claim-lockup]");
+
+    expect(lockup).toHaveClass("overflow-visible");
+    expect(heading).toHaveClass("overflow-visible");
+    for (const line of heading.querySelectorAll("span")) {
+      expect(line).toHaveClass("whitespace-nowrap");
+      expect(line.className).not.toMatch(/\bw-full\b/);
+    }
   });
 });

--- a/src/components/sections/homepage/hero-section.tsx
+++ b/src/components/sections/homepage/hero-section.tsx
@@ -1,150 +1,115 @@
 "use client";
 
-import { Container, Heading, HeroFallback, HeroMedia } from "@/components/ui";
-import type { PhotoItem } from "@/data/types";
-import { motion, useScroll, useTransform } from "framer-motion";
-import { useRef } from "react";
+import { Heading, Loop } from "@/components/ui";
+import type { ClaimRole, HomeClaim } from "@/data/types";
 import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
-import {
-  fadeUpDistance,
-  motionDurations,
-  motionEasings,
-  motionSprings,
-} from "@/lib/motion/tokens";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { fitClaimLockup } from "@/components/sections/homepage/fit-claim-lockup";
+
+const ROLE_START_MS = 700;
+const ROLE_STEP_MS = 1100;
+
+const roleLineClassName =
+  "relative z-[3] min-h-[1.4em] px-6 font-body text-[clamp(1.1rem,2.4vw,1.85rem)] font-semibold tracking-[-0.03em] text-[var(--foreground)]";
 
 interface HeroSectionProps {
-  name: string;
-  title: string;
-  /** Site Content home photo; CSS fallback when null/undefined. */
-  media?: PhotoItem | null;
+  claim: HomeClaim;
 }
 
-export function HeroSection({ name, title, media }: HeroSectionProps) {
+function staticRolesText(roles: ClaimRole[]) {
+  return roles.map((role) => role.question).join(" ");
+}
+
+function ClaimRoles({ roles }: { roles: ClaimRole[] }) {
   const prefersReducedMotion = usePrefersReducedMotion();
-  const containerRef = useRef<HTMLElement>(null);
+  const sequence = roles.map((role) => role.question);
+  const [index, setIndex] = useState(0);
 
-  const { scrollYProgress } = useScroll({
-    target: containerRef,
-    offset: ["start start", "end start"],
-  });
+  useEffect(() => {
+    if (prefersReducedMotion || sequence.length === 0) return;
 
-  const contentY = useTransform(
-    scrollYProgress,
-    [0, 1],
-    prefersReducedMotion ? ["0%", "0%"] : ["0%", "28%"],
-  );
-  const contentOpacity = useTransform(
-    scrollYProgress,
-    [0, 0.55],
-    prefersReducedMotion ? [1, 1] : [1, 0],
-  );
-  const mediaScale = useTransform(
-    scrollYProgress,
-    [0, 1],
-    prefersReducedMotion ? [1, 1] : [1, 1.08],
-  );
+    let step = 0;
+    let timer: ReturnType<typeof setTimeout>;
 
-  const enterTransition = prefersReducedMotion
-    ? { duration: 0 }
-    : { ...motionSprings.heroEnter, duration: motionDurations.slow };
+    const tick = () => {
+      step = (step + 1) % sequence.length;
+      setIndex(step);
+      timer = setTimeout(tick, ROLE_STEP_MS);
+    };
+
+    timer = setTimeout(tick, ROLE_START_MS);
+    return () => clearTimeout(timer);
+  }, [prefersReducedMotion, roles, sequence.length]);
+
+  const staticText = staticRolesText(roles);
+
+  if (prefersReducedMotion) {
+    return <p className={roleLineClassName}>{staticText}</p>;
+  }
+
+  return (
+    <>
+      <p className="sr-only">{staticText}</p>
+      <p className={roleLineClassName} aria-hidden="true">
+        {sequence[index]}
+      </p>
+    </>
+  );
+}
+
+export function HeroSection({ claim }: HeroSectionProps) {
+  const lockupRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const lockup = lockupRef.current;
+    if (!lockup) return;
+
+    const fit = () => fitClaimLockup(lockup);
+    fit();
+    void document.fonts?.ready.then(fit);
+    document.fonts?.addEventListener?.("loadingdone", fit);
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => document.fonts?.removeEventListener?.("loadingdone", fit);
+    }
+
+    const observer = new ResizeObserver(fit);
+    observer.observe(lockup);
+    return () => {
+      observer.disconnect();
+      document.fonts?.removeEventListener?.("loadingdone", fit);
+    };
+  }, [claim.lockup]);
 
   return (
     <section
-      ref={containerRef}
-      id="hero"
-      className="relative flex min-h-screen items-end justify-center overflow-hidden bg-[var(--background)] pb-16 pt-24 sm:items-center sm:pb-0 sm:pt-20"
+      id="claim"
+      className="relative flex min-h-screen min-h-[100dvh] flex-col justify-end overflow-hidden bg-[var(--background)] pb-9"
     >
-      {media ? (
-        <HeroMedia
-          media={media}
-          scale={mediaScale}
-          prefersReducedMotion={prefersReducedMotion}
-        />
-      ) : (
-        <HeroFallback />
-      )}
-
-      <Container className="hero-container relative z-10 w-full">
-        <motion.div
-          style={{ y: contentY, opacity: contentOpacity }}
-          className="mx-auto w-full max-w-5xl space-y-8 overflow-visible px-4 text-center sm:px-6 md:space-y-10"
+      <Loop src={claim.loopSrc} objectPosition={claim.loopObjectPosition} />
+      <div
+        ref={lockupRef}
+        data-claim-lockup
+        className="pointer-events-none absolute inset-x-0 top-11 bottom-10 z-[2] overflow-visible"
+      >
+        <Heading
+          size="hero"
+          className="flex h-full w-full flex-col justify-start overflow-visible break-normal font-semibold"
+          style={{
+            fontSize: "22vw",
+            lineHeight: 0.8,
+            letterSpacing: "-0.04em",
+            fontWeight: 600,
+          }}
         >
-          <motion.div
-            initial={
-              prefersReducedMotion
-                ? { opacity: 1 }
-                : { opacity: 0, y: fadeUpDistance.lg }
-            }
-            animate={{ opacity: 1, y: 0 }}
-            transition={enterTransition}
-            className="relative"
-          >
-            <div className="mx-auto mb-6 h-px w-16 bg-[var(--primary)]/50 -skew-x-12 sm:mb-8" />
-            <Heading size="hero" className="hero-text relative inline-block">
-              <span className="relative z-10">{name}</span>
-            </Heading>
-          </motion.div>
-
-          <motion.div
-            initial={
-              prefersReducedMotion
-                ? { opacity: 1 }
-                : { opacity: 0, y: fadeUpDistance.md }
-            }
-            animate={{ opacity: 1, y: 0 }}
-            transition={
-              prefersReducedMotion
-                ? { duration: 0 }
-                : {
-                    ...motionSprings.heroEnter,
-                    delay: motionDurations.base * 0.55,
-                    duration: motionDurations.base,
-                  }
-            }
-          >
-            <Heading
-              size="sm"
-              as="h2"
-              className="capitalize tracking-[0.28em] text-[var(--primary)]"
-            >
-              {title}
-            </Heading>
-            <div className="mx-auto mt-6 h-px w-12 bg-[var(--foreground)]/20 skew-x-12" />
-          </motion.div>
-
-          <motion.div
-            initial={{ opacity: prefersReducedMotion ? 1 : 0 }}
-            animate={{ opacity: 1 }}
-            transition={
-              prefersReducedMotion
-                ? { duration: 0 }
-                : {
-                    delay: motionDurations.slow + 0.2,
-                    duration: motionDurations.base,
-                  }
-            }
-            className="flex justify-center pt-6 sm:pt-10"
-          >
-            <motion.div
-              animate={prefersReducedMotion ? undefined : { y: [0, 8, 0] }}
-              transition={
-                prefersReducedMotion
-                  ? undefined
-                  : {
-                      duration: motionDurations.slow + 0.8,
-                      repeat: Infinity,
-                      ease: motionEasings.inOut,
-                    }
-              }
-              className="flex flex-col items-center space-y-2"
-              aria-hidden="true"
-            >
-              <div className="h-8 w-px bg-[var(--primary)]/40" />
-              <div className="h-1.5 w-1.5 rotate-45 bg-[var(--primary)]/70" />
-            </motion.div>
-          </motion.div>
-        </motion.div>
-      </Container>
+          {claim.lockup.map((line) => (
+            <span key={line} className="block w-max max-w-none whitespace-nowrap leading-[0.8]">
+              {line}
+            </span>
+          ))}
+        </Heading>
+      </div>
+      <ClaimRoles roles={claim.roles} />
     </section>
   );
 }

--- a/src/components/ui/loop/loop.test.tsx
+++ b/src/components/ui/loop/loop.test.tsx
@@ -67,6 +67,7 @@ describe("Loop", () => {
     expect(root).toHaveAttribute("aria-hidden", "true");
     expect(container.querySelector(".loop-grain-motion")).toBeNull();
     expect(container.querySelector(".loop-plate-motion")).toBeNull();
+    expect(container.querySelector(".loop-flash-motion")).toBeNull();
     expect(container.querySelector("canvas")).toBeNull();
     expect(container.querySelector("img")).toHaveAttribute("src", "/loops/claim-poster.webp");
   });
@@ -103,6 +104,7 @@ describe("Loop", () => {
     expect(container.querySelector("[data-loop]")).toHaveAttribute("data-loop", "live");
     expect(container.querySelector(".loop-grain-motion")).toBeTruthy();
     expect(container.querySelector(".loop-plate-motion")).toBeTruthy();
+    expect(container.querySelector(".loop-flash-motion")).toBeTruthy();
     expect(container.querySelector(".loop-light-motion")).toBeTruthy();
 
     cleanup();
@@ -116,5 +118,6 @@ describe("Loop", () => {
 
     expect(frozen.container.querySelector("[data-loop]")).toHaveAttribute("data-loop", "frozen");
     expect(frozen.container.querySelector(".loop-grain-motion")).toBeNull();
+    expect(frozen.container.querySelector(".loop-flash-motion")).toBeNull();
   });
 });

--- a/src/components/ui/loop/loop.tsx
+++ b/src/components/ui/loop/loop.tsx
@@ -69,7 +69,8 @@ export function Loop({ src, className, objectPosition = "center" }: LoopProps) {
           <div className="loop-fallback absolute inset-0" />
         )}
       </div>
-      <div className={cn("loop-grain absolute inset-0", motion && "loop-grain-motion")} />
+      <div className={cn("loop-grain absolute -inset-[16%]", motion && "loop-grain-motion")} />
+      <div className={cn("loop-flash absolute inset-0", motion && "loop-flash-motion")} />
       <div className={cn("loop-light absolute inset-0", motion && "loop-light-motion")} />
     </div>
   );

--- a/src/components/ui/navigation/header.test.tsx
+++ b/src/components/ui/navigation/header.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { navigation, site } from "@/data";
+import { Header } from "@/components/ui/navigation/header";
+
+const nav = vi.hoisted(() => ({ pathname: "/" }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => nav.pathname,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  nav.pathname = "/";
+  Object.defineProperty(window, "IntersectionObserver", {
+    writable: true,
+    value: class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  });
+});
+
+describe("Header", () => {
+  it("does not repeat the name while the Home Claim is in view", () => {
+    nav.pathname = "/";
+    render(
+      <>
+        <Header />
+        <section id="claim">
+          <h1>hasha dar</h1>
+        </section>
+      </>,
+    );
+
+    const header = screen.getByRole("banner");
+    expect(within(header).queryByRole("link", { name: site.brandName })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "hasha dar" })).toBeInTheDocument();
+    expect(header.querySelector("nav")).not.toHaveClass("container");
+  });
+
+  it("keeps the wordmark on interior pages as the Home door", () => {
+    nav.pathname = "/about";
+    render(<Header />);
+
+    const header = screen.getByRole("banner");
+    expect(within(header).getByRole("link", { name: site.brandName })).toHaveAttribute("href", "/");
+    for (const link of navigation.links) {
+      expect(within(header).getByRole("link", { name: link.label })).toHaveAttribute("href", link.href);
+    }
+  });
+
+  it("returns the wordmark once the Claim is out of view", () => {
+    nav.pathname = "/";
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      value: class {
+        callback: IntersectionObserverCallback;
+        constructor(callback: IntersectionObserverCallback) {
+          this.callback = callback;
+        }
+        observe() {
+          this.callback(
+            [{ isIntersecting: false } as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver,
+          );
+        }
+        unobserve() {}
+        disconnect() {}
+      },
+    });
+
+    render(
+      <>
+        <Header />
+        <section id="claim">
+          <h1>hasha dar</h1>
+        </section>
+      </>,
+    );
+
+    const header = screen.getByRole("banner");
+    expect(within(header).getByRole("link", { name: site.brandName })).toHaveAttribute("href", "/");
+  });
+});

--- a/src/components/ui/navigation/header.tsx
+++ b/src/components/ui/navigation/header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { navigation, site } from "@/data";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useSmoothScroll } from "@/hooks/use-smooth-scroll";
@@ -11,7 +11,31 @@ import { cn } from "@/lib/utils";
 export function Header() {
   useSmoothScroll();
   const pathname = usePathname();
+  const isHome = pathname === "/";
+  const [claimInView, setClaimInView] = useState(isHome);
+  const [trackedHome, setTrackedHome] = useState(isHome);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  if (trackedHome !== isHome) {
+    setTrackedHome(isHome);
+    setClaimInView(isHome);
+  }
+
+  useEffect(() => {
+    if (!isHome) return;
+
+    const claim = document.getElementById("claim");
+    if (!claim) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setClaimInView(entry.isIntersecting);
+      },
+      { threshold: 0.35 },
+    );
+    observer.observe(claim);
+    return () => observer.disconnect();
+  }, [isHome]);
 
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/";
@@ -19,6 +43,7 @@ export function Header() {
   };
 
   const closeMobileMenu = () => setMobileMenuOpen(false);
+  const showWordmark = !isHome || !claimInView;
 
   const doorClassName =
     "text-sm font-medium text-[var(--foreground)] hover:text-[var(--primary)] transition-colors";
@@ -26,15 +51,19 @@ export function Header() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50">
       <nav
-        className="container mx-auto flex items-center justify-between px-6 py-5"
+        className="flex w-full items-center justify-between px-6 py-5"
         aria-label="Primary"
       >
-        <Link
-          href="/"
-          className="font-body text-sm tracking-tight text-[var(--foreground)] hover:text-[var(--primary)] transition-colors"
-        >
-          {site.brandName}
-        </Link>
+        {showWordmark ? (
+          <Link
+            href="/"
+            className="font-body text-sm tracking-tight text-[var(--foreground)] hover:text-[var(--primary)] transition-colors"
+          >
+            {site.brandName}
+          </Link>
+        ) : (
+          <span aria-hidden="true" />
+        )}
 
         <div className="flex items-center gap-4">
           <div className="hidden items-center gap-6 md:flex">
@@ -71,7 +100,7 @@ export function Header() {
 
       {mobileMenuOpen && (
         <div className="bg-[var(--background)] md:hidden">
-          <div className="container mx-auto flex flex-col gap-4 px-6 py-4">
+          <div className="flex w-full flex-col gap-4 px-6 py-4">
             {navigation.links.map((link) => (
               <Link
                 key={link.href}

--- a/src/lib/motion/isolation.test.ts
+++ b/src/lib/motion/isolation.test.ts
@@ -58,12 +58,13 @@ describe("motion isolation", () => {
     expect(barrel).not.toContain("hero-webgl");
   });
 
-  it("imports home hero atmosphere from the UI barrel", () => {
+  it("imports the Claim Loop from the UI barrel", () => {
     const source = readSrc("src/components/sections/homepage/hero-section.tsx");
 
-    expect(source).toContain("HeroMedia");
-    expect(source).toContain("HeroFallback");
-    expect(source).not.toContain("@/components/ui/hero-media/");
+    expect(source).toContain("Loop");
+    expect(source).not.toContain("@/components/ui/loop/");
+    expect(source).not.toContain("HeroMedia");
+    expect(source).not.toContain("HeroFallback");
   });
 
   it("keeps Labs, Admin, and Login free of marketing spectacle primitives", () => {


### PR DESCRIPTION
## Summary
- Rewrites `/` as the Claim: two-line `hasha` / `dar` lockup (one shared size), looping Roles, and the Loop still behind it instead of the job-title photo hero.
- Hides the header wordmark while the Claim is in view, takes header and footer to the viewport edges, and inverts the Loop in dark mode.
- Adds a quiet analog reel flash with a little blur, slower edge grain, and reduced-motion / screen-reader static Roles (no live region).

## Test plan
- [x] Open `/`: lockup is two lines, job title is not the headline, Loop still is behind it.
- [x] Roles cycle consultant? → photographer? → software developer? → writer? and loop; they never land on “all of the above.”
- [x] Header has no competing wordmark on the Claim; it returns after scrolling and on About / other routes.
- [x] Toggle dark mode: Loop inverts; light mode is unchanged.
- [x] Landscape and mobile: lockup shares one size, glyphs do not clip, `dar` is not stretched full width.
- [x] `prefers-reduced-motion`: no Role roll, no Loop motion/flash, four Roles present as static text.
- [x] Header and footer align to the screen edges (padding only, no inner container).
- [x] Experience listing below the Claim is unchanged (Statement/Proof are out of scope).

Closes #247

Made with [Cursor](https://cursor.com)